### PR TITLE
docs: add OpenSpec arch-05 bridge registry change

### DIFF
--- a/openspec/changes/arch-05-bridge-registry/.openspec.yaml
+++ b/openspec/changes/arch-05-bridge-registry/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-08

--- a/openspec/changes/arch-05-bridge-registry/CHANGE_VALIDATION.md
+++ b/openspec/changes/arch-05-bridge-registry/CHANGE_VALIDATION.md
@@ -1,0 +1,78 @@
+# Change Validation Report: arch-05-bridge-registry
+
+**Validation Date**: 2026-02-08
+**Change Proposal**: [proposal.md](./proposal.md)
+**Validation Method**: Dry-run interface/dependency analysis + strict OpenSpec validation
+
+## Executive Summary
+
+- **Breaking Changes**: 0 detected
+- **Impact Level**: Medium (new registry surface, additive manifest/schema behavior)
+- **Validation Result**: Pass
+- **User Decision Required**: No
+
+## Breaking Change Analysis
+
+No breaking interfaces were proposed.
+
+Additive-only changes:
+
+1. New `bridge_registry` module and `SchemaConverter` protocol.
+2. New optional `service_bridges` manifest metadata.
+3. New lifecycle registration behavior for declared bridges.
+4. New backlog converter implementations.
+
+Compatibility expectation:
+
+- Modules without `service_bridges` remain valid and operational.
+- Existing CLI commands continue functioning when bridge metadata is absent.
+
+## Dependency Analysis
+
+## Directly impacted runtime areas
+
+- `src/specfact_cli/registry/module_packages.py`
+- `src/specfact_cli/modules/init/src/commands.py`
+- `src/specfact_cli/registry/bootstrap.py`
+- `src/specfact_cli/modules/backlog/src/commands.py`
+
+## Directly impacted tests
+
+- `tests/unit/specfact_cli/registry/test_module_packages.py`
+- `tests/unit/specfact_cli/registry/test_module_dependencies.py`
+- `tests/unit/specfact_cli/registry/test_version_constraints.py`
+- `tests/unit/specfact_cli/registry/test_init_module_lifecycle_ux.py`
+
+## Risk notes
+
+- `module_packages` is a shared registration path; metadata shape changes can affect init and bootstrap flows.
+- Bridge ID conflict behavior must be deterministic and covered by tests.
+- Converter import path validation should warn clearly and degrade gracefully.
+
+## Dry-Run Validation Notes
+
+Dry-run checks were performed as proposal-level analysis only (no implementation changes):
+
+- Interface additions were checked for additive semantics.
+- Dependent call sites were identified via `rg` against registry, init, and backlog modules.
+- No code execution changes were applied to production files during validation stage.
+
+## Artifact and Format Validation
+
+- `proposal.md`: required sections present (`Why`, `What Changes`, `Capabilities`, `Impact`, `Source Tracking`).
+- `design.md`: includes context, decisions, risks, migration, and sequence diagram.
+- `tasks.md`: branch-first, tests-before-code ordering, issue creation task, PR-last.
+- Spec deltas present for:
+  - `specs/bridge-registry/spec.md`
+  - `specs/module-packages/spec.md`
+  - `specs/module-lifecycle-management/spec.md`
+  - `specs/backlog-adapter/spec.md`
+
+## OpenSpec Validation
+
+- Command: `openspec validate arch-05-bridge-registry --strict`
+- Result: `Change 'arch-05-bridge-registry' is valid`
+
+## Conclusion
+
+`arch-05-bridge-registry` is ready for implementation planning and execution under the documented TDD/SDD workflow.

--- a/openspec/changes/arch-05-bridge-registry/design.md
+++ b/openspec/changes/arch-05-bridge-registry/design.md
@@ -1,0 +1,126 @@
+# Design: Bridge Registry for Cross-Module Service Interoperability
+
+## Context
+
+`arch-04-core-contracts-interfaces` establishes module IO contracts and core/module isolation, but it does not define how modules publish reusable schema converters for external services. The internal analysis dated 2026-02-08 and the implementation plan identify this as the next architectural step (arch-05) required before marketplace-grade module decoupling.
+
+Current state:
+
+- Service mapping logic is module-local and not discoverable through a common registry contract.
+- Module manifests support dependencies and core compatibility, but not converter bridge declarations.
+- Core must stay decoupled from module internals while still enabling dynamic bridge usage.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Introduce a registry-level bridge abstraction (`SchemaConverter`, `BridgeRegistry`) for bidirectional schema conversion.
+- Make bridge declarations manifest-driven (`service_bridges`) and validated at module registration time.
+- Keep core/module isolation intact: no hardcoded core imports of module adapter implementations.
+- Deliver backlog reference converters (ADO, Jira, Linear, GitHub) as first adopters.
+- Document extension points for custom enterprise bridge mappings.
+
+**Non-Goals:**
+
+- Cryptographic signature validation and trust chain (arch-06).
+- Marketplace install/uninstall UX and remote registry APIs (marketplace-01/02).
+- Per-module Python environment isolation.
+- Breaking existing module registration APIs.
+
+## Decisions
+
+### Decision 1: Protocol + Registry Pattern for Bridges
+
+**Choice:** Define a `SchemaConverter` Protocol and a centralized `BridgeRegistry` with `register_converter()` and `get_converter()` methods.
+
+**Rationale:**
+
+- Preserves plugin-style extensibility already used in module discovery.
+- Keeps conversion contract explicit and testable.
+- Avoids hardcoded adapter branching in sync/backlog flows.
+
+**Alternatives considered:**
+
+- Inline converter logic in each command path: duplicates logic and increases coupling.
+- Abstract base class with strict inheritance: less flexible than protocol-based structural typing.
+
+### Decision 2: Manifest-Driven Bridge Registration
+
+**Choice:** Extend `module-package.yaml` metadata with `service_bridges` entries containing bridge id, description, and converter class path.
+
+**Rationale:**
+
+- Keeps registration declarative and discoverable.
+- Allows lifecycle validation before registration.
+- Supports future marketplace metadata verification without changing runtime architecture.
+
+**Alternatives considered:**
+
+- Hardcoded module-specific bridge lists in core: violates core isolation.
+- Runtime classpath scanning without manifest declarations: less deterministic and harder to validate.
+
+### Decision 3: Graceful Degradation on Bridge Registration Failures
+
+**Choice:** If a bridge declaration is invalid or import fails, skip that bridge with warning/debug logging; do not crash CLI startup.
+
+**Rationale:**
+
+- Matches existing module lifecycle behavior for compatibility/dependency issues.
+- Supports parallel module evolution without blocking unrelated workflows.
+
+**Alternatives considered:**
+
+- Fail-fast for any invalid bridge: safer but too disruptive for modular incremental rollout.
+
+### Decision 4: Backlog Module as Reference Bridge Provider
+
+**Choice:** Implement first converter set in backlog module (`ado`, `jira`, `linear`, `github`) and register through metadata.
+
+**Rationale:**
+
+- Backlog already contains major external service integration surface.
+- Provides concrete pattern for future modules to follow.
+
+## Risks / Trade-offs
+
+- **Risk:** Converter class import paths drift from code layout.
+  - **Mitigation:** Add registration-time path validation tests and clear startup warnings.
+- **Risk:** Bridge IDs collide across modules.
+  - **Mitigation:** Deterministic registration rules and explicit duplicate handling with warnings.
+- **Risk:** Converter logic divergence across modules.
+  - **Mitigation:** Publish docs and contract tests against the `SchemaConverter` protocol.
+- **Trade-off:** Non-fatal bridge failures improve resilience but can hide misconfiguration.
+  - **Mitigation:** Elevated warning logs and dedicated validation tests in CI.
+
+## Migration Plan
+
+1. Add bridge registry and converter protocol with unit tests.
+2. Extend manifest schema and parser for `service_bridges` metadata.
+3. Add lifecycle registration hooks for bridge declaration validation and registry insertion.
+4. Add backlog reference converters and manifest declarations.
+5. Update docs and run quality gates.
+
+Rollback strategy:
+
+- Remove bridge registration calls from module lifecycle.
+- Remove `service_bridges` metadata usage while keeping manifests backward compatible.
+- Keep backlog adapters functional through existing direct paths until reintroduced.
+
+## Open Questions
+
+- Should duplicate bridge IDs fail registration or use first-wins semantics with warnings?
+- Should converter registration support versioned bridge contracts in arch-06 or later?
+- Should enterprise custom mappings be loaded at bridge-level registration or adapter execution time?
+
+## Sequence Diagram: Manifest-Driven Bridge Registration
+
+```text
+CLI Startup -> ModuleRegistry: discover module packages
+ModuleRegistry -> ManifestParser: parse module-package.yaml
+ManifestParser --> ModuleRegistry: metadata (+service_bridges)
+ModuleRegistry -> BridgeRegistry: register_converter(bridge_id, converter_class)
+BridgeRegistry --> ModuleRegistry: success or warning
+ModuleRegistry --> CLI Startup: module commands + bridges available
+CLI Command -> BridgeRegistry: get_converter(service_id)
+BridgeRegistry --> CLI Command: SchemaConverter implementation
+```

--- a/openspec/changes/arch-05-bridge-registry/proposal.md
+++ b/openspec/changes/arch-05-bridge-registry/proposal.md
@@ -1,0 +1,55 @@
+# Change: Bridge Registry for Cross-Module Service Interoperability
+
+## Why
+
+
+`arch-04-core-contracts-interfaces` formalizes module IO contracts and core isolation, but modules still lack a standard way to expose reusable external-service schema converters. Without a bridge registry, modules either duplicate adapter logic or reintroduce coupling, which slows parallel development and blocks marketplace-ready interoperability.
+
+## What Changes
+
+
+- **NEW**: Add `src/specfact_cli/registry/bridge_registry.py` with `SchemaConverter` protocol and `BridgeRegistry` for converter registration/discovery.
+- **MODIFY**: Extend module package metadata to declare `service_bridges` in `module-package.yaml`.
+- **MODIFY**: Extend module lifecycle registration to validate and register declared service bridges without direct core-to-module imports.
+- **MODIFY**: Add backlog bridge converter implementations (ADO, Jira, Linear, GitHub) under module-local adapters and register them via manifest metadata.
+- **NEW**: Add user and developer documentation for bridge registry usage and custom bridge mappings.
+- **NEW**: Add tests for bridge registry behavior, manifest parsing, registration-time validation, and module integration.
+
+## Capabilities
+### New Capabilities
+
+- `bridge-registry`: Contract-driven registry for service schema converters so modules can publish and consume conversion bridges without hardcoded core logic.
+
+### Modified Capabilities
+
+- `module-packages`: Extend module package manifest schema with declarative bridge metadata.
+- `module-lifecycle-management`: Extend discovery/registration flow to validate and register bridge converters safely.
+- `backlog-adapter`: Add bridge converter implementations and mapping behaviors for backlog service integrations.
+
+## Impact
+
+- **Affected specs**: New spec for `bridge-registry`; delta specs for `module-packages`, `module-lifecycle-management`, and `backlog-adapter`.
+- **Affected code**:
+  - `src/specfact_cli/registry/bridge_registry.py` (new)
+  - `src/specfact_cli/registry/module_packages.py` (bridge metadata loading and registration)
+  - `src/specfact_cli/models/module_package.py` (service bridge metadata)
+  - `src/specfact_cli/modules/backlog/src/adapters/*.py` (new converter modules)
+  - `tests/unit/registry/test_bridge_registry.py` (new)
+  - `tests/unit/registry/test_module_bridge_registration.py` (new)
+- **Affected documentation**:
+  - `docs/reference/bridge-registry.md` (new)
+  - `docs/guides/creating-custom-bridges.md` (new)
+  - `docs/reference/architecture.md` and `docs/_layouts/default.html` (updated navigation and architecture notes)
+- **Integration points**: module discovery, manifest parsing, registry startup, backlog adapters, sync workflows.
+- **Backward compatibility**: Backward compatible. Modules without `service_bridges` remain valid and continue working.
+- **Rollback plan**: Disable bridge registration in module lifecycle and remove `service_bridges` manifest handling; modules continue with existing adapter behavior.
+
+---
+
+## Source Tracking
+
+<!-- source_repo: nold-ai/specfact-cli -->
+- **GitHub Issue**: #207
+- **Issue URL**: <https://github.com/nold-ai/specfact-cli/issues/207>
+- **Last Synced Status**: proposed
+- **Sanitized**: false

--- a/openspec/changes/arch-05-bridge-registry/specs/backlog-adapter/spec.md
+++ b/openspec/changes/arch-05-bridge-registry/specs/backlog-adapter/spec.md
@@ -1,0 +1,35 @@
+# Spec: Backlog Adapter
+
+## ADDED Requirements
+
+### Requirement: Backlog module provides bridge converters for supported services
+
+The system SHALL provide backlog bridge converters for Azure DevOps, Jira, Linear, and GitHub using the shared bridge registry contract.
+
+#### Scenario: Backlog module declares service bridges in manifest
+
+- **WHEN** backlog module package metadata is discovered
+- **THEN** manifest `service_bridges` SHALL declare converter entries for `ado`, `jira`, `linear`, and `github`
+- **AND** each entry SHALL reference a converter class path under backlog adapters.
+
+#### Scenario: Backlog converters satisfy schema converter contract
+
+- **WHEN** bridge converters are loaded
+- **THEN** each converter SHALL implement `to_bundle` and `from_bundle` operations
+- **AND** conversion behavior SHALL preserve required backlog fields for round-trip workflows.
+
+### Requirement: Backlog bridge mappings support custom enterprise overrides
+
+The system SHALL allow custom bridge field mappings for backlog converter workflows.
+
+#### Scenario: Custom mapping file overrides default mapping
+
+- **WHEN** a custom mapping YAML exists for a configured service bridge
+- **THEN** backlog converter behavior SHALL apply custom mapping before default mapping
+- **AND** fallback to defaults when custom mappings are absent or incomplete.
+
+#### Scenario: Invalid custom mapping falls back safely
+
+- **WHEN** custom mapping configuration is malformed
+- **THEN** converter execution SHALL continue with default mapping behavior
+- **AND** SHALL emit warning/debug context for troubleshooting.

--- a/openspec/changes/arch-05-bridge-registry/specs/bridge-registry/spec.md
+++ b/openspec/changes/arch-05-bridge-registry/specs/bridge-registry/spec.md
@@ -1,0 +1,61 @@
+# Spec: Bridge Registry
+
+## ADDED Requirements
+
+### Requirement: Bridge registry provides converter registration and lookup
+
+The system SHALL provide a `BridgeRegistry` that supports module-driven registration and lookup of service schema converters.
+
+#### Scenario: Register converter for service ID
+
+- **WHEN** a module lifecycle registration step provides a valid bridge declaration
+- **THEN** `BridgeRegistry` SHALL register the converter for the declared bridge ID
+- **AND** the converter SHALL be retrievable by that same bridge ID.
+
+#### Scenario: Lookup missing converter fails with explicit error
+
+- **WHEN** code requests a converter for a bridge ID that is not registered
+- **THEN** `BridgeRegistry` SHALL raise a clear lookup error
+- **AND** the error SHALL include the missing bridge ID.
+
+### Requirement: SchemaConverter protocol defines bidirectional conversion contract
+
+The system SHALL provide a `SchemaConverter` protocol to standardize conversion between external service payloads and ProjectBundle-compatible data.
+
+#### Scenario: Converter defines to_bundle contract
+
+- **WHEN** a converter implements `SchemaConverter`
+- **THEN** it SHALL implement `to_bundle(external_data: dict) -> dict`
+- **AND** the returned payload SHALL be compatible with ProjectBundle construction.
+
+#### Scenario: Converter defines from_bundle contract
+
+- **WHEN** a converter implements `SchemaConverter`
+- **THEN** it SHALL implement `from_bundle(bundle_data: dict) -> dict`
+- **AND** the returned payload SHALL be service-specific output.
+
+### Requirement: Bridge registry preserves core-module isolation
+
+The system SHALL enforce bridge registration without introducing direct core imports from `specfact_cli.modules.*`.
+
+#### Scenario: Core retrieves bridge via registry only
+
+- **WHEN** core CLI workflows need a converter
+- **THEN** they SHALL call `BridgeRegistry.get_converter()`
+- **AND** SHALL NOT import converter implementations directly from module command packages.
+
+#### Scenario: Invalid bridge declaration degrades gracefully
+
+- **WHEN** module metadata declares an invalid converter class path
+- **THEN** registration SHALL skip that bridge and log warning/debug context
+- **AND** CLI startup SHALL continue for unaffected modules.
+
+### Requirement: Bridge registration supports offline-first workflows
+
+The system SHALL support bridge registration and local converter resolution without requiring network access.
+
+#### Scenario: Offline startup with local manifests
+
+- **WHEN** CLI starts in an offline environment
+- **THEN** bridge registration SHALL complete using local module manifests and local Python imports
+- **AND** SHALL NOT require external API or registry calls.

--- a/openspec/changes/arch-05-bridge-registry/specs/module-lifecycle-management/spec.md
+++ b/openspec/changes/arch-05-bridge-registry/specs/module-lifecycle-management/spec.md
@@ -1,0 +1,38 @@
+# Spec: Module Lifecycle Management
+
+## ADDED Requirements
+
+### Requirement: Lifecycle registration loads module-declared bridges
+
+The system SHALL load and register module-declared service bridges during module lifecycle registration.
+
+#### Scenario: Registration wires declared bridge converters
+
+- **WHEN** `register_module_package_commands()` processes an enabled module with valid `service_bridges`
+- **THEN** each declared converter SHALL be registered into `BridgeRegistry`
+- **AND** registration SHALL occur without direct core imports from module command internals.
+
+#### Scenario: Bridge registration respects module enable/disable state
+
+- **WHEN** a module is disabled or skipped due to compatibility/dependency failure
+- **THEN** its bridge declarations SHALL NOT be registered.
+
+### Requirement: Lifecycle handles bridge conflicts deterministically
+
+The system SHALL handle duplicate bridge IDs predictably and with actionable diagnostics.
+
+#### Scenario: Duplicate bridge ID detected
+
+- **WHEN** two enabled modules declare the same bridge ID
+- **THEN** lifecycle registration SHALL apply deterministic conflict handling
+- **AND** SHALL log warning/debug details identifying both modules and bridge ID.
+
+### Requirement: Bridge registration failures do not block unrelated modules
+
+The system SHALL degrade gracefully when individual bridge declarations fail.
+
+#### Scenario: Converter import failure is non-fatal
+
+- **WHEN** a module declares a converter class that cannot be imported
+- **THEN** lifecycle registration SHALL skip that bridge declaration
+- **AND** continue registering other valid modules and bridges.

--- a/openspec/changes/arch-05-bridge-registry/specs/module-packages/spec.md
+++ b/openspec/changes/arch-05-bridge-registry/specs/module-packages/spec.md
@@ -1,0 +1,34 @@
+# Spec: Module Packages
+
+## ADDED Requirements
+
+### Requirement: Module package manifests declare service bridges
+
+The system SHALL allow `module-package.yaml` to declare `service_bridges` metadata for converter registration.
+
+#### Scenario: Manifest includes service bridge declaration
+
+- **WHEN** a module manifest includes `service_bridges`
+- **THEN** each bridge entry SHALL include `id` and `converter_class`
+- **AND** optional metadata such as `description` MAY be provided.
+
+#### Scenario: Manifest without service bridges remains valid
+
+- **WHEN** a legacy module manifest omits `service_bridges`
+- **THEN** manifest validation SHALL still pass
+- **AND** module lifecycle SHALL treat the module as having no bridge declarations.
+
+### Requirement: Service bridge metadata is validated during manifest parsing
+
+The system SHALL validate service bridge metadata structure before module registration.
+
+#### Scenario: Invalid bridge metadata is rejected for registration
+
+- **WHEN** a bridge entry is missing required keys or has malformed converter path
+- **THEN** parser validation SHALL flag the declaration as invalid
+- **AND** module registration SHALL skip only invalid bridge declarations.
+
+#### Scenario: Valid bridge metadata is preserved in package model
+
+- **WHEN** a manifest contains valid bridge declarations
+- **THEN** the parsed `ModulePackageMetadata` SHALL expose those declarations for lifecycle registration.

--- a/openspec/changes/arch-05-bridge-registry/tasks.md
+++ b/openspec/changes/arch-05-bridge-registry/tasks.md
@@ -1,0 +1,111 @@
+# Tasks: Bridge Registry for Cross-Module Service Interoperability
+
+## TDD / SDD Order (Enforced)
+
+Per `openspec/config.yaml`, development discipline follows strict SDD+TDD order:
+
+1. **Specs first** - Spec deltas define behavior in Given/When/Then scenarios.
+2. **Tests second** - Write tests from scenarios, run tests, and expect failure before implementation.
+3. **Code last** - Implement until tests pass and behavior matches spec scenarios.
+
+Do not implement production code for new behavior until corresponding tests exist and have been run expecting failure.
+
+---
+
+## 1. Create git branch from dev
+
+- [ ] 1.1 Ensure `dev` is current and create `feature/arch-05-bridge-registry`
+- [ ] 1.2 Verify current branch is `feature/arch-05-bridge-registry`
+
+## 2. Tests: bridge registry contract (TDD)
+
+- [ ] 2.1 Add `tests/unit/registry/test_bridge_registry.py`
+- [ ] 2.2 Add tests for register/get behavior and duplicate bridge ID handling
+- [ ] 2.3 Add tests for missing bridge lookup error behavior
+- [ ] 2.4 Run `pytest tests/unit/registry/test_bridge_registry.py -v` and expect failure
+
+## 3. Implementation: bridge registry
+
+- [ ] 3.1 Create `src/specfact_cli/registry/bridge_registry.py`
+- [ ] 3.2 Define `SchemaConverter` protocol (`to_bundle`, `from_bundle`) with type hints
+- [ ] 3.3 Implement `BridgeRegistry` registration and retrieval methods
+- [ ] 3.4 Add `@beartype` and `@icontract` decorators to public APIs
+- [ ] 3.5 Run `pytest tests/unit/registry/test_bridge_registry.py -v` and expect pass
+
+## 4. Tests: module manifest service bridge metadata (TDD)
+
+- [ ] 4.1 Add tests in `tests/unit/models/test_module_package_metadata.py` for `service_bridges`
+- [ ] 4.2 Add tests for valid and invalid converter class path metadata
+- [ ] 4.3 Run `pytest tests/unit/models/test_module_package_metadata.py -v` and expect failure for new fields
+
+## 5. Implementation: manifest metadata extension
+
+- [ ] 5.1 Update `src/specfact_cli/models/module_package.py` with `service_bridges` metadata model
+- [ ] 5.2 Add validation for required bridge metadata keys (`id`, `converter_class`)
+- [ ] 5.3 Add `@beartype` and `@icontract` decorators to public validation methods
+- [ ] 5.4 Run `pytest tests/unit/models/test_module_package_metadata.py -v` and expect pass
+
+## 6. Tests: lifecycle bridge registration flow (TDD)
+
+- [ ] 6.1 Add `tests/unit/registry/test_module_bridge_registration.py`
+- [ ] 6.2 Add tests for manifest-driven bridge loading in `register_module_package_commands()`
+- [ ] 6.3 Add tests that invalid bridge declarations are skipped with warnings, not fatal
+- [ ] 6.4 Run `pytest tests/unit/registry/test_module_bridge_registration.py -v` and expect failure
+
+## 7. Implementation: lifecycle integration
+
+- [ ] 7.1 Update `src/specfact_cli/registry/module_packages.py` to parse and validate `service_bridges`
+- [ ] 7.2 Register declared bridges through `BridgeRegistry`
+- [ ] 7.3 Add deterministic handling for duplicate bridge IDs
+- [ ] 7.4 Ensure no direct core imports from module command internals
+- [ ] 7.5 Run `pytest tests/unit/registry/test_module_bridge_registration.py -v` and expect pass
+
+## 8. Tests: backlog bridge converters (TDD)
+
+- [ ] 8.1 Add tests under `tests/unit/modules/backlog/` for converter contract compliance
+- [ ] 8.2 Add tests for ADO, Jira, Linear, GitHub converter mapping behavior
+- [ ] 8.3 Add tests for custom mapping override loading behavior
+- [ ] 8.4 Run `pytest tests/unit/modules/backlog -k converter -v` and expect failure
+
+## 9. Implementation: backlog bridge converters
+
+- [ ] 9.1 Add converter modules under `src/specfact_cli/modules/backlog/src/adapters/`
+- [ ] 9.2 Update backlog module manifest to declare `service_bridges`
+- [ ] 9.3 Ensure converters satisfy `SchemaConverter` protocol and contract decorators
+- [ ] 9.4 Run `pytest tests/unit/modules/backlog -k converter -v` and expect pass
+
+## 10. Quality gates and validation
+
+- [ ] 10.1 Run `hatch run format`
+- [ ] 10.2 Run `hatch run lint`
+- [ ] 10.3 Run `hatch run type-check`
+- [ ] 10.4 Run `hatch run contract-test`
+- [ ] 10.5 Run `hatch run smart-test`
+- [ ] 10.6 Run `openspec validate arch-05-bridge-registry --strict`
+
+## 11. Documentation research and review
+
+- [ ] 11.1 Identify affected docs: `docs/reference/`, `docs/guides/`, `README.md`, `docs/index.md`
+- [ ] 11.2 Add `docs/reference/bridge-registry.md` with contract and usage examples
+- [ ] 11.3 Add `docs/guides/creating-custom-bridges.md` with manifest and converter examples
+- [ ] 11.4 Update `docs/reference/architecture.md` with bridge registry integration notes
+- [ ] 11.5 Update `docs/_layouts/default.html` sidebar links for new docs
+
+## 12. Version and changelog
+
+- [ ] 12.1 Determine semantic version bump for new capability
+- [ ] 12.2 Sync version updates in `pyproject.toml`, `setup.py`, `src/__init__.py`, `src/specfact_cli/__init__.py`
+- [ ] 12.3 Add CHANGELOG entry for bridge registry and manifest bridge metadata support
+
+## 13. GitHub issue creation
+
+- [ ] 13.1 Create issue in `nold-ai/specfact-cli` with title `[Change] Bridge Registry for Cross-Module Service Interoperability`
+- [ ] 13.2 Use labels `enhancement` and `change-proposal`
+- [ ] 13.3 Build issue body from proposal Why/What Changes and append footer `*OpenSpec Change Proposal: arch-05-bridge-registry*`
+- [ ] 13.4 Update `proposal.md` Source Tracking with issue number and URL
+
+## 14. Create pull request to dev (LAST)
+
+- [ ] 14.1 Commit all completed work with conventional commit message
+- [ ] 14.2 Push branch `feature/arch-05-bridge-registry`
+- [ ] 14.3 Create PR to `dev` with OpenSpec change reference and quality gate evidence


### PR DESCRIPTION
## Summary
- add OpenSpec change `arch-05-bridge-registry`
- include proposal, tasks, design, validation, and spec deltas

## Notes
- scoped to `openspec/changes/arch-05-bridge-registry` only
- separate PR from arch-04 and arch-06 as requested
