### PR TITLE
Include missing resource folders in package build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -305,10 +305,17 @@ packages = [
     "src/specfact_cli",
 ]
 
+[tool.hatch.build.targets.wheel.force-include]
+"resources/prompts" = "specfact_cli/resources/prompts"
+"resources/templates" = "specfact_cli/resources/templates"
+"resources/schemas" = "specfact_cli/resources/schemas"
+"resources/mappings" = "specfact_cli/resources/mappings"
+
 [tool.hatch.build.targets.sdist]
 # Only include essential files in source distribution
 include = [
     "/src",
+    "/resources",
     "/README.md",
     "/LICENSE.md",
     "/pyproject.toml",


### PR DESCRIPTION
# Description

Updated `pyproject.toml` to include essential resource directories (`prompts`, `templates`, `schemas`, `mappings`) in both wheel and source distributions. This resolves an issue where these resources were missing from the installed PyPI package, ensuring the CLI has necessary assets at runtime.

**Fixes** Addresses the reported issue of missing resource folders in the PyPI package.

**New Features**

**Contract References**:

## Type of Change

Please check all that apply:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Contract enforcement (adding/updating `@icontract` decorators)
- [ ] 🧪 Test enhancement (scenario tests, property-based tests)
- [ ] 🔧 Refactoring (code improvement without functionality change)

## Contract-First Testing Evidence

**Required for all changes affecting CLI commands or public APIs:**
*This change is a build configuration update and does not directly affect CLI commands or public APIs in a way that requires runtime contract validation or extensive testing beyond verifying the build output.*

### Contract Validation

- [ ] **Runtime contracts added/updated** (`@icontract` decorators on public APIs)
- [ ] **Type checking enforced** (`@beartype` decorators applied)
- [ ] **CrossHair exploration** completed: `hatch run contract-test-exploration`
- [ ] **Contract violations** reviewed and addressed

### Test Execution

- [ ] **Contract validation**: `hatch run contract-test-contracts` ✅
- [ ] **Contract exploration**: `hatch run contract-test-exploration` ✅
- [ ] **Scenario tests**: `hatch run contract-test-scenarios` ✅
- [ ] **Full test suite**: `hatch run contract-test-full` ✅

### Test Quality

- [ ] **CLI commands tested** with typer test client
- [ ] **Edge cases covered** with Hypothesis property tests
- [ ] **Error handling tested** with invalid inputs
- [ ] **Rich console output verified** manually or with snapshots

## How Has This Been Tested?

**Contract-First Approach**: N/A, this is a build configuration change.

### Manual Testing

- [ ] Tested CLI commands manually
- [ ] Verified rich console output
- [ ] Tested with different input scenarios
- [ ] Checked error messages for clarity
*Note: Manual verification of the generated wheel/sdist contents is the recommended next step to confirm the fix.*

### Automated Testing

- [ ] Contract validation passes
- [ ] Property-based tests cover edge cases
- [ ] Scenario tests cover user workflows
- [ ] All existing tests still pass
*Note: No automated tests were run as this is a configuration-only update.*

### Test Environment

- Python version: Not specified in conversation
- OS: Not specified in conversation

## Checklist

- [ ] My code follows the style guidelines (PEP 8, ruff format, isort)
- [x] I have performed a self-review of my code
- [ ] I have added/updated contracts (`@icontract`, `@beartype`)
- [ ] I have added/updated docstrings (Google style)
- [ ] I have made corresponding changes to documentation
- [ ] My changes generate no new warnings (basedpyright, ruff, pylint)
- [ ] All tests pass locally
- [ ] I have added tests that prove my fix/feature works
- [ ] Any dependent changes have been merged

## Quality Gates Status

*These quality gates are not applicable for a `pyproject.toml` build configuration change.*

- [ ] **Type checking** ✅ (`hatch run type-check`)
- [ ] **Linting** ✅ (`hatch run lint`)
- [ ] **Contract validation** ✅ (`hatch run contract-test-contracts`)
- [ ] **Contract exploration** ✅ (`hatch run contract-test-exploration`)
- [ ] **Scenario tests** ✅ (`hatch run contract-test-scenarios`)

## Screenshots/Recordings (if applicable)

---
<a href="https://cursor.com/background-agent?bcId=bc-6f3b4f40-445e-41d2-9bcf-bef700e58535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6f3b4f40-445e-41d2-9bcf-bef700e58535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

