### PR TITLE
fix: resolve startup performance regression in module freshness check

### DIFF
--- a/src/specfact_cli/utils/startup_checks.py
+++ b/src/specfact_cli/utils/startup_checks.py
@@ -21,7 +21,7 @@ from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from specfact_cli import __version__
-from specfact_cli.registry.module_installer import USER_MODULES_ROOT, get_outdated_or_missing_bundled_modules
+from specfact_cli.registry.module_installer import get_outdated_or_missing_bundled_modules
 from specfact_cli.utils.ide_setup import IDE_CONFIG, detect_ide, find_package_resources_path
 from specfact_cli.utils.metadata import (
     get_last_checked_version,
@@ -287,7 +287,7 @@ def check_module_freshness(repo_path: Path | None = None) -> ModuleFreshnessChec
         repo_path = Path.cwd()
 
     project_modules_root = repo_path / ".specfact" / "modules"
-    user_modules_root = USER_MODULES_ROOT
+    user_modules_root = Path.home() / ".specfact" / "modules"
 
     project_outdated_modules = get_outdated_or_missing_bundled_modules(project_modules_root)
     user_outdated_modules = get_outdated_or_missing_bundled_modules(user_modules_root)


### PR DESCRIPTION
### Motivation
- Ensure startup checks are fast and respect runtime `Path.home()` (e.g. when tests monkeypatch home) so stale-module guidance is not emitted unnecessarily and startup performance regressions are avoided.

### Description
- Replace import-time `USER_MODULES_ROOT` usage with a runtime resolution of the user modules root (`Path.home() / ".specfact" / "modules"`) in `src/specfact_cli/utils/startup_checks.py` so module freshness checks honor environment/time-of-call overrides.

### Testing
- Ran targeted integration tests: `hatch test -- tests/integration/test_startup_performance.py::TestStartupPerformance::test_startup_time_under_threshold -v` and `hatch test -v tests/integration/test_startup_performance.py`, and all tests in that file passed.
- Ran formatting and verification: `hatch run format` succeeded and `hatch run ./scripts/verify-modules-signature.py --require-signature` succeeded.
- Ran linting (`hatch run lint`) which produced pre-existing warnings but did not fail the validation for this change; a full `hatch test -v` run was started and progressed through a large subset of the suite in-session but was not fully completed due to runtime constraints in this environment.
- Applied rulesets: `AGENTS.md` and `.cursorrules` (OpenSpec/workflow guidance considered).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dd8eba1f083218e733f8bd3697cd6)