### PR TITLE
fix: align PyPI publish build step with Hatch packaging config

### DIFF
--- a/.github/workflows/scripts/check-and-publish-pypi.sh
+++ b/.github/workflows/scripts/check-and-publish-pypi.sh
@@ -83,9 +83,10 @@ if [ "$SHOULD_PUBLISH" = "true" ]; then
     echo "🚀 Publishing to PyPI..."
     
     # Build package
+    # Use hatch build to match the project's configured packaging flow.
     echo "📦 Building package..."
-    python -m pip install --upgrade build twine
-    python -m build
+    python -m pip install --upgrade hatch twine
+    hatch build
     
     # Validate package
     echo "🔍 Validating package..."


### PR DESCRIPTION
### Motivation
- The Publish-to-PyPI job failed because the workflow built artifacts with `python -m build`, which can fail for this repository's forced-include layout when building a wheel from an sdist in an isolated temp directory, so the project's canonical `hatch` build flow must be used.

### Description
- Updated `.github/workflows/scripts/check-and-publish-pypi.sh` to install `hatch` (instead of `build`) and run `hatch build` for packaging, preserving the `twine check` and upload logic.

### Testing
- Reproduced the original failure locally, then ran the updated publish script and verified `hatch build` produced valid artifacts and `twine check` passed, with the script subsequently exiting at the expected guard due to a missing `PYPI_API_TOKEN` (intentional in this environment). 
- Ran `hatch run format` and `hatch run lint`, both completed successfully. 
- Began `hatch test -v` and observed a large portion of the test suite execute successfully, but the full suite run was interrupted by environment time/IO constraints (no production code changes were required for this fix).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d618cdbd08321b765b88f1850baa8)