### PR TITLE
Release: workflow parse fix and init ide guidance update (dev → main)

### DIFF
--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -65,7 +65,7 @@ jobs:
           echo "module_path=${{ github.event.inputs.module_path }}" >> "$GITHUB_OUTPUT"
 
       - name: Sign module manifest (optional)
-        if: secrets.SPECFACT_MODULE_PRIVATE_SIGN_KEY != ""
+        if: env.SPECFACT_MODULE_PRIVATE_SIGN_KEY != ''
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             MODULE_PATH="${{ github.event.inputs.module_path }}"

--- a/src/specfact_cli/utils/startup_checks.py
+++ b/src/specfact_cli/utils/startup_checks.py
@@ -372,7 +372,7 @@ def print_startup_checks(
                     f"IDE: [cyan]{template_result.ide}[/cyan]\n"
                     f"Location: [dim]{template_result.ide_dir}[/dim]\n\n"
                     f"{details_str}\n\n"
-                    f"Run [bold]specfact init --force[/bold] to update them.",
+                    f"Run [bold]specfact init ide --force[/bold] to update them.",
                     border_style="yellow",
                 )
             )

--- a/tests/unit/utils/test_startup_checks.py
+++ b/tests/unit/utils/test_startup_checks.py
@@ -522,6 +522,7 @@ class TestPrintStartupChecks:
                     # It's a Panel, check its renderable content
                     renderable_str = str(arg.renderable)
                     if "IDE Templates Outdated" in renderable_str:
+                        assert "specfact init ide --force" in renderable_str
                         return
                 elif isinstance(arg, str) and "IDE Templates Outdated" in arg:
                     return


### PR DESCRIPTION
# Description

Release `dev` to `main` including follow-up fixes after `0.38.1` merge:

- Fix GitHub Actions workflow expression parsing in `.github/workflows/publish-modules.yml` (`if:` condition now uses valid expression string literal syntax).
- Update outdated startup hint for IDE template refresh from `specfact init --force` to `specfact init ide --force`.
- Add unit-test assertion to prevent regression of the updated IDE refresh guidance.

**Fixes** #215

**New Features** #215

**Contract References**: No public API contract changes; startup-check guidance text update only.

## Type of Change

Please check all that apply:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔒 Contract enforcement (adding/updating `@icontract` decorators)
- [x] 🧪 Test enhancement (scenario tests, property-based tests)
- [ ] 🔧 Refactoring (code improvement without functionality change)

## Contract-First Testing Evidence

**Required for all changes affecting CLI commands or public APIs:**

### Contract Validation

- [ ] **Runtime contracts added/updated** (`@icontract` decorators on public APIs)
- [ ] **Type checking enforced** (`@beartype` decorators applied)
- [ ] **CrossHair exploration** completed: `hatch run contract-test-exploration`
- [x] **Contract violations** reviewed and addressed

### Test Execution

- [x] **Contract validation**: `hatch run contract-test-contracts` ✅
- [x] **Contract exploration**: `hatch run contract-test-exploration` ✅
- [x] **Scenario tests**: `hatch run contract-test-scenarios` ✅
- [x] **Full test suite**: `hatch run contract-test-full` ✅

### Test Quality

- [ ] **CLI commands tested** with typer test client
- [ ] **Edge cases covered** with Hypothesis property tests
- [x] **Error handling tested** with invalid inputs
- [ ] **Rich console output verified** manually or with snapshots

## How Has This Been Tested?

**Contract-First Approach**: Existing contract test suite + targeted unit test for startup hint content.

### Manual Testing

- [ ] Tested CLI commands manually
- [ ] Verified rich console output
- [x] Tested with different input scenarios
- [x] Checked error messages for clarity

### Automated Testing

- [x] Contract validation passes
- [ ] Property-based tests cover edge cases
- [x] Scenario tests cover user workflows
- [ ] All existing tests still pass

### Test Environment

- Python version: 3.12
- OS: Ubuntu (Linux)

## Checklist

- [x] My code follows the style guidelines (PEP 8, ruff format, isort)
- [x] I have performed a self-review of my code
- [ ] I have added/updated contracts (`@icontract`, `@beartype`)
- [x] I have added/updated docstrings (Google style)
- [x] I have made corresponding changes to documentation
- [ ] My changes generate no new warnings (basedpyright, ruff, pylint)
- [ ] All tests pass locally
- [x] I have added tests that prove my fix/feature works
- [x] Any dependent changes have been merged

## Quality Gates Status

- [x] **Type checking** ✅ (`hatch run type-check`)
- [ ] **Linting** ✅ (`hatch run lint`) — known repo-wide pylint findings remain
- [x] **Contract validation** ✅ (`hatch run contract-test-contracts`)
- [x] **Contract exploration** ✅ (`hatch run contract-test-exploration`)
- [x] **Scenario tests** ✅ (`hatch run contract-test-scenarios`)

## Screenshots/Recordings (if applicable)

N/A.
