### PR TITLE
feat(ci): attach test and repro log artifacts to PR orchestrator runs

### DIFF
--- a/.github/workflows/pr-orchestrator.yml
+++ b/.github/workflows/pr-orchestrator.yml
@@ -135,7 +135,7 @@ jobs:
             fi
           fi
 
-      - name: Run contract-first tests (no coverage)
+      - name: Run full test suite (smart-test-full)
         if: needs.changes.outputs.skip_tests_dev_to_main != 'true'
         shell: bash
         env:
@@ -145,39 +145,22 @@ jobs:
           SMART_TEST_TIMEOUT_SECONDS: "1800"
           PYTEST_ADDOPTS: "-r fEw"
         run: |
-          echo "🧪 Running contract-first test suite (3.12)..."
+          echo "🧪 Running full test suite (smart-test-full, Python 3.12)..."
           echo "ℹ️ HATCH_TEST_ENV=${HATCH_TEST_ENV}"
-          run_layer() {
-            local label="$1"
-            shift
-            local start_ts
-            start_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-            echo "▶️ [${start_ts}] Starting ${label}"
-            echo "   Command: $*"
-            if "$@"; then
-              local end_ts
-              end_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-              echo "✅ [${end_ts}] ${label} completed"
-            else
-              local end_ts
-              end_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-              echo "⚠️ [${end_ts}] ${label} incomplete"
-            fi
-          }
+          hatch run smart-test-full
 
-          run_layer "Contract validation" hatch run contract-test-contracts
-          run_layer "Contract exploration" hatch run contract-test-exploration
-          run_layer "Scenario tests" hatch run contract-test-scenarios
-          run_layer "E2E tests" hatch run contract-test-e2e
-
-      - name: Run unit tests with coverage (3.12)
+      - name: Generate coverage XML for quality gates
         if: needs.changes.outputs.skip_tests_dev_to_main != 'true' && env.RUN_UNIT_COVERAGE == 'true'
-        env:
-          PYTEST_ADDOPTS: "-r fEw"
         run: |
-          echo "🧪 Running unit tests with coverage (3.12)..."
-          hatch -e hatch-test.py3.12 run run-cov
           hatch -e hatch-test.py3.12 run xml
+
+      - name: Upload test logs
+        if: needs.changes.outputs.skip_tests_dev_to_main != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs
+          path: logs/tests/
+          if-no-files-found: ignore
 
       - name: Upload coverage artifacts
         if: needs.changes.outputs.skip_tests_dev_to_main != 'true' && env.RUN_UNIT_COVERAGE == 'true'
@@ -255,10 +238,29 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-hatch-contract-first-py312-
             ${{ runner.os }}-hatch-
+      - name: Prepare repro log directory
+        run: mkdir -p logs/repro
       - name: Run contract validation and exploration
+        id: repro
         run: |
           echo "🔍 Validating runtime contracts..."
-          echo "Running specfact repro with required CrossHair..." && hatch run specfact repro --verbose --crosshair-required --budget 120 || echo "SpecFact repro found issues"
+          REPRO_LOG="logs/repro/repro_$(date -u +%Y%m%d_%H%M%S).log"
+          echo "Running specfact repro with required CrossHair... (log: $REPRO_LOG)"
+          hatch run specfact repro --verbose --crosshair-required --budget 120 2>&1 | tee "$REPRO_LOG" || echo "SpecFact repro found issues"
+      - name: Upload repro logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: repro-logs
+          path: logs/repro/
+          if-no-files-found: ignore
+      - name: Upload repro reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: repro-reports
+          path: .specfact/reports/enforcement/
+          if-no-files-found: ignore
 
   cli-validation:
     name: CLI Command Validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.31.1] - 2026-02-16
+
+### Added
+
+- CI log artifacts: PR Orchestrator workflow now uploads test logs (`test-logs`) from `hatch run smart-test-full` and repro logs/reports (`repro-logs`, `repro-reports`) from the contract-first-ci job so failed runs can be debugged by downloading full logs from the Actions Artifacts section without re-running locally.
+- Documentation: "CI and GitHub Actions" section in [Troubleshooting](docs/guides/troubleshooting.md) describing artifact names and how to download and use them.
+
+### Changed
+
+- Tests job in `.github/workflows/pr-orchestrator.yml` now runs `hatch run smart-test-full` (single full-suite step with log output to `logs/tests/`) and uploads `logs/tests/` as the `test-logs` artifact.
+- Contract-first-ci job captures `specfact repro` stdout/stderr to `logs/repro/` and uploads `repro-logs` and `repro-reports` (`.specfact/reports/enforcement/`) as artifacts on every run.
+
+---
+
 ## [0.31.0] - 2026-02-13
 
 ### Added

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -789,6 +789,34 @@ The command automatically uses tokens in this order:
 
 ---
 
+## CI and GitHub Actions
+
+### Downloading test and repro logs from CI
+
+When a PR or push runs the **PR Orchestrator** workflow, test and repro output are uploaded as workflow artifacts so you can debug failures without re-running the full suite locally.
+
+1. **Where to find artifacts**
+
+   - Open the workflow run: **Actions** → select the **PR Orchestrator** run (e.g. from your PR or branch).
+   - Scroll to the **Artifacts** section at the bottom of the run.
+
+2. **Artifact names and contents**
+
+   | Artifact        | Contents                                                                 |
+   |----------------|---------------------------------------------------------------------------|
+   | `test-logs`   | Full test run and coverage logs from `hatch run smart-test-full` (`logs/tests/`). |
+   | `repro-logs`  | Full stdout/stderr of `specfact repro` (`logs/repro/`).                   |
+   | `repro-reports` | Repro report YAMLs from `.specfact/reports/enforcement/`.              |
+   | `coverage-reports` | Coverage XML used by quality gates (when unit tests ran).            |
+
+3. **How to use them**
+
+   - Download the artifact (e.g. `test-logs` or `repro-logs`) from the run page.
+   - Unzip and open the log or report files to see the full output that led to the failure.
+   - Use this instead of copying snippets from the step log, so you get complete error context before fixing and pushing again.
+
+---
+
 ## Getting Help
 
 If you're still experiencing issues:

--- a/docs/plans/ci-pr-orchestrator-log-artifacts.md
+++ b/docs/plans/ci-pr-orchestrator-log-artifacts.md
@@ -1,0 +1,44 @@
+# Plan: PR Orchestrator — Attach Test and Repro Logs to CI Runs
+
+**Repository**: `nold-ai/specfact-cli` (public)
+
+## Purpose
+
+Improve the GitHub Action runner (`.github/workflows/pr-orchestrator.yml`) so that:
+
+1. **Full test output is available on failure** — Today we often copy-paste from the UI, error details are truncated or only snippets, and we must re-run locally to find all issues. The goal is to run `smart-test-full` (or equivalent) so that log files are generated and attached to each CI run so we can download them when a run fails.
+
+2. **Repro test logs are captured and attached** — For the `specfact repro` step (contract-first-ci job), collect logs and the repro report directory (e.g. `.specfact/reports/enforcement`) and upload them as artifacts so we can download on error.
+
+3. **Shift full execution validation to CI** — By having full logs and repro artifacts attached, we can rely on CI for full validation before merging to `dev` and avoid redundant local full runs.
+
+## Current Shortcomings
+
+- **pr-orchestrator.yml** runs contract-first test layers (contract-test-contracts, contract-test-exploration, contract-test-scenarios, contract-test-e2e) but does **not** use `smart-test-full`; it does not write test output to log files that are then uploaded.
+- Only **coverage.xml** is uploaded (in Tests job); no raw test logs or repro logs.
+- The **contract-first-ci** job runs `hatch run specfact repro --verbose --crosshair-required --budget 120` with `|| echo "SpecFact repro found issues"`, so the job does not fail hard and repro stdout/stderr and reports are not uploaded as artifacts.
+- Error details in the GitHub Actions UI are limited to step output (snippets); full logs are not downloadable.
+
+## What Changes
+
+- **Tests job**: Switch to (or add) running `hatch run smart-test-full` so that the smart-test script writes logs under `logs/tests/` (e.g. `full_test_run_*.log`, `full_coverage_*.log`). Upload the contents of `logs/tests/` (and existing `logs/tests/coverage/coverage.xml`) as workflow artifacts so they are available for download on every run (or on failure only to save space/retention).
+- **Contract-first-ci job (repro)**: After running `specfact repro`, collect (1) repro stdout/stderr (e.g. by redirecting to a file or using a wrapper that writes to `logs/repro/`), and (2) `.specfact/reports/enforcement/` (repro reports). Upload these as artifacts (e.g. `repro-logs` and `repro-reports`), so on failure we can download full repro output and reports.
+- **Artifact upload strategy**: Use `actions/upload-artifact@v4` with a consistent naming scheme (e.g. `test-logs-<job>`, `repro-logs`, `repro-reports`). Optionally use `if: failure()` or `if: always()` so artifacts are retained for failed runs or all runs per project policy.
+- **Documentation**: Update docs (e.g. contributing, troubleshooting, or reference) to mention that CI produces downloadable test and repro log artifacts and how to use them.
+
+## Files to Create/Modify
+
+- `.github/workflows/pr-orchestrator.yml` — Add/change test step to use smart-test-full with log output; add artifact upload steps for test logs and repro logs/reports.
+- Optionally: a small script under `.github/workflows/scripts/` to run repro and capture logs to a file (if not done inline).
+- `docs/` — Add or update a section on CI artifacts (where to find them, what they contain).
+
+## Success Metrics
+
+- Every PR/push run that executes tests produces downloadable artifacts containing full test log files when using smart-test-full.
+- Every run that executes `specfact repro` produces downloadable artifacts containing repro stdout/stderr and repro report files.
+- Contributors can diagnose failures from downloaded artifacts without needing to re-run the full suite locally.
+
+## Dependencies
+
+- Existing `tools/smart_test_coverage.py` already writes to `logs/tests/` when running full tests; ensure CI has write access and paths are consistent.
+- Existing `specfact.yml` already uploads `.specfact/reports/enforcement/*.yaml` and `.specfact/pr-comment.md`; align naming and behavior with pr-orchestrator for repro artifacts.

--- a/openspec/CHANGE_ORDER.md
+++ b/openspec/CHANGE_ORDER.md
@@ -65,6 +65,12 @@ These are derived extensions of the same 2026-02-15 plan and are required to ope
 | validation | 01 | validation-01-deep-validation | [#163](https://github.com/nold-ai/specfact-cli/issues/163) | — |
 | bundle-mapper | 01 | bundle-mapper-01-mapping-strategy | [#121](https://github.com/nold-ai/specfact-cli/issues/121) | — |
 
+### CI/CD (workflow and artifacts)
+
+| Module | Order | Change folder | GitHub # | Blocked by |
+|--------|-------|----------------|----------|------------|
+| ci | 01 | ci-01-pr-orchestrator-log-artifacts | [#260](https://github.com/nold-ai/specfact-cli/issues/260) | — |
+
 ### backlog-core (required by all backlog-* modules)
 
 | Module | Order | Change folder | GitHub # | Blocked by |

--- a/openspec/changes/ci-01-pr-orchestrator-log-artifacts/.openspec.yaml
+++ b/openspec/changes/ci-01-pr-orchestrator-log-artifacts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-16

--- a/openspec/changes/ci-01-pr-orchestrator-log-artifacts/CHANGE_VALIDATION.md
+++ b/openspec/changes/ci-01-pr-orchestrator-log-artifacts/CHANGE_VALIDATION.md
@@ -1,0 +1,61 @@
+# Change Validation Report: ci-01-pr-orchestrator-log-artifacts
+
+**Validation Date**: 2026-02-16
+**Change Proposal**: [proposal.md](./proposal.md)
+**Validation Method**: Dry-run simulation; format and OpenSpec strict validation
+
+## Executive Summary
+
+- Breaking Changes: 0 detected
+- Dependent Files: 0 (workflow and docs only; no application code interfaces changed)
+- Impact Level: Low
+- Validation Result: Pass
+- User Decision: N/A (no breaking changes)
+
+## Breaking Changes Detected
+
+None. This change only modifies `.github/workflows/pr-orchestrator.yml` (add/change steps for smart-test-full and artifact uploads) and adds or updates documentation. No public API, contract, or application code changes.
+
+## Dependencies Affected
+
+- **Workflow**: `.github/workflows/pr-orchestrator.yml` — add steps; existing jobs (tests, contract-first-ci) extended with new steps. No other workflows depend on pr-orchestrator's internal step names.
+- **Docs**: One new or updated section (troubleshooting or contributing). No code imports or references to workflow artifact names outside docs.
+
+## Impact Assessment
+
+- **Code Impact**: None (workflow YAML and docs only).
+- **Test Impact**: None; optional manual verification that artifacts appear in a CI run.
+- **Documentation Impact**: New or updated subsection on CI artifacts (where to find them, what they contain).
+- **Release Impact**: Patch (CI improvement, no user-facing API change).
+
+## Format Validation
+
+- **proposal.md Format**: Pass
+  - Title: `# Change: CI — Attach Test and Repro Log Artifacts...` (correct).
+  - Required sections: Why, What Changes, Capabilities, Impact, Source Tracking present.
+  - Capabilities section: One capability `ci-log-artifacts` with spec file `specs/ci-log-artifacts/spec.md`.
+- **tasks.md Format**: Pass
+  - TDD/SDD order section at top; hierarchical numbered tasks; branch creation first (## 1), PR creation last (## 9).
+  - Sub-tasks use `- [ ] N.M.N` format.
+- **specs Format**: Pass
+  - `specs/ci-log-artifacts/spec.md` uses Given/When/Then; ADDED requirements with scenarios.
+- **design.md Format**: Pass
+  - Overview, current/target state, integration points, edge cases; no bridge adapters (N/A).
+- **Config.yaml Compliance**: Pass
+  - Git workflow: branch first, PR last; quality gates; documentation task; version/changelog before PR.
+  - No GitHub issue creation task in tasks.md; proposal has Source Tracking placeholder for issue (to be created).
+
+## OpenSpec Validation
+
+- **Status**: Pass
+- **Validation Command**: `openspec validate ci-01-pr-orchestrator-log-artifacts --strict`
+- **Issues Found**: 0
+- **Issues Fixed**: 0
+- **Re-validated**: N/A
+
+## Next Steps
+
+1. Create GitHub issue in nold-ai/specfact-cli (title: `[Change] Attach test and repro log artifacts to PR orchestrator runs`; labels: enhancement, change-proposal).
+2. Update proposal.md Source Tracking with issue number and URL.
+3. Proceed with implementation: `/opsx:apply ci-01-pr-orchestrator-log-artifacts` or apply tasks manually.
+4. Update CHANGE_ORDER.md when change is created (add row under a CI or cross-cutting section).

--- a/openspec/changes/ci-01-pr-orchestrator-log-artifacts/design.md
+++ b/openspec/changes/ci-01-pr-orchestrator-log-artifacts/design.md
@@ -1,0 +1,33 @@
+# Design: CI Log Artifacts for PR Orchestrator
+
+## Overview
+
+This change updates `.github/workflows/pr-orchestrator.yml` so that (1) the Tests job runs `hatch run smart-test-full` and uploads generated logs under `logs/tests/` as artifacts, and (2) the contract-first-ci job captures `specfact repro` output to a log file and uploads repro logs and `.specfact/reports/enforcement/` as artifacts. No new external systems; only workflow YAML and optional helper scripts.
+
+## Current State
+
+- **Tests job**: Runs contract-test layers (contract-test-contracts, contract-test-exploration, contract-test-scenarios, contract-test-e2e) and unit tests with coverage via `hatch -e hatch-test.py3.12 run run-cov` / `hatch -e hatch-test.py3.12 run xml`. Uploads only `logs/tests/coverage/coverage.xml` as `coverage-reports`. No full test stdout/stderr log files are produced or uploaded.
+- **contract-first-ci job**: Runs `hatch run specfact repro --verbose --crosshair-required --budget 120` with `|| echo "SpecFact repro found issues"`. No log file capture; no artifact upload for repro output or reports.
+- **smart_test_coverage.py**: When run with `--level full`, writes to `logs/tests/` (e.g. `full_test_run_<timestamp>.log`, `full_coverage_<timestamp>.log`). Used locally; not yet used in pr-orchestrator.
+
+## Target State
+
+- **Tests job**: Add or replace a step to run `hatch run smart-test-full` so that logs are written to `logs/tests/`. Keep or align with existing coverage XML generation so quality-gates job still receives coverage. Add an upload-artifact step that uploads `logs/tests/` (and `logs/tests/coverage/` if separate) with a name like `test-logs`. Use `if: always()` so logs are available for both success and failure.
+- **contract-first-ci job**: Before or as part of the repro step, ensure `logs/repro/` exists. Run repro with stdout/stderr redirected to a file (e.g. `logs/repro/repro_$(date +%Y%m%d_%H%M%S).log`). After the repro step, add an upload-artifact step that uploads `logs/repro/` and `.specfact/reports/enforcement/` (if present) with names like `repro-logs` and `repro-reports`, with `if: always()`.
+- **Artifact retention**: Rely on GitHub Actions default retention; no change to workflow-level retention unless required by org policy.
+
+## Integration Points
+
+- **smart_test_coverage.py**: Already creates `logs/tests/` and writes timestamped log files when running full tests. CI must run in an environment where `hatch run smart-test-full` is available (Python 3.12, hatch, dependencies). Timeout: existing step may use SMART_TEST_TIMEOUT_SECONDS (e.g. 1800); ensure sufficient for full run.
+- **specfact repro**: Writes reports to `.specfact/reports/enforcement/` (existing). Repro does not write its own stdout to a file; workflow must redirect (e.g. `tee` or `script -q -c "..." repro.log`).
+- **specfact.yml**: Already uploads `.specfact/reports/enforcement/*.yaml` and `.specfact/pr-comment.md` as `specfact-report`. We keep pr-orchestrator artifact names distinct (e.g. `repro-reports`) so both workflows remain consistent and downloadable.
+
+## Edge Cases
+
+- **dev→main skip**: When `skip_tests_dev_to_main` is true, Tests and contract-first-ci are skipped; no new artifact steps run. No change.
+- **No report directory**: If `specfact repro` never creates `.specfact/reports/enforcement/`, upload with `if-no-files-found: ignore` so the step does not fail.
+- **Log directory missing**: Create `logs/repro/` in the contract-first-ci job before running repro so the redirect target exists.
+
+## Contract Enforcement
+
+- No new Python public APIs; only workflow and docs. No new @icontract/@beartype. Existing tools (smart_test_coverage.py, specfact repro) are unchanged except how they are invoked from CI.

--- a/openspec/changes/ci-01-pr-orchestrator-log-artifacts/proposal.md
+++ b/openspec/changes/ci-01-pr-orchestrator-log-artifacts/proposal.md
@@ -1,0 +1,30 @@
+# Change: CI — Attach Test and Repro Log Artifacts to PR Orchestrator Runs
+
+## Why
+
+The current GitHub Action runner (`.github/workflows/pr-orchestrator.yml`) forces us to copy-paste from the UI when debugging; error details are often truncated or only snippets are visible, so we must re-run the full suite locally to find all issues before fixing them. Repro test output and reports are not attached to the run, so failures in `specfact repro` are hard to diagnose from CI alone. The goal is to use `smart-test-full` to generate log files, attach those logs (and repro logs/reports) as workflow artifacts so we can download them on failure, and shift full execution validation from local runs to CI before merging to `dev`.
+
+## What Changes
+
+- **Tests job**: Use `hatch run smart-test-full` so that the smart-test script writes full test and coverage logs under `logs/tests/`. Upload `logs/tests/` (and existing coverage XML) as workflow artifacts so every run (or every failed run) has downloadable full logs.
+- **Contract-first-ci job (repro)**: After running `specfact repro`, capture repro stdout/stderr to a file under `logs/repro/` and upload `.specfact/reports/enforcement/` and the repro log file as artifacts so we can download them when the job fails.
+- **Artifact upload**: Add `actions/upload-artifact@v4` steps for test logs and repro logs/reports with consistent names (e.g. `test-logs`, `repro-logs`, `repro-reports`). Use `if: always()` or `if: failure()` per project policy so artifacts are available for debugging.
+- **Documentation**: Update contributing or troubleshooting docs to describe CI log artifacts and how to download and use them.
+
+## Capabilities
+
+- **ci-log-artifacts**: PR orchestrator runs produce downloadable test logs (from smart-test-full) and repro logs/reports so failures can be diagnosed from CI without local re-runs.
+
+## Impact
+
+- **CI**: Longer test step when using smart-test-full (writes logs); additional artifact upload steps; slightly more storage/retention for artifacts. No change to test semantics beyond ensuring full logs are generated and uploaded.
+- **Developers**: Can download full test and repro logs from the Actions run when a job fails, reducing need to re-run locally.
+- **Docs**: One new or updated section on CI artifacts (where to find them, what they contain).
+
+## Source Tracking
+
+<!-- source_repo: nold-ai/specfact-cli -->
+- **GitHub Issue**: #260
+- **Issue URL**: <https://github.com/nold-ai/specfact-cli/issues/260>
+- **Repository**: nold-ai/specfact-cli
+- **Last Synced Status**: proposed

--- a/openspec/changes/ci-01-pr-orchestrator-log-artifacts/specs/ci-log-artifacts/spec.md
+++ b/openspec/changes/ci-01-pr-orchestrator-log-artifacts/specs/ci-log-artifacts/spec.md
@@ -1,0 +1,92 @@
+# CI Log Artifacts
+
+## ADDED Requirements
+
+### Requirement: Full Test Logs from Smart-Test-Full in CI
+
+The PR orchestrator workflow SHALL run the full test suite via `hatch run smart-test-full` (or equivalent) so that test and coverage logs are written under `logs/tests/`, and those logs SHALL be uploaded as workflow artifacts so they can be downloaded when a run fails.
+
+**Rationale**: Today only snippets appear in the GitHub UI; full logs are needed to diagnose failures without re-running locally.
+
+#### Scenario: Tests Job Produces and Uploads Test Logs
+
+**Given**: A PR or push that triggers the PR orchestrator and runs the Tests job (code changed, not dev→main skip)
+
+**When**: The Tests job runs `hatch run smart-test-full` (or a step that invokes the smart-test script with level `full`)
+
+**Then**: The smart-test script writes test run output and coverage output to files under `logs/tests/` (e.g. `full_test_run_<timestamp>.log`, `full_coverage_<timestamp>.log` or equivalent), and a subsequent step uploads the contents of `logs/tests/` (and any existing `logs/tests/coverage/coverage.xml`) as a workflow artifact (e.g. name `test-logs` or `test-logs-py312`)
+
+**Acceptance Criteria**:
+
+- Tests job runs full suite in a way that generates log files under `logs/tests/`
+- Artifact upload step uses `actions/upload-artifact@v4` with path including `logs/tests/`
+- Artifacts are available for download from the Actions run (on failure or always, per policy)
+
+#### Scenario: Download Test Logs After Failed Tests Job
+
+**Given**: The Tests job failed (e.g. smart-test-full exited non-zero)
+
+**When**: A developer opens the workflow run in GitHub Actions and goes to the Artifacts section
+
+**Then**: An artifact (e.g. `test-logs`) is present and contains at least one test log file and, when coverage was run, coverage XML or coverage log, so the developer can inspect full output without re-running locally
+
+**Acceptance Criteria**:
+
+- Failed runs that produced logs have a downloadable artifact with those logs
+- Artifact naming is consistent so it can be referenced in docs
+
+---
+
+### Requirement: Repro Logs and Reports Attached to CI Run
+
+The contract-first-ci job (which runs `specfact repro`) SHALL capture repro command stdout/stderr to a log file and SHALL upload that log file plus the repro report directory (e.g. `.specfact/reports/enforcement/`) as workflow artifacts so they can be downloaded when the job fails.
+
+**Rationale**: Repro failures are currently hard to diagnose from CI because only step output (truncated) is visible; full repro output and report YAMLs are needed.
+
+#### Scenario: Contract-First-CI Job Captures and Uploads Repro Logs
+
+**Given**: The contract-first-ci job runs `specfact repro --verbose --crosshair-required --budget 120` (or equivalent)
+
+**When**: The repro command runs (whether it passes or fails)
+
+**Then**: (1) Stdout and stderr of the repro command are captured to a file under `logs/repro/` (e.g. `repro_<timestamp>.log`), and (2) the contents of `.specfact/reports/enforcement/` (if present) are uploaded together with the repro log as workflow artifacts (e.g. `repro-logs` and `repro-reports` or a single `repro-artifacts` artifact)
+
+**Acceptance Criteria**:
+
+- Repro command output is written to a file in `logs/repro/` (directory created if needed)
+- Upload step runs after repro (e.g. `if: always()`) so artifacts are available even when repro fails
+- Artifact(s) include the repro log file and any report YAMLs under `.specfact/reports/enforcement/`
+
+#### Scenario: Download Repro Artifacts After Failed Repro Step
+
+**Given**: The contract-first-ci job ran and the repro step failed (or completed with issues)
+
+**When**: A developer opens the workflow run and goes to the Artifacts section
+
+**Then**: An artifact such as `repro-logs` or `repro-reports` is present and contains the full repro log and report files so the developer can diagnose without re-running `specfact repro` locally
+
+**Acceptance Criteria**:
+
+- Naming and path are documented so developers know where to find repro logs and reports
+- Align with existing specfact.yml behavior (that workflow already uploads `.specfact/reports/enforcement/*.yaml`) for consistency
+
+---
+
+### Requirement: Documentation for CI Log Artifacts
+
+The documentation SHALL describe where to find test and repro log artifacts in GitHub Actions and how to use them for debugging failed runs.
+
+**Rationale**: Contributors need to know that artifacts exist and what they contain.
+
+#### Scenario: Contributor Finds CI Artifact Documentation
+
+**Given**: A contributor has a failed CI run and wants to debug without re-running locally
+
+**When**: They look in the contributing guide, troubleshooting guide, or a reference section on CI
+
+**Then**: They find a short section explaining that test logs and repro logs/reports are uploaded as artifacts, how to download them from the Actions run (Artifacts section), and what each artifact contains (test output, coverage, repro stdout/stderr, repro report YAMLs)
+
+**Acceptance Criteria**:
+
+- At least one doc page (e.g. `docs/guides/troubleshooting.md` or `docs/contributing/`) includes a subsection on CI artifacts
+- Section is copy-paste or link friendly (e.g. "Go to the run → Artifacts → download test-logs or repro-logs")

--- a/openspec/changes/ci-01-pr-orchestrator-log-artifacts/tasks.md
+++ b/openspec/changes/ci-01-pr-orchestrator-log-artifacts/tasks.md
@@ -1,0 +1,62 @@
+# Tasks: CI — Attach Test and Repro Log Artifacts to PR Orchestrator Runs
+
+## TDD / SDD order (enforced)
+
+Per `openspec/config.yaml`, **tests before code** apply to any task that adds or changes behavior. Order: (1) Spec deltas define behavior (Given/When/Then). (2) **Tests second** — write unit/integration tests from those scenarios; run tests and **expect failure** (no implementation yet). (3) **Code last** — implement until tests pass and behavior satisfies the spec. Do not implement production code for new behavior until the corresponding tests exist and have been run (expecting failure).
+
+For this change, the main deliverable is workflow YAML and docs; "tests" are satisfied by workflow lint (`hatch run lint-workflows`) and optional manual/e2e verification that artifacts appear. No new application code; TDD for this change is: validate workflow syntax and lint first, then implement workflow and upload steps, then verify artifacts in a run.
+
+---
+
+## 1. Create git branch
+
+- [ ] 1.1 Ensure we're on dev and up to date: `git checkout dev && git pull origin dev`
+- [ ] 1.2 Create branch: `gh issue develop <issue-number> --repo nold-ai/specfact-cli --name feature/ci-01-pr-orchestrator-log-artifacts --checkout` if issue exists, else `git checkout -b feature/ci-01-pr-orchestrator-log-artifacts`
+- [ ] 1.3 Verify branch: `git branch --show-current`
+
+## 2. Verify spec deltas (SDD: specs first)
+
+- [ ] 2.1 Confirm `specs/ci-log-artifacts/spec.md` exists and is complete (Given/When/Then for test logs upload, repro logs/reports upload, documentation).
+- [ ] 2.2 Map scenarios to implementation: Tests job smart-test-full + artifact upload; contract-first-ci repro log capture + artifact upload; doc section on CI artifacts.
+
+## 3. Tests job: Run smart-test-full and upload test logs (TDD: validate then implement)
+
+- [ ] 3.1 **Validation**: Run `hatch run lint-workflows` (or equivalent) to ensure workflow syntax is valid; note current pr-orchestrator.yml structure.
+- [ ] 3.2 In `.github/workflows/pr-orchestrator.yml`, add or replace the test execution step in the **Tests** job so that it runs `hatch run smart-test-full` (with env such as `CONTRACT_FIRST_TESTING`, `TEST_MODE`, `HATCH_TEST_ENV`, `SMART_TEST_TIMEOUT_SECONDS`, `PYTEST_ADDOPTS` as needed). Ensure the script writes logs under `logs/tests/` (existing behavior of smart_test_coverage.py when level is full).
+- [ ] 3.3 Add a step to upload test log artifacts: use `actions/upload-artifact@v4` with name `test-logs` (or `test-logs-py312`), path `logs/tests/`, and `if-no-files-found: ignore` or `warn` so the job does not fail if no logs (e.g. when step was skipped). Use `if: always()` or `if: success() || failure()` so artifacts are uploaded on both success and failure when the step ran.
+- [ ] 3.4 Keep or adjust the existing "Upload coverage artifacts" step so quality-gates still receives coverage (e.g. continue uploading `logs/tests/coverage/coverage.xml` as `coverage-reports` if that path is still produced by smart-test-full or a separate coverage step).
+- [ ] 3.5 Re-run `hatch run lint-workflows` and fix any issues.
+
+## 4. Contract-first-ci job: Capture repro output and upload repro logs/reports
+
+- [ ] 4.1 In the **contract-first-ci** job, ensure `logs/repro/` exists before running repro (e.g. `mkdir -p logs/repro`).
+- [ ] 4.2 Change the repro run step so that stdout and stderr are captured to a timestamped file under `logs/repro/` (e.g. `repro_$(date -u +%Y%m%d_%H%M%S).log`) using `tee` or redirection, while still displaying output in the step log. Run `hatch run specfact repro --verbose --crosshair-required --budget 120`; keep `|| echo "SpecFact repro found issues"` or similar so the job can continue to upload artifacts even when repro fails.
+- [ ] 4.3 Add an upload-artifact step for repro logs: upload `logs/repro/` with name `repro-logs`, `if-no-files-found: ignore`, and `if: always()` so it runs after the repro step whether repro passed or failed.
+- [ ] 4.4 Add an upload-artifact step for repro reports: upload `.specfact/reports/enforcement/` with name `repro-reports`, `if-no-files-found: ignore`, and `if: always()`.
+- [ ] 4.5 Run `hatch run lint-workflows` again.
+
+## 5. Documentation: CI log artifacts
+
+- [ ] 5.1 Identify the best doc location (e.g. `docs/guides/troubleshooting.md`, `docs/contributing/`, or a new `docs/reference/ci-artifacts.md`). Add or update a subsection that explains: (1) test logs and repro logs/reports are uploaded as workflow artifacts; (2) where to find them (Actions run → Artifacts); (3) artifact names (`test-logs`, `repro-logs`, `repro-reports`) and what they contain; (4) how to use them to debug failed runs without re-running locally.
+- [ ] 5.2 If adding a new page, set front-matter (layout, title, permalink, description) and update `docs/_layouts/default.html` sidebar if needed.
+
+## 6. Quality gates
+
+- [ ] 6.1 Run `hatch run format`, `hatch run type-check`.
+- [ ] 6.2 Run `hatch run lint` and `hatch run yaml-lint`; run `hatch run lint-workflows` for workflow files.
+- [ ] 6.3 Run `hatch run contract-test` and `hatch run smart-test` (or `smart-test-unit` / `smart-test-folder` for minimal validation). No new application code; ensure no regressions.
+
+## 7. Documentation research and review (per openspec/config.yaml)
+
+- [ ] 7.1 Confirm affected docs are listed in task 5; check for broken links and correct front-matter.
+
+## 8. Version and changelog (required before PR)
+
+- [ ] 8.1 Bump patch version (this is a fix/enhancement to CI): update `pyproject.toml`, `setup.py`, `src/__init__.py`, `src/specfact_cli/__init__.py`.
+- [ ] 8.2 Add CHANGELOG.md entry under new version: Added — CI log artifacts (test logs and repro logs/reports) attached to PR orchestrator runs for easier debugging.
+
+## 9. Create Pull Request to dev
+
+- [ ] 9.1 Commit and push: `git add .`, `git commit -m "feat(ci): attach test and repro log artifacts to PR orchestrator runs"`, `git push origin feature/ci-01-pr-orchestrator-log-artifacts`.
+- [ ] 9.2 Create PR: `gh pr create --repo nold-ai/specfact-cli --base dev --head feature/ci-01-pr-orchestrator-log-artifacts --title "feat(ci): attach test and repro log artifacts to PR orchestrator runs" --body-file <path>` (use PR template; reference OpenSpec change `ci-01-pr-orchestrator-log-artifacts` and link to GitHub issue if created).
+- [ ] 9.3 Verify PR and branch are linked to the issue in the Development section.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "specfact-cli"
-version = "0.31.0"
+version = "0.31.1"
 description = "The swiss knife CLI for agile DevOps teams. Keep backlog, specs, tests, and code in sync with validation and contract enforcement for new projects and long-lived codebases."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 if __name__ == "__main__":
     _setup = setup(
         name="specfact-cli",
-        version="0.31.0",
+        version="0.31.1",
         description=(
             "The swiss knife CLI for agile DevOps teams. Keep backlog, specs, tests, and code in sync with "
             "validation and contract enforcement for new projects and long-lived codebases."

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,4 +3,4 @@ SpecFact CLI - Spec→Contract→Sentinel tool for contract-driven development.
 """
 
 # Package version: keep in sync with pyproject.toml, setup.py, src/specfact_cli/__init__.py
-__version__ = "0.31.0"
+__version__ = "0.31.1"

--- a/src/specfact_cli/__init__.py
+++ b/src/specfact_cli/__init__.py
@@ -8,6 +8,6 @@ This package provides command-line tools for:
 - Supporting agile ceremonies and team workflows
 """
 
-__version__ = "0.31.0"
+__version__ = "0.31.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
# Description

Attach test and repro log artifacts to PR Orchestrator workflow runs so failed CI can be debugged by downloading full logs from the Actions Artifacts section without re-running locally.

- **Tests job**: Runs `hatch run smart-test-full` and uploads `logs/tests/` as `test-logs` artifact; coverage XML still uploaded for quality gates.
- **Contract-first-ci job**: Captures `specfact repro` stdout/stderr to `logs/repro/`, uploads `repro-logs` and `repro-reports` (`.specfact/reports/enforcement/`) as artifacts.
- **Docs**: New "CI and GitHub Actions" section in Troubleshooting describing artifact names and how to use them.

**Fixes** nold-ai/specfact-cli#260

**New Features** (none)

**Contract References**: None (workflow and docs only). OpenSpec change: `ci-01-pr-orchestrator-log-artifacts`.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update

## Contract-First Testing Evidence

No application code or public API changes; workflow YAML and docs only. Contract/test evidence N/A.

- [x] **Workflow lint**: `hatch run lint-workflows` ✅
- [x] **Contract validation**: `hatch run contract-test` ✅ (cached)
- [x] **YAML lint**: `hatch run yaml-lint` ✅

## How Has This Been Tested?

- Workflow syntax validated with `hatch run lint-workflows`.
- Contract-test and smart-test-unit run (no modified Python files; no new tests required for workflow-only change).

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have made corresponding changes to documentation
- [x] Version and CHANGELOG updated (0.31.1)

## Quality Gates Status

- [x] **Workflow lint** ✅
- [x] **YAML lint** ✅
- [x] **Contract validation** ✅
