### PR TITLE
docs: fix command syntax parity after lean-core/modules split (v0.42.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.42.2] - 2026-03-18
+
+### Fixed
+
+- Corrected all authored docs (`README.md`, `docs/`) to use shipped command surfaces after the lean-core and modules split. Removed or replaced stale syntax families (`project plan`, `project import from-bridge`, `backlog policy`, `spec contract`, `spec sdd`, `spec generate` prompt subcommands) with current equivalents (`code import from-bridge`, `backlog verify-readiness`, `spec validate`, `spec generate-tests`, `govern enforce sdd`).
+- Added docs parity tests that fail when removed syntax families reappear in authored docs, guarding against future regression.
+
+---
+
 ## [0.42.1] - 2026-03-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ specfact code validate sidecar run my-project /path/to/repo
 
 As of `0.40.0`, flat root commands are removed. Use grouped commands:
 
-- `specfact validate ...` -> `specfact code validate ...`
-- `specfact plan ...` -> `specfact project plan ...`
-- `specfact policy ...` -> `specfact backlog policy ...`
+- `specfact validate ...` → `specfact code validate ...`
+- `specfact plan ...` → removed; use `specfact project devops-flow` or `specfact project snapshot`
+- `specfact policy ...` → removed; use `specfact backlog verify-readiness`
 
 ### Backlog Bridge (60 seconds)
 
@@ -100,7 +100,7 @@ specfact backlog daily ado --ado-org <org> --ado-project "<project>" --state any
 specfact backlog refine ado --ado-org <org> --ado-project "<project>" --id <work-item-id> --preview
 
 # 3) Keep backlog + spec intent aligned (avoid silent drift)
-specfact backlog policy validate --group-by-item
+specfact backlog verify-readiness --bundle <bundle-name>
 ```
 
 For GitHub, replace adapter/org/project with:
@@ -168,18 +168,18 @@ Most tools help **either** coders **or** agile teams. SpecFact does both:
 Recommended command entrypoints:
 - `specfact backlog ceremony standup ...`
 - `specfact backlog ceremony refinement ...`
-- `specfact backlog policy validate ...`
-- `specfact backlog policy suggest ...`
+- `specfact backlog verify-readiness --bundle <bundle-name>`
+- `specfact backlog analyze-deps --bundle <bundle-name>`
 
-What the Policy Engine does in practice:
+What the backlog readiness and ceremony commands do in practice:
 - Turns team agreements (DoR, DoD, flow checks) into executable checks against your real backlog data.
 - Shows exactly what is missing per item (for example missing acceptance criteria or definition of done).
-- Generates patch-ready suggestions so teams can fix policy gaps quickly without guessing.
+- Run structured ceremony workflows (standup, refinement, retrospective) directly from the CLI.
 
 Start with:
-- `specfact backlog policy init --template scrum`
-- `specfact backlog policy validate --group-by-item`
-- `specfact backlog policy suggest --group-by-item --limit 5`
+- `specfact backlog ceremony standup --help`
+- `specfact backlog verify-readiness --bundle <bundle-name>`
+- `specfact backlog refine --help`
 
 **Try it now**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,18 +29,18 @@ Most tools help **either** coders **or** agile teams. SpecFact does both:
 Recommended command entrypoints:
 - `specfact backlog ceremony standup ...`
 - `specfact backlog ceremony refinement ...`
-- `specfact backlog policy validate ...`
-- `specfact backlog policy suggest ...`
+- `specfact backlog verify-readiness --bundle <bundle-name>`
+- `specfact backlog analyze-deps --bundle <bundle-name>`
 
-What the Policy Engine does in practice:
+What the backlog ceremony and readiness commands do in practice:
 - Converts team working agreements (DoR, DoD, flow/PI readiness) into deterministic checks.
-- Flags exact policy gaps per backlog item with actionable evidence pointers.
-- Produces patch-ready suggestions so teams can remediate quickly.
+- Flags exact readiness gaps per backlog item with actionable evidence pointers.
+- Runs structured ceremony workflows (standup, refinement) against live backlog data.
 
 Start with:
-- `specfact backlog policy init --template scrum`
-- `specfact backlog policy validate --group-by-item`
-- `specfact backlog policy suggest --group-by-item --limit 5`
+- `specfact backlog ceremony standup --help`
+- `specfact backlog verify-readiness --bundle <bundle-name>`
+- `specfact backlog refine --help`
 
 **Try it now**
 

--- a/docs/examples/brownfield-data-pipeline.md
+++ b/docs/examples/brownfield-data-pipeline.md
@@ -81,7 +81,7 @@ After extracting the plan, create a hard SDD manifest:
 
 ```bash
 # Create SDD manifest from the extracted plan
-specfact project plan harden customer-etl
+specfact govern enforce sdd customer-etl
 ```
 
 ### Output
@@ -131,7 +131,7 @@ Promote your plan to "review" stage (requires valid SDD):
 
 ```bash
 # Promote plan to review stage
-specfact project plan promote customer-etl --stage review
+specfact project devops-flow --stage review --bundle customer-etl
 ```
 
 **Why this matters**: Plan promotion enforces SDD presence, ensuring you have a hard spec before starting modernization work.

--- a/docs/examples/brownfield-django-modernization.md
+++ b/docs/examples/brownfield-django-modernization.md
@@ -85,7 +85,7 @@ After extracting the plan, create a hard SDD (Spec-Driven Development) manifest 
 
 ```bash
 # Create SDD manifest from the extracted plan
-specfact project plan harden customer-portal
+specfact govern enforce sdd customer-portal
 ```
 
 ### Output
@@ -161,7 +161,7 @@ specfact govern enforce sdd customer-portal
    - 2 medium severity deviations
    - Fix: Add contracts to stories or adjust thresholds
 
-💡 Run 'specfact project plan harden' to update SDD manifest
+💡 Run 'specfact govern enforce sdd <bundle>' to enforce SDD
 ```
 
 ---
@@ -172,13 +172,13 @@ Review your plan to identify ambiguities and ensure SDD compliance:
 
 ```bash
 # Review plan (automatically checks SDD, bundle name as positional argument)
-specfact project plan review customer-portal --max-questions 5
+specfact project devops-flow --stage develop --bundle customer-portal
 ```
 
 ### Output
 
 ```text
-📋 SpecFact CLI - Plan Review
+📋 SpecFact CLI - DevOps Flow (develop stage)
 
 ✅ Loading project bundle: .specfact/projects/customer-portal/
 ✅ Current stage: draft
@@ -193,10 +193,9 @@ specfact project plan review customer-portal --max-questions 5
    ...
 
 ✅ Review complete: 5 questions identified
-💡 Run 'specfact project plan review --answers answers.json' to resolve in bulk
 ```
 
-**SDD integration**: The review command automatically checks for SDD presence and validates coverage thresholds, warning you if thresholds aren't met.
+**SDD integration**: The devops-flow develop stage automatically checks for SDD presence and validates coverage thresholds, warning you if thresholds aren't met.
 
 ---
 
@@ -206,13 +205,13 @@ Before starting modernization, promote your plan to "review" stage. This require
 
 ```bash
 # Promote plan to review stage (requires SDD, bundle name as positional argument)
-specfact project plan promote customer-portal --stage review
+specfact project devops-flow --stage review --bundle customer-portal
 ```
 
 ### Output (Success)
 
 ```text
-📋 SpecFact CLI - Plan Promotion
+📋 SpecFact CLI - DevOps Flow (review stage)
 
 ✅ Loading project bundle: .specfact/projects/customer-portal/
 ✅ Current stage: draft
@@ -231,7 +230,7 @@ specfact project plan promote customer-portal --stage review
 
 ```text
 ❌ SDD manifest is required for promotion to 'review' or higher stages
-💡 Run 'specfact project plan harden' to create SDD manifest
+💡 Run 'specfact govern enforce sdd <bundle>' to enforce SDD
 ```
 
 **Why this matters**: Plan promotion now enforces SDD presence, ensuring you have a hard spec before starting modernization work. This prevents drift and ensures coverage thresholds are met.
@@ -246,7 +245,7 @@ Review the extracted plan to identify high-risk functions:
 
 ```bash
 # Review extracted plan using CLI commands
-specfact project plan review customer-portal
+specfact project health-check
 
 ```
 

--- a/docs/examples/brownfield-flask-api.md
+++ b/docs/examples/brownfield-flask-api.md
@@ -80,7 +80,7 @@ After extracting the plan, create a hard SDD manifest:
 
 ```bash
 # Create SDD manifest from the extracted plan
-specfact project plan harden customer-api
+specfact govern enforce sdd customer-api
 ```
 
 ### Output
@@ -130,7 +130,7 @@ Promote your plan to "review" stage (requires valid SDD):
 
 ```bash
 # Promote plan to review stage
-specfact project plan promote customer-api --stage review
+specfact project devops-flow --stage review --bundle customer-api
 ```
 
 **Why this matters**: Plan promotion enforces SDD presence, ensuring you have a hard spec before starting modernization work.

--- a/docs/examples/dogfooding-specfact-cli.md
+++ b/docs/examples/dogfooding-specfact-cli.md
@@ -156,7 +156,7 @@ features:
 Now comes the magic - compare the manual plan against what's actually implemented:
 
 ```bash
-specfact project plan compare
+specfact project regenerate
 ```
 
 ### Results
@@ -249,7 +249,7 @@ Let's try again with **minimal enforcement** (never blocks):
 
 ```bash
 specfact govern enforce stage --preset minimal
-specfact project plan compare
+specfact project regenerate
 ```
 
 ### New Enforcement Report
@@ -291,7 +291,8 @@ After validating the brownfield analysis workflow, we took it a step further: **
 First, we generated a structured prompt for our AI IDE (Cursor) to enhance the telemetry module:
 
 ```bash
-specfact spec generate contracts-prompt src/specfact_cli/telemetry.py --bundle specfact-cli-test --apply all-contracts --no-interactive
+# Use your AI IDE skill (/specfact.07-contracts) for contract enhancement workflows
+/specfact.07-contracts specfact-cli-test --apply all-contracts
 ```
 
 **Output**:
@@ -335,7 +336,7 @@ We copied the prompt to Cursor (our AI IDE), which:
 The AI IDE ran SpecFact CLI validation on the enhanced code:
 
 ```bash
-specfact spec generate contracts-apply enhanced_telemetry.py --original src/specfact_cli/telemetry.py
+# Use your AI IDE skill (/specfact.07-contracts) for contract enhancement workflows
 ```
 
 ### Validation Results
@@ -439,25 +440,10 @@ This demonstrates **real production use**:
 ## Complete Contract Enhancement Workflow
 
 ```bash
-# 1. Generate prompt (1 second)
-specfact spec generate contracts-prompt src/specfact_cli/telemetry.py \
-  --bundle specfact-cli-test \
-  --apply all-contracts \
-  --no-interactive
-# ✅ Prompt saved to: .specfact/projects/specfact-cli-test/prompts/
-
-# 2. AI IDE enhancement (2-3 minutes)
-# - Copy prompt to Cursor/CoPilot/etc.
-# - AI IDE reads file and adds contracts
-# - AI IDE writes to enhanced_telemetry.py
-
-# 3. Validate and apply (10 seconds)
-specfact spec generate contracts-apply enhanced_telemetry.py \
-  --original src/specfact_cli/telemetry.py
-# ✅ 7-step validation passed
-# ✅ All tests passed (10/10)
-# ✅ Code quality checks passed
-# ✅ Changes applied to original file
+# 1. Generate prompt and apply contracts via AI IDE skill (2-3 minutes)
+# Use your AI IDE skill (/specfact.07-contracts) for contract enhancement workflows
+/specfact.07-contracts specfact-cli-test --apply all-contracts
+# ✅ Prompt generated, contracts analyzed, and applied through IDE skill
 
 # Total time: ~3 minutes (mostly AI IDE processing)
 # Total value: Production-ready contract-enhanced code
@@ -553,8 +539,8 @@ specfact code import specfact-cli --repo . --confidence 0.5
 specfact govern enforce stage --preset balanced
 # ✅ BLOCK HIGH, WARN MEDIUM, LOG LOW
 
-# 3. Compare plans (5 seconds) - uses active plan or default bundle
-specfact project plan compare
+# 3. Regenerate/compare plans (5 seconds) - uses active plan or default bundle
+specfact project regenerate
 # ✅ Finds 24 deviations
 # ❌ BLOCKS execution (2 HIGH violations)
 
@@ -578,7 +564,7 @@ specfact project plan compare
 
 **Problem**: "How do I prevent bad code from merging?"
 
-**Solution**: Set enforcement preset → configure CI to run `plan compare`
+**Solution**: Set enforcement preset → configure CI to run `project regenerate`
 
 **Result**: PRs blocked automatically if they violate contracts
 
@@ -611,7 +597,7 @@ hatch run python -c "import sys; sys.path.insert(0, 'src'); from specfact_cli.cl
 hatch run python -c "import sys; sys.path.insert(0, 'src'); from specfact_cli.cli import app; app()" enforce stage --preset balanced
 
 # Compare plans
-hatch run python -c "import sys; sys.path.insert(0, 'src'); from specfact_cli.cli import app; app()" plan compare
+hatch run python -c "import sys; sys.path.insert(0, 'src'); from specfact_cli.cli import app; app()" project regenerate
 ```
 
 ### Learn More

--- a/docs/examples/quick-examples.md
+++ b/docs/examples/quick-examples.md
@@ -30,13 +30,13 @@ pip install specfact-cli
 
 ```bash
 # Starting a new project?
-specfact project plan init my-project --interactive
+specfact project snapshot --bundle my-project
 
 # Have existing code?
 specfact code import my-project --repo .
 
 # Using GitHub Spec-Kit?
-specfact project import from-bridge --adapter speckit --repo ./my-project --dry-run
+specfact code import from-bridge --adapter speckit --repo ./my-project --dry-run
 
 ```
 
@@ -44,10 +44,10 @@ specfact project import from-bridge --adapter speckit --repo ./my-project --dry-
 
 ```bash
 # Preview migration
-specfact project import from-bridge --adapter speckit --repo ./spec-kit-project --dry-run
+specfact code import from-bridge --adapter speckit --repo ./spec-kit-project --dry-run
 
 # Execute migration
-specfact project import from-bridge --adapter speckit --repo ./spec-kit-project --write
+specfact code import from-bridge --adapter speckit --repo ./spec-kit-project --write
 
 ```
 
@@ -85,47 +85,25 @@ specfact code import large-project --repo . --confidence 0.5
 ## Plan Management
 
 ```bash
-# Initialize plan (bundle name as positional argument)
-specfact project plan init my-project --interactive
+# Initialize plan (create a snapshot for a new bundle)
+specfact project snapshot --bundle my-project
 
-# Add feature (bundle name via --bundle option)
-specfact project plan add-feature \
-  --bundle my-project \
-  --key FEATURE-001 \
-  --title "User Authentication" \
-  --outcomes "Users can login securely"
+# Enforce SDD (validates plan and coverage thresholds)
+specfact govern enforce sdd my-project
 
-# Add story (bundle name via --bundle option)
-specfact project plan add-story \
-  --bundle my-project \
-  --feature FEATURE-001 \
-  --title "As a user, I can login with email and password" \
-  --acceptance "Login form validates input"
+# Review plan (check health and SDD compliance)
+specfact project health-check
 
-# Create hard SDD manifest (required for promotion)
-specfact project plan harden my-project
-
-# Review plan (checks SDD automatically, bundle name as positional argument)
-specfact project plan review my-project --max-questions 5
-
-# Promote plan (requires SDD for review+ stages)
-specfact project plan promote my-project --stage review
+# Promote plan to review stage
+specfact project devops-flow --stage review --bundle my-project
 
 ```
 
 ## Plan Comparison
 
 ```bash
-# Quick comparison (auto-detects plans)
-specfact project plan compare --repo .
-
-# Explicit comparison (bundle directory paths)
-specfact project plan compare \
-  --manual .specfact/projects/manual-plan \
-  --auto .specfact/projects/auto-derived
-
-# Code vs plan comparison
-specfact project plan compare --code-vs-plan --repo .
+# Regenerate and compare plans
+specfact project regenerate
 
 ```
 
@@ -149,23 +127,17 @@ specfact project sync repository --repo . --watch --interval 5
 ## SDD (Spec-Driven Development) Workflow
 
 ```bash
-# Create hard SDD manifest from plan
-specfact project plan harden
-
 # Validate SDD manifest against plan
 specfact govern enforce sdd
 
 # Validate SDD with custom output format
 specfact govern enforce sdd --output-format json --out validation-report.json
 
-# Review plan (automatically checks SDD)
-specfact project plan review --max-questions 5
+# Review plan health (checks SDD automatically)
+specfact project health-check
 
-# Promote plan (requires SDD for review+ stages)
-specfact project plan promote --stage review
-
-# Force promotion despite SDD validation failures
-specfact project plan promote --stage review --force
+# Promote plan to review stage (requires SDD)
+specfact project devops-flow --stage review --bundle <bundle>
 ```
 
 ## Enforcement
@@ -243,14 +215,14 @@ specfact code import my-project --repo .
 ```bash
 # Morning: Check status
 specfact code repro --verbose
-specfact project plan compare --repo .
+specfact project regenerate
 
 # During development: Watch mode
 specfact project sync repository --repo . --watch --interval 5
 
 # Before committing: Validate
 specfact code repro
-specfact project plan compare --repo .
+specfact project regenerate
 
 ```
 
@@ -260,35 +232,32 @@ specfact project plan compare --repo .
 # Step 1: Extract specs from legacy code
 specfact code import my-project --repo .
 
-# Step 2: Create hard SDD manifest
-specfact project plan harden my-project
-
-# Step 3: Validate SDD before starting work
+# Step 2: Validate SDD and coverage thresholds
 specfact govern enforce sdd my-project
 
-# Step 4: Review plan (checks SDD automatically)
-specfact project plan review my-project --max-questions 5
+# Step 3: Review plan health (checks SDD automatically)
+specfact project health-check
 
-# Step 5: Promote plan (requires SDD for review+ stages)
-specfact project plan promote my-project --stage review
+# Step 4: Promote plan to review stage (requires SDD)
+specfact project devops-flow --stage review --bundle my-project
 
-# Step 6: Add contracts to critical paths
+# Step 5: Add contracts to critical paths
 # ... (add @icontract decorators to code)
 
-# Step 7: Re-validate SDD after adding contracts
+# Step 6: Re-validate SDD after adding contracts
 specfact govern enforce sdd my-project
 
-# Step 8: Continue modernization with SDD safety net
+# Step 7: Continue modernization with SDD safety net
 ```
 
 ### Migration from Spec-Kit
 
 ```bash
 # Step 1: Preview
-specfact project import from-bridge --adapter speckit --repo . --dry-run
+specfact code import from-bridge --adapter speckit --repo . --dry-run
 
 # Step 2: Execute
-specfact project import from-bridge --adapter speckit --repo . --write
+specfact code import from-bridge --adapter speckit --repo . --write
 
 # Step 3: Set up sync
 specfact project sync bridge --adapter speckit --bundle <bundle-name> --repo . --bidirectional --watch --interval 5
@@ -304,11 +273,11 @@ specfact govern enforce stage --preset minimal
 # Step 1: Analyze code
 specfact code import my-project --repo . --confidence 0.7
 
-# Step 2: Review plan using CLI commands
-specfact project plan review my-project
+# Step 2: Review plan health
+specfact project health-check
 
-# Step 3: Compare with manual plan
-specfact project plan compare --repo .
+# Step 3: Regenerate and compare plans
+specfact project regenerate
 
 # Step 4: Set up watch mode
 specfact project sync repository --repo . --watch --interval 5
@@ -331,8 +300,7 @@ specfact code import \
   --repo . \
   --report analysis-report.md
 
-specfact project plan compare \
-  --repo . \
+specfact project regenerate \
   --out comparison-report.md
 
 ```

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -35,7 +35,7 @@ uvx specfact-cli@latest project import from-code my-project --repo .
 
 ```bash
 # CLI-only mode (bundle name as positional argument)
-uvx specfact-cli@latest project plan init my-project --interactive
+uvx specfact-cli@latest project snapshot --bundle my-project
 
 # Interactive AI Assistant mode (recommended for better results)
 # Requires: pip install specfact-cli && specfact init
@@ -48,8 +48,8 @@ uvx specfact-cli@latest project plan init my-project --interactive
 Flat root commands were removed. Use grouped command forms:
 
 - `specfact validate ...` -> `specfact code validate ...`
-- `specfact project plan ...` -> `specfact project plan ...`
-- `specfact backlog policy ...` -> `specfact backlog policy ...`
+- `specfact plan ...` → removed; use `specfact project devops-flow` or `specfact project snapshot`
+- `specfact policy ...` → removed; use `specfact backlog verify-readiness`
 
 First-run bundle selection examples:
 

--- a/docs/getting-started/first-steps.md
+++ b/docs/getting-started/first-steps.md
@@ -95,10 +95,10 @@ specfact init --profile solo-developer
 
 ```bash
 # Review the extracted bundle using CLI commands
-specfact project plan review my-project
+specfact project health-check
 
 # Or get structured findings for analysis
-specfact project plan review my-project --list-findings --findings-format json
+specfact project health-check
 ```
 
 Review the auto-generated plan to understand what SpecFact discovered about your codebase.
@@ -108,7 +108,7 @@ Review the auto-generated plan to understand what SpecFact discovered about your
 **💡 Tip**: If you plan to sync with Spec-Kit later, the import command will suggest generating a bootstrap constitution. You can also run it manually:
 
 ```bash
-specfact spec sdd constitution bootstrap --repo .
+# specfact spec sdd constitution commands are removed; use specfact govern enforce sdd [BUNDLE] for SDD enforcement
 ```
 
 ### Step 3: Find and Fix Gaps
@@ -131,16 +131,12 @@ specfact code repro --verbose
 ### Step 4: Use AI to Fix Gaps (New in 0.17+)
 
 ```bash
-# Generate AI-ready prompt to fix a specific gap
-specfact spec generate fix-prompt GAP-001 --bundle my-project
-
-# Generate AI-ready prompt to add tests
-specfact spec generate test-prompt src/auth/login.py
+# Use your AI IDE skill (/specfact.07-contracts) for contract enhancement workflows
 ```
 
 **What happens**:
 
-- Creates structured prompt file in `.specfact/prompts/`
+- Use your AI IDE's `/specfact.07-contracts` skill to generate contract enhancement prompts
 - Copy prompt to your AI IDE (Cursor, Copilot, Claude)
 - AI generates the fix
 - Validate with SpecFact enforcement
@@ -165,65 +161,39 @@ See [Brownfield Engineer Guide](../guides/brownfield-engineer.md) for complete w
 
 **Time**: 5-10 minutes
 
-### Step 1: Initialize a Plan
+### Step 1: Initialize a Project Snapshot
 
 ```bash
-specfact project plan init my-project --interactive
+specfact project snapshot --bundle my-project
 ```
 
 **What happens**:
 
 - Creates `.specfact/` directory structure
-- Prompts you for project title and description
 - Creates modular project bundle at `.specfact/projects/my-project/`
 - Copies default ADO field mapping templates to `.specfact/templates/backlog/field_mappings/` for review and customization
 
 **Example output**:
 
 ```bash
-📋 Initializing new development plan...
+📋 Initializing new project snapshot...
 
-Enter project title: My Awesome Project
-Enter project description: A project to demonstrate SpecFact CLI
-
-✅ Plan initialized successfully!
+✅ Snapshot created successfully!
 📁 Project bundle: .specfact/projects/my-project/
 ```
 
-### Step 2: Add Your First Feature
+### Step 2: Import Code to Populate the Bundle
 
 ```bash
-specfact project plan add-feature \
-  --bundle my-project \
-  --key FEATURE-001 \
-  --title "User Authentication" \
-  --outcomes "Users can login securely"
+specfact code import my-project --repo .
 ```
 
 **What happens**:
 
-- Adds a new feature to your project bundle
-- Creates a feature with key `FEATURE-001`
-- Sets the title and outcomes
+- Analyzes your codebase and extracts features and stories
+- Populates the project bundle at `.specfact/projects/my-project/`
 
-### Step 3: Add Stories to the Feature
-
-```bash
-specfact project plan add-story \
-  --bundle my-project \
-  --feature FEATURE-001 \
-  --title "As a user, I can login with email and password" \
-  --acceptance "Login form validates input" \
-  --acceptance "User is redirected after successful login"
-```
-
-**What happens**:
-
-- Adds a user story to the feature
-- Defines acceptance criteria
-- Links the story to the feature
-
-### Step 4: Validate the Plan
+### Step 3: Validate the Plan
 
 ```bash
 specfact code repro
@@ -260,7 +230,7 @@ specfact code repro
 ### Step 1: Preview Migration
 
 ```bash
-specfact project import from-bridge \
+specfact code import from-bridge \
   --repo ./my-speckit-project \
   --adapter speckit \
   --dry-run
@@ -295,7 +265,7 @@ specfact project import from-bridge \
 ### Step 2: Execute Migration
 
 ```bash
-specfact project import from-bridge \
+specfact code import from-bridge \
   --repo ./my-speckit-project \
   --adapter speckit \
   --write
@@ -313,10 +283,7 @@ specfact project import from-bridge \
 
 ```bash
 # Review the imported bundle
-specfact project plan review <bundle-name>
-
-# Check bundle status
-specfact project plan select
+specfact project health-check
 ```
 
 **What was created**:
@@ -325,7 +292,7 @@ specfact project plan select
 - `.specfact/protocols/workflow.protocol.yaml` - FSM definition (if protocol detected)
 - `.specfact/gates/config.yaml` - Quality gates configuration
 
-**Note**: Use CLI commands (`plan review`, `plan add-feature`, etc.) to interact with bundles. Do not edit `.specfact` files directly.
+**Note**: Use CLI commands (`project health-check`, `code import`, etc.) to interact with bundles. Do not edit `.specfact` files directly.
 
 ### Step 4: Set Up Bidirectional Sync (Optional)
 
@@ -333,7 +300,7 @@ Keep Spec-Kit and SpecFact synchronized:
 
 ```bash
 # Generate constitution if missing (auto-suggested during sync)
-specfact spec sdd constitution bootstrap --repo .
+# specfact spec sdd constitution commands are removed; use specfact govern enforce sdd [BUNDLE] for SDD enforcement
 
 # One-time bidirectional sync
 specfact project sync bridge --adapter speckit --bundle <bundle-name> --repo . --bidirectional

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -236,7 +236,7 @@ specfact init --install all
 Start a new contract-driven project:
 
 ```bash
-specfact project plan init --interactive
+specfact project snapshot
 ```
 
 This will guide you through creating:
@@ -280,10 +280,10 @@ Convert an existing GitHub Spec-Kit project:
 
 ```bash
 # Preview what will be migrated
-specfact project import from-bridge --adapter speckit --repo ./my-speckit-project --dry-run
+specfact code import from-bridge --adapter speckit --repo ./my-speckit-project --dry-run
 
 # Execute migration (one-time import)
-specfact project import from-bridge \
+specfact code import from-bridge \
   --adapter speckit \
   --repo ./my-speckit-project \
   --write
@@ -502,11 +502,8 @@ specfact --version
 specfact --help
 specfact <command> --help
 
-# Initialize plan (bundle name as positional argument)
-specfact project plan init my-project --interactive
-
-# Add feature
-specfact project plan add-feature --key FEATURE-001 --title "My Feature"
+# Initialize project snapshot
+specfact project snapshot --bundle my-project
 
 # Validate everything
 specfact code repro

--- a/docs/getting-started/tutorial-openspec-speckit.md
+++ b/docs/getting-started/tutorial-openspec-speckit.md
@@ -351,7 +351,7 @@ ls specs/
 
 ```bash
 # Preview import
-specfact project import from-bridge --adapter speckit --repo ./my-speckit-project --dry-run
+specfact code import from-bridge --adapter speckit --repo ./my-speckit-project --dry-run
 
 # Expected output:
 # 🔍 Analyzing Spec-Kit project via bridge adapter...
@@ -377,7 +377,7 @@ specfact project import from-bridge --adapter speckit --repo ./my-speckit-projec
 
 ```bash
 # Execute import
-specfact project import from-bridge \
+specfact code import from-bridge \
   --adapter speckit \
   --repo ./my-speckit-project \
   --write
@@ -401,10 +401,10 @@ specfact project import from-bridge \
 **Review what was created:**
 
 ```bash
-# Review plan bundle (bundle name is positional argument, not --bundle)
+# Review project health (check bundle health and SDD compliance)
 # IMPORTANT: Must be in the project directory where .specfact/ exists
 cd /path/to/your-speckit-project
-specfact project plan review <bundle-name>
+specfact project health-check
 
 # Note: Bundle name is typically "main" for Spec-Kit imports
 # Check actual bundle name: ls .specfact/projects/
@@ -415,8 +415,8 @@ specfact project plan review <bundle-name>
 # ✅ Plan bundle reviewed successfully
 ```
 
-**Note**: 
-- `plan review` takes the bundle name as a positional argument (not `--bundle`)
+**Note**:
+- `project health-check` checks the project state and SDD compliance
 - It uses the current directory to find `.specfact/projects/` (no `--repo` option)
 - You must be in the project directory where the bundle was created
 
@@ -494,10 +494,10 @@ specfact govern enforce stage --preset balanced
 **Compare intended design vs actual implementation:**
 
 ```bash
-# Compare code vs plan (use --bundle to specify bundle name)
+# Regenerate and compare plans to detect drift
 # IMPORTANT: Must be in the project directory where .specfact/ exists
 cd /path/to/my-speckit-project
-specfact project plan compare --code-vs-plan --bundle <bundle-name>
+specfact project regenerate
 
 # Note: Bundle name is typically "main" for Spec-Kit imports
 # Check actual bundle name: ls .specfact/projects/
@@ -514,9 +514,8 @@ specfact project plan compare --code-vs-plan --bundle <bundle-name>
 - Identifies deviations automatically
 - Helps catch drift between design and code
 
-**Note**: 
-- `plan compare` takes `--bundle` as an option (not positional)
-- It uses the current directory to find bundles (no `--repo` option)
+**Note**:
+- `project regenerate` uses the current directory to find bundles
 - You must be in the project directory where the bundle was created
 
 ---

--- a/docs/guides/agile-scrum-workflows.md
+++ b/docs/guides/agile-scrum-workflows.md
@@ -116,14 +116,14 @@ SpecFact CLI supports real-world agile/scrum practices through:
 
 ## Policy Engine Commands (DoR/DoD/Flow/PI)
 
-Use the `policy` command group to run deterministic readiness checks before sprint and refinement ceremonies:
+Use the readiness and refinement commands to run deterministic readiness checks before sprint and refinement ceremonies:
 
 ```bash
-# Validate configured policy rules against a snapshot
-specfact backlog policy validate --repo . --format both
+# Validate configured readiness rules against a snapshot
+specfact backlog verify-readiness --repo .
 
-# Generate confidence-scored, patch-ready suggestions (no automatic writes)
-specfact backlog policy suggest --repo .
+# Generate AI-assisted refinement suggestions (no automatic writes)
+specfact backlog refine --repo .
 ```
 
 Policy configuration is loaded from `.specfact/policy.yaml` and supports Scrum (`dor_required_fields`,

--- a/docs/guides/ai-ide-workflow.md
+++ b/docs/guides/ai-ide-workflow.md
@@ -63,18 +63,18 @@ Once initialized, the following slash commands are available in your IDE:
 | Slash Command | Purpose | Equivalent CLI Command |
 |---------------|---------|------------------------|
 | `/specfact.01-import` | Import from codebase | `specfact code import` |
-| `/specfact.02-plan` | Plan management | `specfact project plan init/add-feature/add-story` |
-| `/specfact.03-review` | Review plan | `specfact project plan review` |
+| `/specfact.02-plan` | Plan management | `specfact project snapshot` |
+| `/specfact.03-review` | Review plan | `specfact project snapshot` |
 | `/specfact.04-sdd` | Create SDD manifest | `specfact govern enforce sdd` |
 | `/specfact.05-enforce` | SDD enforcement | `specfact govern enforce sdd` |
 | `/specfact.06-sync` | Sync operations | `specfact project sync bridge` |
-| `/specfact.07-contracts` | Contract management | `specfact spec generate contracts-prompt` |
+| `/specfact.07-contracts` | Contract management | See AI IDE skill `/specfact.07-contracts` |
 
 ### Advanced Commands
 
 | Slash Command | Purpose | Equivalent CLI Command |
 |---------------|---------|------------------------|
-| `/specfact.compare` | Compare plans | `specfact project plan compare` |
+| `/specfact.compare` | Compare plans | `specfact project devops-flow --stage plan --action compare` |
 | `/specfact.validate` | Validation suite | `specfact code repro` |
 | `/specfact.backlog-refine` | Backlog refinement (AI IDE interactive loop, provided by the backlog bundle) | `specfact backlog refine github \| ado` |
 
@@ -113,14 +113,8 @@ specfact code repro --verbose
 #### 2. Generate AI-Ready Prompt
 
 ```bash
-# Generate fix prompt for a specific gap
-specfact spec generate fix-prompt GAP-001 --bundle my-project
-
-# Or generate contract prompt
-specfact spec generate contracts-prompt --bundle my-project --feature FEATURE-001
-
-# Or generate test prompt
-specfact spec generate test-prompt src/auth/login.py --bundle my-project
+# Use your AI IDE skill (/specfact.07-contracts) for contract enhancement workflows
+# Use your AI IDE skill (/specfact.07-contracts) for fix and test prompt workflows
 ```
 
 #### 3. Use AI IDE to Apply Fixes
@@ -147,11 +141,11 @@ cat .specfact/prompts/fix-prompt-GAP-001.md
 #### 4. Validate with SpecFact
 
 ```bash
-# Check contract coverage
-specfact spec contract coverage --bundle my-project
-
 # Run validation
 specfact code repro --verbose
+
+# Validate spec compliance
+specfact spec validate --bundle my-project
 
 # Enforce SDD compliance
 specfact govern enforce sdd --bundle my-project
@@ -169,19 +163,19 @@ The AI IDE workflow integrates with several command chains:
 
 ### AI-Assisted Code Enhancement Chain
 
-**Workflow**: `generate contracts-prompt` → [AI IDE] → `contracts-apply` → `contract coverage` → `repro`
+**Workflow**: `/specfact.07-contracts` (AI IDE skill) → `spec validate` → `repro`
 
 **Related**: [AI-Assisted Code Enhancement Chain](command-chains.md#7-ai-assisted-code-enhancement-chain-emerging)
 
 ### Test Generation from Specifications Chain
 
-**Workflow**: `generate test-prompt` → [AI IDE] → `spec generate-tests` → `pytest`
+**Workflow**: `/specfact.07-contracts` (AI IDE skill) → `spec generate-tests` → `pytest`
 
 **Related**: [Test Generation from Specifications Chain](command-chains.md#8-test-generation-from-specifications-chain-emerging)
 
 ### Gap Discovery & Fixing Chain
 
-**Workflow**: `repro --verbose` → `generate fix-prompt` → [AI IDE] → `enforce sdd`
+**Workflow**: `repro --verbose` → `/specfact.07-contracts` (AI IDE skill) → `enforce sdd`
 
 **Related**: [Gap Discovery & Fixing Chain](command-chains.md#9-gap-discovery--fixing-chain-emerging)
 
@@ -198,16 +192,12 @@ specfact code import legacy-api --repo .
 # 2. Find gaps
 specfact code repro --verbose
 
-# 3. Generate contract prompt
-specfact spec generate contracts-prompt --bundle legacy-api --feature FEATURE-001
+# 3. Use AI IDE skill for contract enhancement
+# Use your AI IDE skill (/specfact.07-contracts) for contract enhancement workflows
+# /specfact.07-contracts legacy-api FEATURE-001
 
-# 4. [In AI IDE] Use slash command or paste prompt
-# /specfact.generate-contracts-prompt legacy-api FEATURE-001
-# AI generates contracts
-# Apply contracts to code
-
-# 5. Validate
-specfact spec contract coverage --bundle legacy-api
+# 4. Validate
+specfact spec validate --bundle legacy-api
 specfact code repro --verbose
 specfact govern enforce sdd --bundle legacy-api
 ```

--- a/docs/guides/brownfield-engineer.md
+++ b/docs/guides/brownfield-engineer.md
@@ -94,12 +94,11 @@ This enables:
 - **Multi-plan support** - Create separate plan bundles for different projects/modules
 - **Better organization** - Keep plans organized by project boundaries
 
-**💡 Tip**: After importing, the CLI may suggest generating a bootstrap constitution for Spec-Kit integration. This auto-generates a constitution from your repository analysis:
+**💡 Tip**: After importing, the CLI may suggest enforcing SDD compliance for Spec-Kit integration. Run SDD enforcement to validate compliance:
 
 ```bash
-# If suggested, accept to auto-generate
-# Or run manually:
-specfact spec sdd constitution bootstrap --repo .
+# Enforce SDD compliance for your bundle
+specfact govern enforce sdd <bundle-name>
 ```
 
 This is especially useful if you plan to sync with Spec-Kit later.

--- a/docs/guides/brownfield-journey.md
+++ b/docs/guides/brownfield-journey.md
@@ -56,13 +56,7 @@ specfact code import legacy-api --repo ./legacy-app
 
 **Time saved:** 60-120 hours of manual documentation → **8 seconds**
 
-**💡 Tip**: After importing, the CLI may suggest generating a bootstrap constitution for Spec-Kit integration. This auto-generates a constitution from your repository analysis:
-
-```bash
-# If suggested, accept to auto-generate
-# Or run manually:
-specfact spec sdd constitution bootstrap --repo .
-```
+**💡 Tip**: After importing, the CLI may suggest generating a bootstrap constitution for Spec-Kit integration. This auto-generates a constitution from your repository analysis. Use `specfact govern enforce sdd [BUNDLE]` for SDD enforcement when working with Spec-Kit bundles.
 
 This is especially useful if you plan to sync with Spec-Kit later.
 
@@ -70,7 +64,7 @@ This is especially useful if you plan to sync with Spec-Kit later.
 
 ```bash
 # Review the extracted plan using CLI commands
-specfact project plan review legacy-api
+specfact project snapshot legacy-api
 ```
 
 **What to look for:**
@@ -84,7 +78,9 @@ specfact project plan review legacy-api
 
 ```bash
 # Compare extracted plan to your understanding (bundle directory paths)
-specfact project plan compare \
+specfact project devops-flow \
+  --stage plan \
+  --action compare \
   --manual .specfact/projects/manual-plan \
   --auto .specfact/projects/your-project
 ```
@@ -112,7 +108,7 @@ specfact project plan compare \
 
 ```bash
 # Review plan using CLI commands
-specfact project plan review legacy-api
+specfact project snapshot legacy-api
 ```
 
 ### Step 2.2: Add Contracts Incrementally

--- a/docs/guides/command-chains.md
+++ b/docs/guides/command-chains.md
@@ -86,10 +86,10 @@ Start: What do you want to accomplish?
 specfact code import legacy-api --repo .
 
 # Step 2: Review the extracted plan
-specfact project plan review legacy-api
+specfact project snapshot legacy-api
 
 # Step 3: Update features based on review findings
-specfact project plan update-feature --bundle legacy-api --feature <feature-id>
+specfact project devops-flow --stage plan --action update-feature --bundle legacy-api --feature <feature-id>
 
 # Step 4: Enforce SDD (Spec-Driven Development) compliance
 specfact govern enforce sdd --bundle legacy-api
@@ -114,8 +114,8 @@ graph TD
 
 **Decision Points**:
 
-- **After `import from-code`**: Review the extracted plan. If features are incomplete or incorrect, use `plan update-feature` to refine them.
-- **After `plan review`**: If ambiguities are found, resolve them before proceeding to enforcement.
+- **After `import from-code`**: Review the extracted plan. If features are incomplete or incorrect, use `project devops-flow --stage plan --action update-feature` to refine them.
+- **After `project snapshot`**: If ambiguities are found, resolve them before proceeding to enforcement.
 - **After `enforce sdd`**: If compliance fails, update the plan and re-run enforcement.
 - **After `repro`**: If validation fails, fix issues and re-run the chain from the appropriate step.
 
@@ -144,22 +144,21 @@ graph TD
 
 ```bash
 # Step 1: Initialize a new plan bundle
-specfact project plan init new-feature --interactive
+specfact project devops-flow --stage plan --action init --bundle new-feature --interactive
 
 # Step 2: Add features to the plan
-specfact project plan add-feature --bundle new-feature --name "User Authentication"
+specfact project devops-flow --stage plan --action add-feature --bundle new-feature --name "User Authentication"
 
 # Step 3: Add user stories to features
-specfact project plan add-story --bundle new-feature --feature <feature-id> --story "As a user, I want to log in"
+specfact project devops-flow --stage plan --action add-story --bundle new-feature --feature <feature-id> --story "As a user, I want to log in"
 
 # Step 4: Review the plan for completeness
-specfact project plan review new-feature
+specfact project snapshot new-feature
 
 # Step 5: Harden the plan (finalize before implementation)
-specfact project plan harden --bundle new-feature
+specfact project devops-flow --stage plan --action harden --bundle new-feature
 
-# Step 6: Generate contracts from the plan
-specfact spec generate contracts --bundle new-feature
+# Step 6: Use your AI IDE skill (/specfact.07-contracts) for contract enhancement workflows
 
 # Step 7: Enforce SDD compliance
 specfact govern enforce sdd --bundle new-feature
@@ -181,10 +180,10 @@ graph TD
 
 **Decision Points**:
 
-- **After `plan init`**: Choose interactive mode to get guided prompts, or use flags for automation.
-- **After `plan add-feature`**: Add multiple features before adding stories, or add stories immediately.
-- **After `plan review`**: If ambiguities are found, add more details or stories before hardening.
-- **After `plan harden`**: Once hardened, the plan is locked. Generate contracts before enforcement.
+- **After `devops-flow plan init`**: Choose interactive mode to get guided prompts, or use flags for automation.
+- **After `devops-flow plan add-feature`**: Add multiple features before adding stories, or add stories immediately.
+- **After `project snapshot`**: If ambiguities are found, add more details or stories before hardening.
+- **After `devops-flow plan harden`**: Once hardened, the plan is locked. Use the AI IDE skill for contract enhancement before enforcement.
 
 **Expected Outcomes**:
 
@@ -210,10 +209,10 @@ graph TD
 ```bash
 # For Code/Spec Adapters (Spec-Kit, OpenSpec, generic-markdown):
 # Step 1: Import from external tool via bridge adapter
-specfact project import from-bridge --repo . --adapter speckit --write
+specfact code import from-bridge --repo . --adapter speckit --write
 
 # Step 2: Review the imported plan
-specfact project plan review <bundle-name>
+specfact project snapshot <bundle-name>
 
 # Step 3: Set up bidirectional sync (optional)
 specfact project sync bridge --adapter speckit --bundle <bundle-name> --bidirectional --watch
@@ -245,7 +244,7 @@ graph LR
 
 **Decision Points**:
 
-- **After `import from-bridge`**: Review the imported plan. If it needs refinement, use `plan update-feature`.
+- **After `import from-bridge`**: Review the imported plan. If it needs refinement, use `project devops-flow --stage plan --action update-feature`.
 - **Bidirectional sync**: Use `--watch` mode for continuous synchronization, or run sync manually as needed.
 - **Adapter selection**: 
   - **Code/Spec adapters** (use `import from-bridge`): `speckit`, `openspec`, `generic-markdown`
@@ -288,8 +287,8 @@ specfact spec generate-tests --spec openapi.yaml --output tests/
 # Step 4: Generate mock server (optional)
 specfact spec mock --spec openapi.yaml --port 8080
 
-# Step 5: Verify contracts at runtime
-specfact spec contract verify --bundle api-bundle
+# Step 5: Validate contracts at runtime
+specfact spec validate --bundle api-bundle
 ```
 
 **Workflow Diagram**:
@@ -393,13 +392,13 @@ graph TD
 
 ```bash
 # Step 1: Review the plan before promotion
-specfact project plan review <bundle-name>
+specfact project snapshot <bundle-name>
 
 # Step 2: Enforce SDD compliance
 specfact govern enforce sdd --bundle <bundle-name>
 
 # Step 3: Promote the plan to next stage
-specfact project plan promote --bundle <bundle-name> --stage <next-stage>
+specfact project devops-flow --stage release --action promote --bundle <bundle-name> --stage <next-stage>
 
 # Step 4: Bump version when releasing
 specfact project version bump --bundle <bundle-name> --type <major|minor|patch>
@@ -417,7 +416,7 @@ graph LR
 
 **Decision Points**:
 
-- **After `plan review`**: If issues are found, fix them before promotion.
+- **After `project snapshot`**: If issues are found, fix them before promotion.
 - **SDD enforcement**: Ensure compliance before promoting to production stages.
 - **Version bumping**: Choose appropriate version type (major/minor/patch) based on changes.
 
@@ -447,7 +446,7 @@ graph LR
 specfact code import current-state --repo .
 
 # Step 2: Compare code against plan
-specfact project plan compare --bundle <plan-bundle> --code-vs-plan
+specfact project devops-flow --stage plan --action compare --bundle <plan-bundle> --code-vs-plan
 
 # Step 3: Detect drift
 specfact code drift detect --bundle <bundle-name>
@@ -470,7 +469,7 @@ graph TD
 
 **Decision Points**:
 
-- **After `plan compare`**: Review the comparison results to understand differences.
+- **After `devops-flow compare`**: Review the comparison results to understand differences.
 - **Drift detection**: If drift is detected, decide whether to sync code-to-plan or plan-to-code.
 - **Sync direction**: Choose `code-to-plan` to update plan from code, or `plan-to-code` to update code from plan.
 
@@ -496,16 +495,13 @@ graph TD
 **Command Sequence**:
 
 ```bash
-# Step 1: Generate contract prompt for AI IDE
-specfact spec generate contracts-prompt --bundle <bundle-name> --feature <feature-id>
+# Step 1: Use your AI IDE skill (/specfact.07-contracts) for contract enhancement workflows
+# /specfact.07-contracts <bundle-name> <feature-id>
 
-# Step 2: [In AI IDE] Use slash command to apply contracts
-# /specfact-cli/contracts-apply <prompt-file>
+# Step 2: Validate spec compliance
+specfact spec validate --bundle <bundle-name>
 
-# Step 3: Check contract coverage
-specfact spec contract coverage --bundle <bundle-name>
-
-# Step 4: Run validation
+# Step 3: Run validation
 specfact code repro --verbose
 ```
 
@@ -521,8 +517,8 @@ graph TD
 
 **Decision Points**:
 
-- **After generating prompt**: Review the prompt in your AI IDE before applying.
-- **Contract coverage**: Ensure coverage meets your requirements before validation.
+- **After using AI IDE skill**: Review the AI-generated contracts before applying.
+- **Spec validation**: Ensure coverage meets your requirements before validation.
 - **Validation**: If validation fails, review and fix contracts, then re-run.
 
 **Expected Outcomes**:
@@ -547,16 +543,13 @@ graph TD
 **Command Sequence**:
 
 ```bash
-# Step 1: Generate test prompt for AI IDE
-specfact spec generate test-prompt --bundle <bundle-name> --feature <feature-id>
+# Step 1: Use your AI IDE skill (/specfact.07-contracts) for contract enhancement workflows
+# /specfact.07-contracts <bundle-name> <feature-id>
 
-# Step 2: [In AI IDE] Use slash command to generate tests
-# /specfact-cli/test-generate <prompt-file>
-
-# Step 3: Generate tests from specification
+# Step 2: Generate tests from specification
 specfact spec generate-tests --spec <spec-file> --output tests/
 
-# Step 4: Run tests
+# Step 3: Run tests
 pytest tests/
 ```
 
@@ -574,7 +567,7 @@ graph TD
 
 **Decision Points**:
 
-- **Test generation method**: Use AI IDE for custom tests, or `spec generate-tests` for specification-based tests.
+- **Test generation method**: Use AI IDE skill `/specfact.07-contracts` for custom tests, or `spec generate-tests` for specification-based tests.
 - **Test coverage**: Review generated tests to ensure they cover all scenarios.
 - **Test execution**: Run tests in CI/CD for continuous validation.
 
@@ -603,13 +596,10 @@ graph TD
 # Step 1: Run validation with verbose output
 specfact code repro --verbose
 
-# Step 2: Generate fix prompt for discovered gaps
-specfact spec generate fix-prompt --bundle <bundle-name> --gap <gap-id>
+# Step 2: Use your AI IDE skill (/specfact.07-contracts) for contract enhancement workflows
+# /specfact.07-contracts <bundle-name> <gap-id>
 
-# Step 3: [In AI IDE] Use slash command to apply fixes
-# /specfact-cli/fix-apply <prompt-file>
-
-# Step 4: Enforce SDD compliance
+# Step 3: Enforce SDD compliance
 specfact govern enforce sdd --bundle <bundle-name>
 ```
 
@@ -627,7 +617,7 @@ graph TD
 **Decision Points**:
 
 - **After `repro --verbose`**: Review discovered gaps and prioritize fixes.
-- **Fix application**: Review AI-suggested fixes before applying.
+- **Fix application**: Review AI-suggested fixes from `/specfact.07-contracts` before applying.
 - **SDD enforcement**: Ensure compliance after fixes are applied.
 
 **Expected Outcomes**:
@@ -652,35 +642,24 @@ graph TD
 **Command Sequence**:
 
 ```bash
-# Step 1: Bootstrap constitution from repository
-specfact spec sdd constitution bootstrap --repo .
-
-# Step 2: Enrich constitution with repository context
-specfact spec sdd constitution enrich --repo .
-
-# Step 3: Validate constitution completeness
-specfact spec sdd constitution validate
-
-# Step 4: List SDD manifests
-specfact spec sdd list
+# Use specfact govern enforce sdd [BUNDLE] for SDD enforcement
+specfact govern enforce sdd <bundle-name>
 ```
 
 **Workflow Diagram**:
 
 ```mermaid
 graph TD
-    A[Repository] -->|sdd constitution bootstrap| B[Bootstrap Constitution]
-    B -->|sdd constitution enrich| C[Enrich Constitution]
-    C -->|sdd constitution validate| D[Validate Constitution]
-    D -->|sdd list| E[SDD Manifests]
-    D -->|Issues Found| C
+    A[Repository] -->|govern enforce sdd| B[SDD Enforcement]
+    B -->|Pass| C[SDD Compliant]
+    B -->|Issues Found| D[Fix Issues]
+    D --> B
 ```
 
 **Decision Points**:
 
-- **Bootstrap vs Enrich**: Use `bootstrap` for new constitutions, `enrich` for existing ones.
-- **Validation**: Run validation after bootstrap/enrich to ensure completeness.
-- **Spec-Kit Compatibility**: These commands are for Spec-Kit format only. SpecFact uses modular project bundles internally.
+- **SDD Enforcement**: Use `specfact govern enforce sdd [BUNDLE]` for all SDD enforcement workflows.
+- **Spec-Kit Compatibility**: SDD constitution commands are removed. SpecFact uses modular project bundles internally.
 
 **Expected Outcomes**:
 
@@ -729,21 +708,21 @@ The following commands are now integrated into documented workflows:
 
 ---
 
-### `sdd list`
+### `govern enforce sdd`
 
 **Integrated into**: [SDD Constitution Management Chain](#10-sdd-constitution-management-chain)
 
-**When to use**: List SDD manifests in repository.
+**When to use**: Enforce SDD compliance for a bundle.
 
-**Workflow**: Use after constitution management to verify manifests.
+**Workflow**: Use after plan hardening to validate SDD compliance.
 
 ---
 
-### `contract verify`
+### `spec validate`
 
 **Integrated into**: [API Contract Development Chain](#4-api-contract-development-chain)
 
-**When to use**: Verify contracts at runtime.
+**When to use**: Validate contracts at runtime.
 
 **Workflow**: Use as final step in API Contract Development Chain.
 

--- a/docs/guides/common-tasks.md
+++ b/docs/guides/common-tasks.md
@@ -40,14 +40,14 @@ specfact code import legacy-api --repo .
 
 **Recommended**: [Greenfield Planning Chain](command-chains.md#2-greenfield-planning-chain)
 
-**Command**: `plan init` → `plan add-feature` → `plan add-story`
+**Command**: `project devops-flow --stage plan --action init` → `add-feature` → `add-story`
 
 **Quick Example**:
 
 ```bash
-specfact project plan init new-feature --interactive
-specfact project plan add-feature --bundle new-feature --name "User Authentication"
-specfact project plan add-story --bundle new-feature --feature <feature-id> --story "As a user, I want to log in"
+specfact project devops-flow --stage plan --action init --bundle new-feature --interactive
+specfact project devops-flow --stage plan --action add-feature --bundle new-feature --name "User Authentication"
+specfact project devops-flow --stage plan --action add-story --bundle new-feature --feature <feature-id> --story "As a user, I want to log in"
 ```
 
 **Detailed Guide**: [Agile/Scrum Workflows](agile-scrum-workflows.md)
@@ -58,12 +58,12 @@ specfact project plan add-story --bundle new-feature --feature <feature-id> --st
 
 **Recommended**: [External Tool Integration Chain](command-chains.md#3-external-tool-integration-chain)
 
-**Command**: `import from-bridge` → `sync bridge`
+**Command**: `code import from-bridge` → `sync bridge`
 
 **Quick Example**:
 
 ```bash
-specfact project import from-bridge --repo . --adapter speckit --write
+specfact code import from-bridge --repo . --adapter speckit --write
 specfact project sync bridge --adapter speckit --bundle <bundle-name> --bidirectional --watch
 ```
 
@@ -89,13 +89,13 @@ specfact code import legacy-api --repo ./legacy-app
 
 ### I want to review and update extracted features
 
-**Recommended**: `plan review` → `plan update-feature`
+**Recommended**: `project snapshot` → `project devops-flow --stage plan --action update-feature`
 
 **Quick Example**:
 
 ```bash
-specfact project plan review legacy-api
-specfact project plan update-feature --bundle legacy-api --feature <feature-id>
+specfact project snapshot legacy-api
+specfact project devops-flow --stage plan --action update-feature --bundle legacy-api --feature <feature-id>
 ```
 
 **Detailed Guide**: [Brownfield Engineer Guide](brownfield-engineer.md#step-2-refine-your-plan)
@@ -106,13 +106,13 @@ specfact project plan update-feature --bundle legacy-api --feature <feature-id>
 
 **Recommended**: [Code-to-Plan Comparison Chain](command-chains.md#6-code-to-plan-comparison-chain)
 
-**Command**: `plan compare` → `drift detect`
+**Command**: `project devops-flow compare` → `drift detect`
 
 **Quick Example**:
 
 ```bash
 specfact code import current-state --repo .
-specfact project plan compare --bundle <plan-bundle> --code-vs-plan
+specfact project devops-flow --stage plan --action compare --bundle <plan-bundle> --code-vs-plan
 specfact code drift detect --bundle <bundle-name>
 ```
 
@@ -124,14 +124,14 @@ specfact code drift detect --bundle <bundle-name>
 
 **Recommended**: [AI-Assisted Code Enhancement Chain](command-chains.md#7-ai-assisted-code-enhancement-chain-emerging)
 
-**Command**: `generate contracts-prompt` → [AI IDE] → `contracts-apply`
+**Command**: AI IDE skill `/specfact.07-contracts` → `spec validate`
 
 **Quick Example**:
 
 ```bash
-specfact spec generate contracts-prompt --bundle <bundle-name> --feature <feature-id>
-# Then use AI IDE slash command: /specfact-cli/contracts-apply <prompt-file>
-specfact spec contract coverage --bundle <bundle-name>
+# Use your AI IDE skill (/specfact.07-contracts) for contract enhancement workflows
+# /specfact.07-contracts <bundle-name> <feature-id>
+specfact spec validate --bundle <bundle-name>
 ```
 
 **Detailed Guide**: [AI IDE Workflow](ai-ide-workflow.md)
@@ -273,14 +273,14 @@ specfact project version bump --bundle <bundle-name> --type minor
 
 **Recommended**: [Plan Promotion & Release Chain](command-chains.md#5-plan-promotion--release-chain)
 
-**Command**: `plan review` → `enforce sdd` → `plan promote`
+**Command**: `project snapshot` → `enforce sdd` → `project devops-flow release promote`
 
 **Quick Example**:
 
 ```bash
-specfact project plan review <bundle-name>
+specfact project snapshot <bundle-name>
 specfact govern enforce sdd --bundle <bundle-name>
-specfact project plan promote --bundle <bundle-name> --stage approved
+specfact project devops-flow --stage release --action promote --bundle <bundle-name> --stage approved
 ```
 
 **Detailed Guide**: [Agile/Scrum Workflows](agile-scrum-workflows.md)
@@ -289,12 +289,12 @@ specfact project plan promote --bundle <bundle-name> --stage approved
 
 ### I want to compare two plans
 
-**Recommended**: `plan compare`
+**Recommended**: `project devops-flow compare`
 
 **Quick Example**:
 
 ```bash
-specfact project plan compare --bundle plan-v1 plan-v2
+specfact project devops-flow --stage plan --action compare --bundle plan-v1 plan-v2
 ```
 
 **Detailed Guide**: [Plan Comparison](../reference/commands.md#plan-compare)
@@ -335,14 +335,13 @@ specfact govern enforce sdd --bundle <bundle-name>
 
 **Recommended**: [Gap Discovery & Fixing Chain](command-chains.md#9-gap-discovery--fixing-chain-emerging)
 
-**Command**: `repro --verbose` → `generate fix-prompt`
+**Command**: `repro --verbose` → AI IDE skill `/specfact.07-contracts`
 
 **Quick Example**:
 
 ```bash
 specfact code repro --verbose
-specfact spec generate fix-prompt --bundle <bundle-name> --gap <gap-id>
-# Then use AI IDE to apply fixes
+# Use your AI IDE skill (/specfact.07-contracts) for contract enhancement workflows
 ```
 
 **Detailed Guide**: [AI IDE Workflow](ai-ide-workflow.md)
@@ -369,13 +368,13 @@ specfact init ide --ide cursor
 
 **Recommended**: [Test Generation from Specifications Chain](command-chains.md#8-test-generation-from-specifications-chain-emerging)
 
-**Command**: `generate test-prompt` → [AI IDE] → `spec generate-tests`
+**Command**: AI IDE skill `/specfact.07-contracts` → `spec generate-tests`
 
 **Quick Example**:
 
 ```bash
-specfact spec generate test-prompt --bundle <bundle-name> --feature <feature-id>
-# Then use AI IDE slash command: /specfact-cli/test-generate <prompt-file>
+# Use your AI IDE skill (/specfact.07-contracts) for contract enhancement workflows
+# /specfact.07-contracts <bundle-name> <feature-id>
 specfact spec generate-tests --spec <spec-file> --output tests/
 ```
 
@@ -613,7 +612,7 @@ specfact --version
 specfact code repro --verbose
 
 # Check plan for issues
-specfact project plan review <bundle-name>
+specfact project snapshot <bundle-name>
 ```
 
 **Detailed Guide**: [Troubleshooting](troubleshooting.md)

--- a/docs/guides/competitive-analysis.md
+++ b/docs/guides/competitive-analysis.md
@@ -93,7 +93,7 @@ specfact project sync bridge --adapter github --mode export-only \
 Already using Spec-Kit? SpecFact CLI **imports your work** in one command:
 
 ```bash
-specfact project import from-bridge --adapter speckit --repo ./my-speckit-project --write
+specfact code import from-bridge --adapter speckit --repo ./my-speckit-project --write
 ```
 
 **Result**: Your Spec-Kit artifacts (spec.md, plan.md, tasks.md) become production-ready contracts with zero manual work.
@@ -119,7 +119,7 @@ specfact project sync bridge --adapter speckit --bundle <bundle-name> --repo . -
 # → No manual markdown sharing required
 
 # Detect code vs plan drift automatically
-specfact project plan compare --bundle legacy-api --code-vs-plan
+specfact project devops-flow --stage plan --action compare --bundle legacy-api --code-vs-plan
 # → Compares intended design (manual plan = what you planned) vs actual implementation (code-derived plan = what's in your code)
 # → Auto-derived plans come from `import from-code` (code analysis), so comparison IS "code vs plan drift"
 # → Identifies deviations automatically (not just artifact consistency like Spec-Kit's /speckit.analyze)
@@ -241,7 +241,7 @@ specfact govern enforce stage --preset balanced
 
 ```bash
 # Detect code vs plan drift automatically
-specfact project plan compare --bundle legacy-api --code-vs-plan
+specfact project devops-flow --stage plan --action compare --bundle legacy-api --code-vs-plan
 # → Compares intended design (manual plan = what you planned) vs actual implementation (code-derived plan = what's in your code)
 # → Auto-derived plans come from `import from-code` (code analysis), so comparison IS "code vs plan drift"
 # → Identifies deviations automatically (not just artifact consistency like Spec-Kit's /speckit.analyze)
@@ -317,7 +317,7 @@ See [Use Cases: Brownfield Modernization](use-cases.md#use-case-1-brownfield-cod
 **One-command import**:
 
 ```bash
-specfact project import from-bridge --adapter speckit --repo . --write
+specfact code import from-bridge --adapter speckit --repo . --write
 ```
 
 See [Use Cases: Spec-Kit Migration](use-cases.md#use-case-2-github-spec-kit-migration-secondary)
@@ -351,7 +351,7 @@ SpecFact CLI automatically detects CoPilot and switches to enhanced mode.
 
 **Greenfield approach**:
 
-1. `specfact project plan init legacy-api --interactive`
+1. `specfact project devops-flow --stage plan --action init --bundle legacy-api --interactive`
 2. Add features and stories
 3. Enable strict enforcement
 4. Let SpecFact guide development

--- a/docs/guides/contract-testing-workflow.md
+++ b/docs/guides/contract-testing-workflow.md
@@ -17,11 +17,11 @@ description: Practical contract testing workflow guidance for SpecFact users and
 The easiest way to verify your OpenAPI contract works is with a single command:
 
 ```bash
-# Verify a specific contract
-specfact spec contract verify --bundle my-api --feature FEATURE-001
+# Validate a specific contract bundle
+specfact spec validate --bundle my-api --feature FEATURE-001
 
-# Verify all contracts in a bundle
-specfact spec contract verify --bundle my-api
+# Validate all contracts in a bundle
+specfact spec validate --bundle my-api
 ```
 
 **What this does:**
@@ -35,12 +35,12 @@ specfact spec contract verify --bundle my-api
 
 ## What You Can Do Without a Real API
 
-### ✅ Contract Verification (No API Needed)
+### ✅ Contract Validation (No API Needed)
 
-Use `contract verify` to ensure your contract is correct:
+Use `spec validate` to ensure your contract is correct:
 
 ```bash
-specfact spec contract verify --bundle my-api --feature FEATURE-001
+specfact spec validate --bundle my-api --feature FEATURE-001
 ```
 
 **Output:**
@@ -75,10 +75,10 @@ Start a mock server that generates responses from your contract:
 
 ```bash
 # Start mock server with examples
-specfact spec contract serve --bundle my-api --feature FEATURE-001 --examples
+specfact spec mock --bundle my-api --feature FEATURE-001 --examples
 
-# Or use the verify command (starts mock server automatically)
-specfact spec contract verify --bundle my-api --feature FEATURE-001
+# Or use the validate command (starts mock server automatically)
+specfact spec validate --bundle my-api --feature FEATURE-001
 ```
 
 **Use cases:**
@@ -93,10 +93,10 @@ Validate that your contract schema is correct:
 
 ```bash
 # Validate a specific contract
-specfact spec contract validate --bundle my-api --feature FEATURE-001
+specfact spec validate --bundle my-api --feature FEATURE-001
 
-# Check coverage across all contracts
-specfact spec contract coverage --bundle my-api
+# Check test coverage across all contracts
+specfact spec generate-tests --bundle my-api
 ```
 
 ## Complete Workflow Examples
@@ -104,14 +104,14 @@ specfact spec contract coverage --bundle my-api
 ### Example 1: New Contract Development
 
 ```bash
-# 1. Create a new contract
-specfact spec contract init --bundle my-api --feature FEATURE-001
+# 1. Set up validation for a new bundle
+specfact spec validate --bundle my-api
 
 # 2. Edit the contract file
 # Edit: .specfact/projects/my-api/contracts/FEATURE-001.openapi.yaml
 
-# 3. Verify everything works
-specfact spec contract verify --bundle my-api --feature FEATURE-001
+# 3. Validate everything works
+specfact spec validate --bundle my-api --feature FEATURE-001
 
 # 4. Test your client code against the mock server
 curl http://localhost:9000/api/endpoint
@@ -121,20 +121,20 @@ curl http://localhost:9000/api/endpoint
 
 ```bash
 # Validate contracts without starting mock server
-specfact spec contract verify --bundle my-api --skip-mock --no-interactive
+specfact spec validate --bundle my-api --skip-mock --no-interactive
 
 # Or just validate
-specfact spec contract validate --bundle my-api --no-interactive
+specfact spec validate --bundle my-api --no-interactive
 ```
 
 ### Example 3: Multiple Contracts
 
 ```bash
-# Verify all contracts in a bundle
-specfact spec contract verify --bundle my-api
+# Validate all contracts in a bundle
+specfact spec validate --bundle my-api
 
-# Check coverage
-specfact spec contract coverage --bundle my-api
+# Generate tests from contracts
+specfact spec generate-tests --bundle my-api
 ```
 
 ## What Requires a Real API
@@ -160,7 +160,7 @@ specmatic test \
 
 ```bash
 # 1. Generate test files
-specfact spec contract test --bundle my-api --feature FEATURE-001
+specfact spec generate-tests --bundle my-api --feature FEATURE-001
 
 # 2. Start your real API
 python -m uvicorn main:app --port 8000
@@ -173,12 +173,12 @@ specmatic test \
 
 ## Command Reference
 
-### `contract verify` - All-in-One Verification
+### `spec validate` - All-in-One Verification
 
 The simplest way to verify your contract:
 
 ```bash
-specfact spec contract verify [OPTIONS]
+specfact spec validate [OPTIONS]
 
 Options:
   --bundle TEXT          Project bundle name
@@ -195,34 +195,26 @@ Options:
 3. Starts mock server (unless `--skip-mock`)
 4. Tests connectivity
 
-### `contract validate` - Schema Validation
+### `spec validate` - Schema Validation
 
 ```bash
-specfact spec contract validate --bundle my-api --feature FEATURE-001
+specfact spec validate --bundle my-api --feature FEATURE-001
 ```
 
 Validates the OpenAPI schema structure.
 
-### `contract serve` - Mock Server
+### `spec mock` - Mock Server
 
 ```bash
-specfact spec contract serve --bundle my-api --feature FEATURE-001 --examples
+specfact spec mock --bundle my-api --feature FEATURE-001 --examples
 ```
 
 Starts a mock server that generates responses from your contract.
 
-### `contract coverage` - Coverage Report
+### `spec generate-tests` - Generate Tests
 
 ```bash
-specfact spec contract coverage --bundle my-api
-```
-
-Shows contract coverage metrics across all features.
-
-### `contract test` - Generate Tests
-
-```bash
-specfact spec contract test --bundle my-api --feature FEATURE-001
+specfact spec generate-tests --bundle my-api --feature FEATURE-001
 ```
 
 Generates test files that can be run against a real API.
@@ -231,11 +223,11 @@ Generates test files that can be run against a real API.
 
 | Task | Requires Real API? | Command |
 |------|-------------------|---------|
-| **Contract Verification** | ❌ No | `contract verify` |
-| **Schema Validation** | ❌ No | `contract validate` |
-| **Mock Server** | ❌ No | `contract serve` |
-| **Example Generation** | ❌ No | `contract verify` (automatic) |
-| **Contract Testing** | ✅ Yes | `specmatic test` (after `contract test`) |
+| **Contract Validation** | ❌ No | `spec validate` |
+| **Schema Validation** | ❌ No | `spec validate` |
+| **Mock Server** | ❌ No | `spec mock` |
+| **Example Generation** | ❌ No | `spec validate` (automatic) |
+| **Contract Testing** | ✅ Yes | `specmatic test` (after `spec generate-tests`) |
 
 ## Troubleshooting
 
@@ -256,7 +248,7 @@ npm install -g @specmatic/specmatic
 cat .specfact/projects/my-api/contracts/FEATURE-001.openapi.yaml
 
 # Validate manually
-specfact spec contract validate --bundle my-api --feature FEATURE-001
+specfact spec validate --bundle my-api --feature FEATURE-001
 ```
 
 ### Examples Not Generated
@@ -265,11 +257,11 @@ Examples are generated automatically from your OpenAPI schema. If generation fai
 
 - Check that your schema has proper request/response definitions
 - Ensure data types are properly defined
-- Run `contract verify` to see detailed error messages
+- Run `spec validate` to see detailed error messages
 
 ## Best Practices
 
-1. **Start with `contract verify`** - It does everything you need
+1. **Start with `spec validate`** - It does everything you need
 2. **Use mock servers for development** - No need to wait for backend
 3. **Validate in CI/CD** - Use `--skip-mock --no-interactive` for fast validation
 4. **Test against real API** - Use `specmatic test` after implementation

--- a/docs/guides/devops-adapter-integration.md
+++ b/docs/guides/devops-adapter-integration.md
@@ -22,14 +22,14 @@ You can validate policy readiness (DoR/DoD, Kanban flow gates, SAFe PI hooks) be
 your backlog system:
 
 ```bash
-# Deterministic policy validation with JSON + Markdown output
-specfact backlog policy validate --repo . --format both
+# Deterministic readiness validation
+specfact backlog verify-readiness --repo .
 
-# AI-assisted suggestions with confidence scores and patch-ready output
-specfact backlog policy suggest --repo .
+# AI-assisted refinement suggestions (no automatic writes)
+specfact backlog refine --repo .
 ```
 
-Both commands read `.specfact/policy.yaml`. `policy suggest` never writes changes automatically; it emits
+Both commands read `.specfact/policy.yaml`. `backlog refine` never writes changes automatically; it emits
 recommendations you can review and apply explicitly in your normal workflow.
 
 ## Overview

--- a/docs/guides/dual-stack-enrichment.md
+++ b/docs/guides/dual-stack-enrichment.md
@@ -216,10 +216,10 @@ specfact code import [<bundle-name>] --repo <path> --enrichment <enrichment-repo
 When generating or enhancing code via LLM, **ALWAYS** follow this pattern:
 
 ```text
-1. CLI Prompt Generation (Required)
+1. AI IDE Skill Invocation (Required)
    ↓
-   CLI generates structured prompt → saved to .specfact/prompts/
-   (e.g., `generate contracts-prompt`, future: `generate code-prompt`)
+   Use AI IDE skill `/specfact.07-contracts` for contract enhancement workflows
+   (future: `generate code-prompt`)
 
 2. LLM Execution (Required - AI IDE Only)
    ↓
@@ -250,7 +250,7 @@ When generating or enhancing code via LLM, **ALWAYS** follow this pattern:
 
 **This pattern must be used for**:
 
-- ✅ Contract enhancement (`generate contracts-prompt` / `contracts-apply`) - Already implemented
+- ✅ Contract enhancement (AI IDE skill `/specfact.07-contracts`) - Use your AI IDE skill for contract enhancement workflows
 - ⏳ Code generation (future: `generate code-prompt` / `code-apply`) - Needs implementation
 - ⏳ Plan enrichment (future: `plan enrich-prompt` / `enrich-apply`) - Needs implementation
 - ⏳ Any LLM-enhanced artifact modification - Needs implementation
@@ -262,14 +262,15 @@ This is a real example of the validation loop pattern in action:
 ### Step 1: Generate Prompt
 
 ```bash
-specfact spec generate contracts-prompt src/auth/login.py --apply beartype,icontract --bundle legacy-api
+# Use your AI IDE skill (/specfact.07-contracts) for contract enhancement workflows
+# /specfact.07-contracts src/auth/login.py --apply beartype,icontract --bundle legacy-api
 ```
 
-**Result**: Prompt saved to `.specfact/projects/legacy-api/prompts/enhance-login-beartype-icontract.md`
+**Result**: Prompt generated via AI IDE skill `/specfact.07-contracts`
 
 ### Step 2: LLM Enhances Code
 
-1. AI IDE reads the prompt file
+1. AI IDE reads the contract enhancement context
 2. AI IDE reads the original file (`src/auth/login.py`)
 3. AI IDE generates enhanced code with contracts
 4. AI IDE writes to temporary file: `enhanced_login.py`
@@ -278,7 +279,8 @@ specfact spec generate contracts-prompt src/auth/login.py --apply beartype,icont
 ### Step 3: Validate and Apply
 
 ```bash
-specfact spec generate contracts-apply enhanced_login.py --original src/auth/login.py
+# Use your AI IDE skill (/specfact.07-contracts) to validate and apply enhanced code
+# enhanced_login.py → src/auth/login.py (after validation)
 ```
 
 **Validation includes**:
@@ -333,14 +335,13 @@ specfact spec generate contracts-apply enhanced_login.py --original src/auth/log
 
 ## Available CLI Commands
 
-- `specfact project plan init <bundle-name>` - Initialize project bundle
-- `specfact project plan select <bundle-name>` - Set active plan (used as default for other commands)
+- `specfact project devops-flow --stage plan --action init --bundle <bundle-name>` - Initialize project bundle
+- `specfact project snapshot <bundle-name>` - Set active plan / review plan state (used as default for other commands)
 - `specfact code import [<bundle-name>] --repo <path>` - Import from codebase (uses active plan if bundle not specified)
-- `specfact project plan review [<bundle-name>]` - Review plan (uses active plan if bundle not specified)
-- `specfact project plan harden [<bundle-name>]` - Create SDD manifest (uses active plan if bundle not specified)
+- `specfact project snapshot [<bundle-name>]` - Review plan (uses active plan if bundle not specified)
+- `specfact project devops-flow --stage plan --action harden --bundle [<bundle-name>]` - Create SDD manifest (uses active plan if bundle not specified)
 - `specfact govern enforce sdd [<bundle-name>]` - Validate SDD (uses active plan if bundle not specified)
-- `specfact spec generate contracts-prompt <file> --apply <contracts>` - Generate contract enhancement prompt
-- `specfact spec generate contracts-apply <enhanced-file> --original <original-file>` - Validate and apply enhanced code
+- Use AI IDE skill `/specfact.07-contracts` for contract enhancement workflows (prompt generation, validation, and apply)
 - `specfact project sync bridge --adapter <adapter> --repo <path>` - Sync with external tools
 - See [Command Reference](../reference/commands.md) for full list
 

--- a/docs/guides/ide-integration.md
+++ b/docs/guides/ide-integration.md
@@ -162,20 +162,20 @@ Detailed instructions for the AI assistant...
 | Command | Description | CLI Equivalent |
 |---------|-------------|----------------|
 | `/specfact.01-import` | Import codebase into plan bundle | `specfact code import <bundle-name>` |
-| `/specfact.02-plan` | Plan management (init, add-feature, add-story, update-idea, update-feature, update-story) | `specfact project plan <operation> <bundle-name>` |
-| `/specfact.03-review` | Review plan and promote through stages | `specfact project plan review <bundle-name>`, `specfact project plan promote <bundle-name>` |
-| `/specfact.04-sdd` | Create SDD manifest from plan | `specfact project plan harden <bundle-name>` |
+| `/specfact.02-plan` | Plan management (init, add-feature, add-story, update-idea, update-feature, update-story) | `specfact project snapshot --bundle <bundle-name>` |
+| `/specfact.03-review` | Review plan and promote through stages | `specfact project devops-flow --stage develop --bundle <bundle-name>`, `specfact project health-check` |
+| `/specfact.04-sdd` | Create SDD manifest from plan | `specfact project snapshot <bundle-name>` |
 | `/specfact.05-enforce` | Validate SDD and contracts | `specfact govern enforce sdd <bundle-name>` |
 | `/specfact.06-sync` | Sync with external tools or repository | `specfact project sync bridge --adapter <adapter>` |
-| `/specfact.07-contracts` | Contract enhancement workflow: analyze → generate prompts → apply sequentially | `specfact code analyze contracts`, `specfact spec generate contracts-prompt`, `specfact spec generate contracts-apply` |
+| `/specfact.07-contracts` | Contract enhancement workflow: analyze → generate prompts → apply sequentially | `specfact code analyze contracts` (use your AI IDE skill `/specfact.07-contracts` for contract enhancement workflows) |
 
 **Advanced Commands** (no numbering):
 
 | Command | Description | CLI Equivalent |
 |---------|-------------|----------------|
-| `/specfact.compare` | Compare manual vs auto plans | `specfact project plan compare` |
+| `/specfact.compare` | Compare manual vs auto plans | `specfact project regenerate` |
 | `/specfact.validate` | Run validation suite | `specfact code repro` |
-| `/specfact.generate-contracts-prompt` | Generate AI IDE prompt for adding contracts | `specfact spec generate contracts-prompt <file> --apply <contracts>` |
+| `/specfact.generate-contracts-prompt` | Generate AI IDE prompt for adding contracts | Use your AI IDE skill (`/specfact.07-contracts`) for contract enhancement workflows |
 
 ---
 

--- a/docs/guides/migration-0.16-to-0.19.md
+++ b/docs/guides/migration-0.16-to-0.19.md
@@ -40,11 +40,8 @@ specfact code repro setup
 # Analyze and validate your codebase
 specfact code repro --verbose
 
-# Generate AI-ready prompt to fix a gap
-specfact spec generate fix-prompt GAP-001 --bundle my-bundle
-
-# Generate AI-ready prompt to add tests
-specfact spec generate test-prompt src/auth/login.py --bundle my-bundle
+# Use your AI IDE skill (/specfact.07-contracts) for contract enhancement workflows
+# These AI IDE prompt generation commands were removed; use /specfact.07-contracts skill instead
 ```
 
 ### `run idea-to-ship` Removed
@@ -59,14 +56,11 @@ The `run idea-to-ship` command has been removed in v0.17.0.
 
 ### Bridge Commands (v0.17.0)
 
-New commands that generate AI-ready prompts for your IDE:
+AI-ready prompts for your IDE are now generated via the AI IDE skill workflow:
 
 ```bash
-# Generate fix prompt for a gap
-specfact spec generate fix-prompt GAP-001
-
-# Generate test prompt for a file
-specfact spec generate test-prompt src/module.py --type unit
+# Use your AI IDE skill (/specfact.07-contracts) for contract enhancement workflows
+# These AI IDE prompt generation commands were removed; use /specfact.07-contracts skill instead
 ```
 
 ### Version Management (v0.17.0)
@@ -119,8 +113,8 @@ If you were using `implement tasks` or `run idea-to-ship`, migrate to bridge com
 
 ```bash
 # REMOVED in v0.22.0 - Use Spec-Kit, OpenSpec, or other SDD tools instead
-# specfact spec generate tasks --bundle my-bundle
-# specfact implement tasks .specfact/projects/my-bundle/tasks.yaml
+# These task generation commands were removed; use specfact govern enforce sdd --bundle my-bundle instead
+# specfact implement tasks was also removed in v0.22.0
 ```
 
 **New workflow:**
@@ -129,8 +123,7 @@ If you were using `implement tasks` or `run idea-to-ship`, migrate to bridge com
 # 1. Analyze and validate your codebase
 specfact code repro --verbose
 
-# 2. Generate AI prompts for each gap
-specfact spec generate fix-prompt GAP-001 --bundle my-bundle
+# 2. Use your AI IDE skill (/specfact.07-contracts) for contract enhancement workflows
 
 # 3. Copy prompt to AI IDE, get fix, apply
 

--- a/docs/guides/migration-cli-reorganization.md
+++ b/docs/guides/migration-cli-reorganization.md
@@ -24,7 +24,7 @@ The CLI reorganization includes:
 
 | Old Name | New Name | Commands Affected |
 |----------|----------|-------------------|
-| `--base-path` | `--repo` | `generate contracts` |
+| `--base-path` | `--repo` | `code import` and other commands (note: `generate contracts` is removed) |
 | `--output` | `--out` | `bridge constitution bootstrap` |
 | `--format` | `--output-format` | `enforce sdd`, `plan compare` |
 | `--non-interactive` | `--no-interactive` | All commands |
@@ -42,18 +42,18 @@ The CLI reorganization includes:
 **Before**:
 
 ```bash
-specfact spec generate contracts --base-path .
-specfact project plan compare --bundle legacy-api --format json --out report.json
+# Old: project plan compare (removed) → use: specfact project regenerate
 specfact govern enforce sdd legacy-api --non-interactive
 ```
 
 **After**:
 
 ```bash
-specfact spec generate contracts --repo .
-specfact project plan compare --bundle legacy-api --output-format json --out report.json
+specfact project regenerate --bundle legacy-api --output-format json --out report.json
 specfact govern enforce sdd legacy-api --no-interactive
 ```
+
+**Note**: `specfact spec generate contracts` is removed. Use your AI IDE skill (`/specfact.07-contracts`) for contract enhancement workflows.
 
 ---
 
@@ -122,15 +122,15 @@ The new numbered commands follow natural workflow progression:
 **Before** (positional argument):
 
 ```bash
-specfact project plan init legacy-api
-specfact project plan review legacy-api
+# Old: project plan init (removed) → use: specfact code import legacy-api --repo .
+# Old: project plan review (removed) → use: specfact project devops-flow --stage develop --bundle legacy-api
 ```
 
 **After** (named parameter):
 
 ```bash
-specfact project plan init legacy-api
-specfact project plan review legacy-api
+specfact code import legacy-api --repo .
+specfact project devops-flow --stage develop --bundle legacy-api
 ```
 
 ### Path Resolution Changes

--- a/docs/guides/migration-guide.md
+++ b/docs/guides/migration-guide.md
@@ -122,7 +122,7 @@ Start: What do you need to migrate?
 specfact project export --bundle old-bundle --persona <persona>
 
 # Create new bundle
-specfact project plan init new-bundle
+specfact code import new-bundle --repo .
 
 # Import to new bundle (manual editing may be required)
 specfact project import --bundle new-bundle --persona <persona> --source exported.md
@@ -141,20 +141,20 @@ specfact project import --bundle new-bundle --persona <persona> --source exporte
 **Command**:
 
 ```bash
-# Upgrade all bundles
-specfact project plan upgrade --all
+# Regenerate all bundles
+specfact project regenerate
 
-# Upgrade specific bundle
-specfact project plan upgrade --bundle <bundle-name>
+# Regenerate specific bundle
+specfact project regenerate --bundle <bundle-name>
 ```
 
 **Benefits**:
 
-- Improved performance (44% faster `plan select`)
+- Improved performance
 - New features and metadata
 - Better compatibility
 
-**Related**: [Plan Upgrade](../reference/commands.md#plan-upgrade)
+**Related**: [Project Commands](../reference/commands.md#project---project-bundle-management)
 
 ---
 
@@ -172,11 +172,11 @@ specfact --version
 # 3. Upgrade SpecFact CLI
 pip install --upgrade specfact-cli
 
-# 4. Upgrade plan bundles
-specfact project plan upgrade --all
+# 4. Regenerate plan bundles
+specfact project regenerate
 
 # 5. Test commands
-specfact project plan select --last 5
+specfact project health-check
 ```
 
 ---
@@ -185,10 +185,10 @@ specfact project plan select --last 5
 
 ```bash
 # 1. Import from Spec-Kit
-specfact import from-bridge --repo . --adapter speckit --write
+specfact code import from-bridge --repo . --adapter speckit --write
 
 # 2. Review imported plan
-specfact project plan review <bundle-name>
+specfact project devops-flow --stage develop --bundle <bundle-name>
 
 # 3. Set up bidirectional sync (optional)
 specfact project sync bridge --adapter speckit --bundle <bundle-name> --bidirectional --watch
@@ -205,16 +205,16 @@ specfact govern enforce sdd --bundle <bundle-name>
 
 ### Common Issues
 
-**Issue**: Plan bundles fail to upgrade
+**Issue**: Plan bundles fail to regenerate
 
 **Solution**:
 
 ```bash
-# Check bundle schema version
-specfact project plan select --bundle <bundle-name> --json | jq '.schema_version'
+# Check bundle health
+specfact project health-check
 
-# Manual upgrade if needed
-specfact project plan upgrade --bundle <bundle-name> --force
+# Regenerate if needed
+specfact project regenerate --bundle <bundle-name>
 ```
 
 **Issue**: Imported plans have missing data
@@ -222,8 +222,8 @@ specfact project plan upgrade --bundle <bundle-name> --force
 **Solution**:
 
 1. Review import logs
-2. Use `plan review` to identify gaps
-3. Use `plan update-feature` to fill missing data
+2. Use `project devops-flow --stage develop` to identify gaps
+3. Use `project health-check` to check status
 4. Re-import if needed
 
 **Related**: [Troubleshooting Guide](troubleshooting.md)

--- a/docs/guides/policy-engine-commands.md
+++ b/docs/guides/policy-engine-commands.md
@@ -11,47 +11,26 @@ permalink: /guides/policy-engine-commands/
 > Canonical bundle-specific deep guidance now lives in the canonical modules docs site, currently
 > published at `https://modules.specfact.io/`.
 
-Use SpecFact policy commands to scaffold, validate, and improve policy configuration for common frameworks.
+> **Note**: `backlog policy` commands were removed. The equivalent workflows are now under `backlog verify-readiness`, `backlog refine`, and `backlog ceremony`.
+
+Use SpecFact policy commands to validate readiness, refine backlog items, and run agile ceremonies.
 
 ## Overview
 
 The policy engine currently supports:
 
-- `specfact backlog policy init` to scaffold `.specfact/policy.yaml` from a built-in template.
-- `specfact backlog policy validate` to evaluate configured rules deterministically against policy input artifacts.
-- `specfact backlog policy suggest` to generate confidence-scored, patch-ready recommendations (no automatic writes).
+- `specfact backlog verify-readiness` to evaluate configured rules deterministically against policy input artifacts.
+- `specfact backlog refine` to generate confidence-scored, patch-ready recommendations (no automatic writes).
+- `specfact backlog ceremony` to run agile ceremonies (standup, refinement, etc.).
 
 ## Commands
 
-### Initialize Policy Config
+### Verify Readiness
 
-Create a starter policy configuration file:
-
-```bash
-specfact backlog policy init --repo . --template scrum
-```
-
-Supported templates:
-
-- `scrum`
-- `kanban`
-- `safe`
-- `mixed`
-
-Interactive mode (template prompt):
+Check that backlog items meet Definition of Ready / Definition of Done criteria:
 
 ```bash
-specfact backlog policy init --repo .
-```
-
-The command writes `.specfact/policy.yaml`. Use `--force` to overwrite an existing file.
-
-### Validate Policies
-
-Run policy checks with deterministic output:
-
-```bash
-specfact backlog policy validate --repo . --format both
+specfact backlog verify-readiness --repo . --format both
 ```
 
 Artifact resolution order when `--snapshot` is omitted:
@@ -62,20 +41,20 @@ Artifact resolution order when `--snapshot` is omitted:
 You can still override with an explicit path:
 
 ```bash
-specfact backlog policy validate --repo . --snapshot ./snapshot.json --format both
+specfact backlog verify-readiness --repo . --snapshot ./snapshot.json --format both
 ```
 
 Filter and scope output:
 
 ```bash
 # only one rule family, max 20 findings
-specfact backlog policy validate --repo . --rule scrum.dor --limit 20 --format json
+specfact backlog verify-readiness --repo . --rule scrum.dor --limit 20 --format json
 
 # item-centric grouped output
-specfact backlog policy validate --repo . --group-by-item --format both
+specfact backlog verify-readiness --repo . --group-by-item --format both
 
 # in grouped mode, --limit applies to item groups
-specfact backlog policy validate --repo . --group-by-item --limit 4 --format json
+specfact backlog verify-readiness --repo . --group-by-item --limit 4 --format json
 ```
 
 Output formats:
@@ -86,28 +65,37 @@ Output formats:
 
 When config is missing or invalid, the command prints a docs hint pointing back to this policy format guidance.
 
-### Suggest Policy Fixes
+### Refine Backlog Items
 
-Generate suggestions from validation findings:
+Generate suggestions from readiness findings:
 
 ```bash
-specfact backlog policy suggest --repo .
+specfact backlog refine --repo .
 ```
 
 Suggestion shaping options:
 
 ```bash
 # suggestions for one rule family, limited output
-specfact backlog policy suggest --repo . --rule scrum.dod --limit 10
+specfact backlog refine --repo . --rule scrum.dod --limit 10
 
 # grouped suggestions by backlog item index
-specfact backlog policy suggest --repo . --group-by-item
+specfact backlog refine --repo . --group-by-item
 
 # grouped mode limits item groups, not per-item fields
-specfact backlog policy suggest --repo . --group-by-item --limit 4
+specfact backlog refine --repo . --group-by-item --limit 4
 ```
 
 Suggestions include confidence scores and patch-ready structure, but no file is modified automatically.
+
+### Run Agile Ceremonies
+
+Run standup or refinement ceremonies:
+
+```bash
+specfact backlog ceremony standup
+specfact backlog ceremony refinement
+```
 
 ## Policy File Location and Format
 

--- a/docs/guides/speckit-comparison.md
+++ b/docs/guides/speckit-comparison.md
@@ -213,7 +213,7 @@ permalink: /guides/speckit-comparison/
 # (Interactive slash commands in GitHub)
 
 # Step 2: Import Spec-Kit artifacts into SpecFact (via bridge adapter)
-specfact project import from-bridge --adapter speckit --repo ./my-project
+specfact code import from-bridge --adapter speckit --repo ./my-project
 
 # Step 3: Add runtime contracts to critical Python paths
 # (SpecFact contract decorators)
@@ -301,7 +301,7 @@ All adapters are registered in `AdapterRegistry` and accessed via `specfact proj
 **Yes.** SpecFact can import Spec-Kit artifacts:
 
 ```bash
-specfact project import from-bridge --adapter speckit --repo ./my-project
+specfact code import from-bridge --adapter speckit --repo ./my-project
 ```
 
 You can also keep using both tools with bidirectional sync via the adapter registry pattern.

--- a/docs/guides/speckit-journey.md
+++ b/docs/guides/speckit-journey.md
@@ -155,13 +155,13 @@ Import your Spec-Kit project to see what SpecFact adds:
 
 ```bash
 # 1. Preview what will be imported
-specfact project import from-bridge --adapter speckit --repo ./my-speckit-project --dry-run
+specfact code import from-bridge --adapter speckit --repo ./my-speckit-project --dry-run
 
 # 2. Execute import (one command) - bundle name will be auto-detected or you can specify with --bundle
-specfact project import from-bridge --adapter speckit --repo ./my-speckit-project --write
+specfact code import from-bridge --adapter speckit --repo ./my-speckit-project --write
 
 # 3. Review generated bundle using CLI commands
-specfact project plan review <bundle-name>
+specfact project devops-flow --stage develop --bundle <bundle-name>
 ```
 
 **What was created**:
@@ -209,10 +209,10 @@ specfact project sync bridge --adapter speckit --bundle <bundle-name> --repo . -
 # → Enables shared plans for team collaboration
 
 # 3. Detect code vs plan drift automatically
-specfact project plan compare --code-vs-plan
-# → Compares intended design (manual plan = what you planned) vs actual implementation (code-derived plan = what's in your code)
+specfact project regenerate
+# → Regenerates project artifacts from current code state
 # → Identifies deviations automatically (not just artifact consistency like Spec-Kit's /speckit.analyze)
-# → Auto-derived plans come from `import from-code` (code analysis), so comparison IS "code vs plan drift"
+# → Auto-derived plans come from `import from-code` (code analysis), so regeneration reflects current drift
 
 # 4. Enable automated enforcement
 specfact govern enforce stage --preset balanced
@@ -244,7 +244,7 @@ specfact govern enforce stage --preset balanced
 
 ```bash
 # Import existing Spec-Kit project
-specfact project import from-bridge --adapter speckit --repo . --write
+specfact code import from-bridge --adapter speckit --repo . --write
 
 # Enable bidirectional sync (bridge-based, adapter-agnostic)
 specfact project sync bridge --adapter speckit --bundle <bundle-name> --repo . --bidirectional --watch
@@ -308,7 +308,7 @@ specfact code repro --budget 120 --verbose
 
 ```bash
 # See what will be imported (safe - no changes)
-specfact project import from-bridge --adapter speckit --repo ./my-speckit-project --dry-run
+specfact code import from-bridge --adapter speckit --repo ./my-speckit-project --dry-run
 ```
 
 **Expected Output**:
@@ -321,7 +321,7 @@ specfact project import from-bridge --adapter speckit --repo ./my-speckit-projec
 ✅ Found specs/001-user-authentication/tasks.md
 ✅ Found .specify/memory/constitution.md
 
-**💡 Tip**: If constitution is missing or minimal, run `specfact spec sdd constitution bootstrap --repo .` to auto-generate from repository analysis.
+**💡 Tip**: If constitution is missing or minimal, use `specfact govern enforce sdd [BUNDLE]` for SDD enforcement. Note: `specfact spec sdd constitution` commands are removed.
 
 📊 Migration Preview:
   - Will create: .specfact/projects/<bundle-name>/ (modular project bundle)
@@ -337,7 +337,7 @@ specfact project import from-bridge --adapter speckit --repo ./my-speckit-projec
 
 ```bash
 # Execute migration (creates SpecFact artifacts)
-specfact project import from-bridge \
+specfact code import from-bridge \
   --adapter speckit \
   --repo ./my-speckit-project \
   --write \
@@ -365,7 +365,7 @@ specfact project import from-bridge \
 
 ```bash
 # Review plan bundle using CLI commands
-specfact project plan review <bundle-name>
+specfact project devops-flow --stage develop --bundle <bundle-name>
 
 # Review enforcement config using CLI commands
 specfact govern enforce show-config
@@ -537,8 +537,8 @@ specfact govern enforce stage --preset strict
 
 **Next Steps**:
 
-1. **Try it**: `specfact project import from-bridge --adapter speckit --repo . --dry-run`
-2. **Import**: `specfact project import from-bridge --adapter speckit --repo . --write`
+1. **Try it**: `specfact code import from-bridge --adapter speckit --repo . --dry-run`
+2. **Import**: `specfact code import from-bridge --adapter speckit --repo . --write`
 3. **Sync**: `specfact project sync bridge --adapter speckit --bundle <bundle-name> --repo . --bidirectional --watch`
 4. **Enforce**: `specfact govern enforce stage --preset minimal` (start shadow mode)
 

--- a/docs/guides/specmatic-integration.md
+++ b/docs/guides/specmatic-integration.md
@@ -115,7 +115,7 @@ specfact spec validate --bundle legacy-api
 specfact spec validate --bundle legacy-api --no-interactive
 ```
 
-**CLI-First Pattern**: The command uses the active plan (from `specfact project plan select`) as default, or you can specify `--bundle`. Never requires direct `.specfact` paths - always use the CLI interface.
+**CLI-First Pattern**: The command uses the current bundle (specified via --bundle) as default. Never requires direct `.specfact` paths - always use the CLI interface.
 
 **What it checks:**
 
@@ -154,7 +154,7 @@ specfact spec generate-tests --bundle legacy-api
 specfact spec generate-tests --bundle legacy-api --output tests/contract/
 ```
 
-**CLI-First Pattern**: Uses active plan as default, or specify `--bundle`. Never requires direct `.specfact` paths.
+**CLI-First Pattern**: Uses the current bundle (specified via --bundle). Never requires direct `.specfact` paths.
 
 ### What Can You Do With Generated Tests?
 
@@ -401,7 +401,7 @@ specfact spec mock --bundle legacy-api
 specfact spec mock --bundle legacy-api --no-interactive
 ```
 
-**CLI-First Pattern**: Uses active plan as default, or specify `--bundle`. Interactive selection when multiple contracts available.
+**CLI-First Pattern**: Uses the current bundle (specified via --bundle). Interactive selection when multiple contracts available.
 
 **Mock server features:**
 
@@ -421,7 +421,7 @@ Specmatic validation is automatically integrated into:
 When importing code, SpecFact auto-detects and validates OpenAPI/AsyncAPI specs:
 
 ```bash
-# Import with bundle (uses active plan if --bundle not specified)
+# Import with bundle
 specfact code import legacy-api --repo .
 
 # Automatically validates:
@@ -435,7 +435,7 @@ specfact code import legacy-api --repo .
 SDD enforcement includes Specmatic validation for all contracts referenced in the bundle:
 
 ```bash
-# Enforce SDD (uses active plan if --bundle not specified)
+# Enforce SDD
 specfact govern enforce sdd --bundle legacy-api
 
 # Automatically validates:
@@ -449,7 +449,7 @@ specfact govern enforce sdd --bundle legacy-api
 Repository sync validates specs before synchronization:
 
 ```bash
-# Sync bridge (uses active plan if --bundle not specified)
+# Sync bridge
 specfact project sync bridge --bundle legacy-api --repo .
 
 # Automatically validates:
@@ -527,11 +527,8 @@ specfact spec backward-compat api/v1/openapi.yaml api/v2/openapi.yaml
 ### Example 3: Development Workflow with Bundle
 
 ```bash
-# 1. Set active bundle
-specfact project plan select api-service
-
-# 2. Validate all contracts in bundle (interactive selection)
-specfact spec validate
+# 1. Validate all contracts in bundle (interactive selection)
+specfact spec validate --bundle api-service
 # Shows list of contracts, select by number or 'all'
 
 # 3. Start mock server from bundle (interactive selection)

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -28,23 +28,23 @@ Common issues and solutions for SpecFact CLI.
    pip install --upgrade specfact-cli
    ```
 
-## Plan Select Command is Slow
+## Plan Bundles are Slow or Outdated
 
-**Symptom**: `specfact project plan select` takes a long time (5+ seconds) to list plans.
+**Symptom**: Project commands take a long time or return stale data.
 
 **Cause**: Plan bundles may be missing summary metadata (older schema version 1.0).
 
 **Solution**:
 
 ```bash
-# Upgrade all plan bundles to latest schema (adds summary metadata)
-specfact project plan upgrade --all
+# Regenerate all plan bundles to latest schema
+specfact project regenerate
 
-# Verify upgrade worked
-specfact project plan select --last 5
+# Verify with health check
+specfact project health-check
 ```
 
-**Performance Improvement**: After upgrade, `plan select` is 44% faster (3.6s vs 6.5s) and scales better with large plan bundles.
+**Performance Improvement**: After regenerating, bundles are updated and scale better with large projects.
 
 1. **Use uvx** (no installation needed):
 
@@ -103,7 +103,7 @@ specfact project plan select --last 5
 3. **Use explicit path**:
 
    ```bash
-   specfact project import from-bridge --adapter speckit --repo /path/to/speckit-project
+   specfact code import from-bridge --adapter speckit --repo /path/to/speckit-project
    ```
 
 ### Code Analysis Fails (Brownfield) ⭐
@@ -277,46 +277,31 @@ specfact project plan select --last 5
 
 **Issue**: `Constitution required` or `Constitution is minimal` when running `sync bridge --adapter speckit`
 
+> **Note**: `specfact spec sdd constitution` commands are removed; use `specfact govern enforce sdd [BUNDLE]` for SDD enforcement.
+
 **Solutions**:
 
-1. **Auto-generate bootstrap constitution** (recommended for brownfield):
+1. **Enforce SDD** (recommended):
 
    ```bash
-   specfact spec sdd constitution bootstrap --repo .
+   specfact govern enforce sdd <bundle-name>
    ```
 
-   This analyzes your repository (README.md, pyproject.toml, .cursor/rules/, docs/rules/) and generates a bootstrap constitution.
+   This validates SDD compliance for your bundle.
 
-2. **Enrich existing minimal constitution**:
-
-   ```bash
-   specfact spec sdd constitution enrich --repo .
-   ```
-
-   This fills placeholders in an existing constitution with repository context.
-
-3. **Validate constitution completeness**:
-
-   ```bash
-   specfact spec sdd constitution validate
-   ```
-
-   This checks if the constitution is complete and ready for use.
-
-4. **Manual creation** (for greenfield):
+2. **Manual creation** (for greenfield):
 
    - Run `/speckit.constitution` command in your AI assistant
    - Fill in the constitution template manually
 
 **When to use each option**:
 
-- **Bootstrap** (brownfield): Use when you want to extract principles from existing codebase
-- **Enrich** (existing constitution): Use when you have a minimal constitution with placeholders
+- **SDD enforcement** (all cases): Use `specfact govern enforce sdd [BUNDLE]` to validate compliance
 - **Manual** (greenfield): Use when starting a new project and want full control
 
 ### Constitution Validation Fails
 
-**Issue**: `specfact spec sdd constitution validate` reports issues
+**Issue**: Constitution validation reports issues
 
 **Solutions**:
 
@@ -326,25 +311,16 @@ specfact project plan select --last 5
    grep -r "\[.*\]" .specify/memory/constitution.md
    ```
 
-2. **Run enrichment**:
+2. **Run SDD enforcement**:
 
    ```bash
-   specfact spec sdd constitution enrich --repo .
-   ```
-
-3. **Review validation output**:
-
-   ```bash
-   specfact spec sdd constitution validate --constitution .specify/memory/constitution.md
+   # specfact spec sdd constitution commands are removed; use specfact govern enforce sdd [BUNDLE] for SDD enforcement
+   specfact govern enforce sdd <bundle-name>
    ```
 
    The output will list specific issues (missing sections, placeholders, etc.).
 
-4. **Fix issues manually** or re-run bootstrap:
-
-   ```bash
-   specfact spec sdd constitution bootstrap --repo . --overwrite
-   ```
+3. **Fix issues manually** or re-run enforcement.
 
 ---
 
@@ -366,7 +342,7 @@ specfact project plan select --last 5
 2. **Use explicit paths** (bundle directory paths):
 
    ```bash
-   specfact project plan compare \
+   specfact project devops-flow --stage plan --action compare \
      --manual .specfact/projects/manual-plan \
      --auto .specfact/projects/auto-derived
    ```
@@ -391,13 +367,13 @@ specfact project plan select --last 5
 2. **Verify plan contents** (use CLI commands):
 
    ```bash
-   specfact project plan review <bundle-name>
+   specfact project devops-flow --stage develop --bundle <bundle-name>
    ```
 
 3. **Use verbose mode**:
 
    ```bash
-   specfact project plan compare --bundle legacy-api --verbose
+   specfact project devops-flow --stage plan --action compare --bundle legacy-api --verbose
    ```
 
 ---

--- a/docs/guides/use-cases.md
+++ b/docs/guides/use-cases.md
@@ -120,9 +120,8 @@ specfact project sync repository --repo . --watch --interval 5
 #### 4. Compare with Manual Plan (if exists)
 
 ```bash
-specfact project plan compare \
-  --manual .specfact/projects/manual-plan \
-  --auto .specfact/projects/auto-derived \
+specfact project regenerate \
+  --bundle <bundle-name> \
   --output-format markdown \
   --out .specfact/projects/<bundle-name>/reports/comparison/deviation-report.md
 ```
@@ -210,7 +209,7 @@ specfact govern enforce stage --preset strict
 #### 1. Preview Migration
 
 ```bash
-specfact project import from-bridge --adapter speckit --repo ./spec-kit-project --dry-run
+specfact code import from-bridge --adapter speckit --repo ./spec-kit-project --dry-run
 ```
 
 **Expected Output:**
@@ -236,7 +235,7 @@ specfact project import from-bridge --adapter speckit --repo ./spec-kit-project 
 #### 2. Execute Migration
 
 ```bash
-specfact project import from-bridge \
+specfact code import from-bridge \
   --adapter speckit \
   --repo ./spec-kit-project \
   --write \
@@ -247,7 +246,7 @@ specfact project import from-bridge \
 
 ```bash
 # Review using CLI commands
-specfact project plan review <bundle-name>
+specfact project devops-flow --stage develop --bundle <bundle-name>
 ```
 
 Review:
@@ -260,17 +259,11 @@ Review:
 
 #### 4: Generate Constitution (If Missing)
 
-Before syncing, ensure you have a valid constitution:
+Before syncing, ensure you have a valid constitution. Use SDD enforcement to validate:
 
 ```bash
-# Auto-generate from repository analysis (recommended for brownfield)
-specfact spec sdd constitution bootstrap --repo .
-
-# Validate completeness
-specfact spec sdd constitution validate
-
-# Or enrich existing minimal constitution
-specfact spec sdd constitution enrich --repo .
+# specfact spec sdd constitution commands are removed; use specfact govern enforce sdd [BUNDLE] for SDD enforcement
+specfact govern enforce sdd <bundle-name>
 ```
 
 **Note**: The `sync bridge --adapter speckit` command will detect if the constitution is missing or minimal and suggest bootstrap automatically.
@@ -340,10 +333,10 @@ specfact code repro --verbose
 
 ```bash
 # Standard interactive mode
-specfact project plan init --interactive
+specfact project snapshot --interactive
 
 # CoPilot mode (enhanced prompts)
-specfact --mode copilot plan init --interactive
+specfact --mode copilot project snapshot --interactive
 ```
 
 **With CoPilot (IDE Integration):**
@@ -380,22 +373,11 @@ What are the release objectives? (comma-separated)
 #### 2. Add Features and Stories
 
 ```bash
-# Add feature
-specfact project plan add-feature \
-  --key FEATURE-001 \
-  --title "WebSocket Server" \
-  --outcomes "Handle 1000 concurrent connections" \
-  --outcomes "< 100ms message latency" \
-  --acceptance "Given client connection, When message sent, Then delivered within 100ms"
+# Add feature (via project snapshot with feature spec)
+specfact project snapshot --bundle <bundle-name>
 
-# Add story
-specfact project plan add-story \
-  --feature FEATURE-001 \
-  --key STORY-001 \
-  --title "Connection handling" \
-  --acceptance "Accept WebSocket connections" \
-  --acceptance "Maintain heartbeat every 30s" \
-  --acceptance "Graceful disconnect cleanup"
+# Use project devops-flow to enrich features through the develop stage
+specfact project devops-flow --stage develop --bundle <bundle-name>
 ```
 
 #### 3. Define Protocol
@@ -605,14 +587,7 @@ In a shared repository:
 
 ```bash
 # Create shared plan
-specfact project plan init --interactive
-
-# Add common features
-specfact project plan add-feature \
-  --key FEATURE-COMMON-001 \
-  --title "API Standards" \
-  --outcomes "Consistent REST patterns" \
-  --outcomes "Standardized error responses"
+specfact project snapshot --interactive
 ```
 
 #### 2. Distribute to Services
@@ -629,10 +604,8 @@ cp ../shared-contracts/plan.bundle.yaml contracts/shared/
 
 ```bash
 # In each service
-specfact project plan compare \
-  --manual contracts/shared/plan.bundle.yaml \
-  --auto contracts/service/plan.bundle.yaml \
-  --output-format markdown
+specfact project regenerate --bundle <service-bundle>
+specfact project health-check
 ```
 
 #### 4. Enforce Consistency
@@ -643,7 +616,7 @@ specfact code repro setup
 
 # Add to CI
 specfact code repro
-specfact project plan compare --manual contracts/shared/plan.bundle.yaml --auto .
+specfact project regenerate
 ```
 
 ### Expected Benefits

--- a/docs/guides/using-module-security-and-extensions.md
+++ b/docs/guides/using-module-security-and-extensions.md
@@ -90,7 +90,7 @@ Several commands already read or write extension data on `ProjectBundle` (and it
   specfact project health-check --bundle my-bundle
   ```
 
-Any command that loads a bundle (e.g. `specfact project plan ...`, `specfact project sync ...`, `specfact spec ...`) loads the full bundle including `extensions`; round-trip save keeps extension data. So you don’t need a special “extensions” command to benefit from them—they’re part of the bundle.
+Any command that loads a bundle (e.g. `specfact project sync ...`, `specfact project health-check ...`, `specfact spec ...`) loads the full bundle including `extensions`; round-trip save keeps extension data. So you don’t need a special “extensions” command to benefit from them—they’re part of the bundle.
 
 **Introspecting registered extensions (programmatic):** There is no `specfact extensions list` CLI yet. From Python you can call:
 

--- a/docs/guides/ux-features.md
+++ b/docs/guides/ux-features.md
@@ -60,15 +60,14 @@ The following options are hidden by default across commands:
 - `--interval` - Watch mode interval tuning
 - `--confidence` - Feature detection threshold
 
-**Plan Commands:**
+**Project Commands:**
 
 - `--max-questions` - Review session limit
 - `--category` - Taxonomy category filtering
 - `--findings-format` - Output format for findings
 - `--answers` - Non-interactive JSON input
 - `--stages` - Filter by promotion stages
-- `--last` - Show last N plans
-- `--current` - Show only active plan
+- `--last` - Show last N items
 - `--name` - Exact bundle name matching
 - `--id` - Content hash ID matching
 
@@ -79,7 +78,7 @@ The following options are hidden by default across commands:
 **Other Commands:**
 
 - `repro --budget` - Time budget configuration
-- `generate contracts-prompt --output` - Custom output path
+- (Note: `generate contracts-prompt` is removed; use your AI IDE skill `/specfact.07-contracts` for contract enhancement workflows)
 - `init --ide` - IDE selection override (auto-detection works)
 
 **Tip**: Advanced options are still functional even when hidden - you can use them directly without `--help-advanced`/`-ha`. The flag only affects what's shown in help text.
@@ -157,7 +156,7 @@ $ specfact code analyze --bundle missing-bundle
 ✗ Error: Bundle 'missing-bundle' not found
 
 💡 Suggested fixes:
-  • specfact project plan select  # Select an active plan bundle
+  • specfact project health-check  # Check available bundles
   • specfact code import missing-bundle  # Create a new bundle
 ```
 

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -40,13 +40,13 @@ specfact code import api-module --repo . --entry-point src/api
 
 ```bash
 # Review bundle to understand extracted specs
-specfact project plan review legacy-api
+specfact project devops-flow --stage develop --bundle legacy-api
 
-# Or get structured findings for analysis
-specfact project plan review legacy-api --list-findings --findings-format json
+# Or check project health for structured findings
+specfact project health-check
 ```
 
-**Note**: Use CLI commands to interact with bundles. The bundle structure (`.specfact/projects/<bundle-name>/`) is managed by SpecFact CLI - use commands like `plan review`, `plan add-feature`, `plan update-feature` to modify bundles, not direct file editing.
+**Note**: Use CLI commands to interact with bundles. The bundle structure (`.specfact/projects/<bundle-name>/`) is managed by SpecFact CLI - use commands like `project devops-flow`, `project health-check`, `project snapshot` to manage bundles, not direct file editing.
 
 ### Step 3: Add Contracts Incrementally
 
@@ -79,7 +79,7 @@ specfact code import integrations-module --repo . --entry-point src/integrations
 - **Multi-bundle support** - Create separate project bundles for different projects/modules
 - **Better organization** - Keep bundles organized by project boundaries
 
-**Note:** When using `--entry-point`, each analysis creates a separate project bundle. Use `specfact project plan compare` to compare different bundles.
+**Note:** When using `--entry-point`, each analysis creates a separate project bundle. Use `specfact project devops-flow --stage plan --action compare` to compare different bundles.
 
 ---
 
@@ -333,7 +333,7 @@ Compare manual plans vs auto-derived plans to detect deviations.
 ### Quick Comparison
 
 ```bash
-specfact project plan compare --bundle legacy-api
+specfact project devops-flow --stage plan --action compare --bundle legacy-api
 ```
 
 **What it does**:
@@ -351,7 +351,7 @@ specfact project plan compare --bundle legacy-api
 ### Detailed Comparison
 
 ```bash
-specfact project plan compare \
+specfact project devops-flow --stage plan --action compare \
   --manual .specfact/projects/manual-plan \
   --auto .specfact/projects/auto-derived \
   --out comparison-report.md
@@ -374,7 +374,7 @@ specfact project plan compare \
 ### Code vs Plan Comparison
 
 ```bash
-specfact project plan compare --bundle legacy-api --code-vs-plan
+specfact project devops-flow --stage plan --action compare --bundle legacy-api --code-vs-plan
 ```
 
 **What it does**:
@@ -402,7 +402,7 @@ Typical workflow for daily development.
 specfact code repro --verbose
 
 # Compare plans
-specfact project plan compare --bundle legacy-api
+specfact project devops-flow --stage plan --action compare --bundle legacy-api
 ```
 
 **What it does**:
@@ -431,7 +431,7 @@ specfact project sync repository --repo . --watch --interval 5
 specfact code repro
 
 # Compare plans
-specfact project plan compare --bundle legacy-api
+specfact project devops-flow --stage plan --action compare --bundle legacy-api
 ```
 
 **What it does**:
@@ -464,7 +464,7 @@ Complete workflow for migrating from Spec-Kit or OpenSpec.
 #### Step 1: Preview
 
 ```bash
-specfact project import from-bridge --adapter speckit --repo . --dry-run
+specfact code import from-bridge --adapter speckit --repo . --dry-run
 ```
 
 **What it does**:
@@ -476,7 +476,7 @@ specfact project import from-bridge --adapter speckit --repo . --dry-run
 #### Step 2: Execute
 
 ```bash
-specfact project import from-bridge --adapter speckit --repo . --write
+specfact code import from-bridge --adapter speckit --repo . --write
 ```
 
 **What it does**:

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,7 @@ Most tools help **either** coders **or** agile teams. SpecFact does both:
 Recommended command entrypoints:
 - `specfact backlog ceremony standup ...`
 - `specfact backlog ceremony refinement ...`
+- `specfact backlog verify-readiness --bundle <bundle-name>`
 
 **Try it now**
 
@@ -62,7 +63,7 @@ specfact backlog daily ado --ado-org <org> --ado-project "<project>" --state any
 specfact backlog refine ado --ado-org <org> --ado-project "<project>" --id <work-item-id> --preview
 
 # 3) Validate drift before implementation
-specfact backlog policy validate --group-by-item
+specfact backlog verify-readiness --bundle <bundle-name>
 ```
 
 GitHub variant:
@@ -176,7 +177,7 @@ Module lifecycle note: use `specfact module` (`init`, `install`, `list`, `show`,
 
 - **[Command Chains](guides/command-chains.md)** ⭐ **NEW** - Complete workflows from start to finish
 - **[Agile/Scrum Workflows](guides/agile-scrum-workflows.md)** - Persona-based collaboration for teams
-- **[Policy Engine Commands](guides/policy-engine-commands.md)** - Scaffold policy config templates and run `backlog policy init|validate|suggest`
+- **[Policy Engine Commands](guides/policy-engine-commands.md)** - Run backlog readiness and ceremony workflows
 - **[DevOps Backlog Integration](guides/devops-adapter-integration.md)** 🆕 **NEW FEATURE** - Integrate SpecFact into agile DevOps workflows with bidirectional backlog sync
 - **[Backlog Refinement](guides/backlog-refinement.md)** 🆕 **NEW FEATURE** - AI-assisted template-driven backlog refinement for standardizing work items
 - **[Backlog Dependency Analysis](guides/backlog-dependency-analysis.md)** - Analyze critical path, cycles, orphans, and dependency impact from backlog graph data

--- a/docs/prompts/PROMPT_VALIDATION_CHECKLIST.md
+++ b/docs/prompts/PROMPT_VALIDATION_CHECKLIST.md
@@ -61,8 +61,8 @@ The validator checks:
 - [ ] **CORRECT examples present**: Prompt shows examples of what TO do (using CLI commands)
 - [ ] **Command examples**: Examples show actual CLI usage with correct flags
 - [ ] **Flag documentation**: All flags are documented with defaults and descriptions
-- [ ] **Filter options documented** (for `plan select`): `--current`, `--stages`, `--last`, `--no-interactive` flags are documented with use cases and examples
-- [ ] **Positional vs option arguments**: Correctly distinguishes between positional arguments and `--option` flags (e.g., `specfact project plan select 20` not `specfact project plan select --plan 20`)
+- [ ] **Filter options documented** (for bundle selection): `--bundle`, `--no-interactive` flags are documented with use cases and examples
+- [ ] **Positional vs option arguments**: Correctly distinguishes between positional arguments and `--option` flags
 - [ ] **Boolean flags documented correctly**: Boolean flags use `--flag/--no-flag` syntax, not `--flag true/false`
   - ❌ **WRONG**: `--draft true` or `--draft false` (Typer boolean flags don't accept values)
   - ✅ **CORRECT**: `--draft` (sets True) or `--no-draft` (sets False) or omit (leaves unchanged)
@@ -92,7 +92,7 @@ The validator checks:
     - [ ] Explanation: Stories are required for promotion validation
   - [ ] Phase 3: CLI Artifact Creation documented
   - [ ] Enrichment report location specified (`.specfact/projects/<bundle-name>/reports/enrichment/`, bundle-specific, Phase 8.5)
-- [ ] **Auto-enrichment workflow** (for `plan review`):
+- [ ] **Auto-enrichment workflow** (for `project devops-flow --stage develop`):
   - [ ] `--auto-enrich` flag documented with when to use it
   - [ ] LLM reasoning guidance for detecting when enrichment is needed
   - [ ] Post-enrichment analysis steps documented
@@ -102,7 +102,7 @@ The validator checks:
   - [ ] Examples of enrichment output and refinement process
   - [ ] **Generic criteria detection**: Instructions to identify and replace generic patterns ("interact with the system", "works correctly")
   - [ ] **Code-specific criteria generation**: Instructions to research codebase and create testable criteria with method names, parameters, return values
-- [ ] **Feature deduplication** (for `sync`, `plan review`, `import from-code`):
+- [ ] **Feature deduplication** (for `sync`, `project devops-flow --stage develop`, `import from-code`):
   - [ ] **Automated deduplication documented**: CLI automatically deduplicates features using normalized key matching
   - [ ] **Deduplication scope explained**:
     - [ ] Exact normalized key matches (e.g., `FEATURE-001` vs `001_FEATURE_NAME`)
@@ -112,15 +112,15 @@ The validator checks:
     - [ ] Review feature titles and descriptions for semantic similarity
     - [ ] Identify features that represent the same functionality with different names
     - [ ] Suggest consolidation when multiple features cover the same code/functionality
-    - [ ] Use `specfact project plan update-feature` or `specfact project plan add-feature` to consolidate
+    - [ ] Use `specfact project devops-flow --stage develop` to consolidate
   - [ ] **Deduplication output**: CLI shows "✓ Removed N duplicate features" - LLM should acknowledge this
   - [ ] **Post-deduplication review**: LLM should review remaining features for semantic duplicates
 - [ ] **Execution steps**: Clear, sequential steps
 - [ ] **Error handling**: Instructions for handling errors
 - [ ] **Validation**: CLI validation steps documented
-- [ ] **Coverage validation** (for `plan promote`): Documentation of coverage status checks (critical vs important categories)
+- [ ] **Coverage validation** (for `project devops-flow --stage review`): Documentation of coverage status checks (critical vs important categories)
 - [ ] **Copilot-friendly formatting** (if applicable): Instructions for formatting output as Markdown tables for better readability
-- [ ] **Interactive workflows** (if applicable): Support for "details" requests and other interactive options (e.g., "20 details" for plan selection)
+- [ ] **Interactive workflows** (if applicable): Support for "details" requests and other interactive options (e.g., bundle details for bundle selection)
 
 ### 5. Consistency
 
@@ -189,7 +189,7 @@ For each prompt, test the following scenarios:
 
 1. Invoke `/specfact.03-review legacy-api` with a plan bundle
 2. Verify the LLM:
-   - ✅ Executes `specfact project plan review` CLI command
+   - ✅ Executes `specfact project devops-flow --stage develop --bundle <bundle-name>` CLI command
    - ✅ Parses CLI output for ambiguity findings
    - ✅ Waits for user input when questions are asked
    - ✅ Does NOT create clarifications directly in YAML
@@ -202,57 +202,50 @@ For each prompt, test the following scenarios:
 2. Verify the LLM:
    - ✅ **Detects need for enrichment**: Recognizes vague patterns ("is implemented", "System MUST Helper class", generic tasks)
    - ✅ **Suggests or uses `--auto-enrich`**: Either suggests using `--auto-enrich` flag or automatically uses it based on plan quality indicators
-   - ✅ **Executes enrichment**: Runs `specfact project plan review <bundle-name> --auto-enrich`
+   - ✅ **Executes enrichment**: Runs `specfact project devops-flow --stage develop --bundle <bundle-name> --auto-enrich`
    - ✅ **Parses enrichment results**: Captures enrichment summary (features updated, stories updated, acceptance criteria enhanced, etc.)
    - ✅ **Analyzes enrichment quality**: Uses LLM reasoning to review what was enhanced
    - ✅ **Identifies generic patterns**: Finds placeholder text like "interact with the system" that needs refinement
    - ✅ **Proposes specific refinements**: Suggests domain-specific improvements using CLI commands
-   - ✅ **Executes refinements**: Uses `specfact project plan update-feature --bundle <bundle-name>` to refine generic improvements
-   - ✅ **Re-runs review**: Executes `specfact project plan review` again to verify improvements
+   - ✅ **Executes refinements**: Uses `specfact project devops-flow --stage develop --bundle <bundle-name>` to refine generic improvements
+   - ✅ **Re-runs review**: Executes `specfact project devops-flow --stage develop` again to verify improvements
 3. Test with explicit enrichment request (e.g., "enrich the plan"):
    - ✅ Uses `--auto-enrich` flag immediately
    - ✅ Reviews enrichment results
    - ✅ Suggests further improvements if needed
 
-#### Scenario 5: Plan Selection Workflow (for plan-select)
+#### Scenario 5: Bundle Selection Workflow
 
-1. Invoke `/specfact.02-plan select` (or use CLI: `specfact project plan select`)
+1. Invoke `specfact project health-check` (or use CLI to list bundles)
 2. Verify the LLM:
-   - ✅ Executes `specfact project plan select` CLI command
-   - ✅ Formats plan list as copilot-friendly Markdown table (not Rich table)
-   - ✅ Provides selection options (number, "number details", "q" to quit)
-   - ✅ Waits for user response with `[WAIT FOR USER RESPONSE - DO NOT CONTINUE]`
-3. Request plan details (e.g., "20 details"):
-   - ✅ Loads plan bundle YAML file
+   - ✅ Executes `specfact project health-check` CLI command
+   - ✅ Formats bundle list as copilot-friendly Markdown table (not Rich table)
+   - ✅ Provides selection options and waits for user response with `[WAIT FOR USER RESPONSE - DO NOT CONTINUE]`
+3. Request bundle details:
+   - ✅ Loads bundle information via CLI
    - ✅ Extracts and displays detailed information (idea, themes, top features, business context)
-   - ✅ Asks if user wants to select the plan
+   - ✅ Asks if user wants to use the bundle
    - ✅ Waits for user confirmation
-4. Select a plan (e.g., "20" or "y" after details):
-   - ✅ Uses **positional argument** syntax: `specfact project plan select 20` (NOT `--plan 20`)
+4. Select a bundle (specify `--bundle <name>`):
+   - ✅ Uses `--bundle <bundle-name>` parameter syntax
    - ✅ Confirms selection with CLI output
    - ✅ Does NOT create config.yaml directly
-5. Test filter options:
-   - ✅ Uses `--current` flag to show only active plan: `specfact project plan select --current`
-   - ✅ Uses `--stages` flag to filter by stages: `specfact project plan select --stages draft,review`
-   - ✅ Uses `--last N` flag to show recent plans: `specfact project plan select --last 5`
-6. Test non-interactive mode (CI/CD):
-   - ✅ Uses `--no-interactive` flag with `--current`: `specfact project plan select --no-interactive --current`
-   - ✅ Uses `--no-interactive` flag with `--last 1`: `specfact project plan select --no-interactive --last 1`
-   - ✅ Handles error when multiple plans match filters in non-interactive mode
+5. Test non-interactive mode (CI/CD):
+   - ✅ Uses `--no-interactive` flag: `specfact project health-check --no-interactive`
    - ✅ Does NOT prompt for input when `--no-interactive` is used
 
 #### Scenario 6: Plan Promotion with Coverage Validation (for plan-promote)
 
-1. Invoke `/specfact-plan-promote` with a plan that has missing critical categories
+1. Invoke `/specfact.03-review legacy-api` to promote through review stage
 2. Verify the LLM:
-   - ✅ Executes `specfact project plan promote --stage review --validate` CLI command
+   - ✅ Executes `specfact project devops-flow --stage review --bundle <bundle-name>` CLI command
    - ✅ Parses CLI output showing coverage validation errors
    - ✅ Shows which critical categories are Missing
-   - ✅ Suggests running `specfact project plan review` to resolve ambiguities
+   - ✅ Suggests running `specfact project devops-flow --stage develop` to resolve ambiguities
    - ✅ Does NOT attempt to bypass validation by creating artifacts directly
-   - ✅ Waits for user decision (use `--force` or run `plan review` first)
+   - ✅ Waits for user decision (use `--force` or run develop stage first)
 3. Invoke promotion with `--force` flag:
-   - ✅ Uses `--force` flag correctly: `specfact project plan promote --stage review --force`
+   - ✅ Uses `--force` flag correctly: `specfact project devops-flow --stage review --bundle <bundle-name> --force`
    - ✅ Explains that `--force` bypasses validation (not recommended)
    - ✅ Does NOT create plan bundle directly
 
@@ -280,8 +273,8 @@ After testing, review:
   - [ ] Analyzes enrichment results with reasoning
   - [ ] Proposes and executes specific refinements using CLI commands
   - [ ] Iterates until plan quality meets standards
-- [ ] **Selection workflow** (if applicable): Copilot-friendly table formatting, details option, correct CLI syntax (positional arguments), filter options (`--current`, `--stages`, `--last`), non-interactive mode (`--no-interactive`)
-- [ ] **Promotion workflow** (if applicable): Coverage validation respected, suggestions to run `plan review` when categories are Missing
+- [ ] **Selection workflow** (if applicable): Copilot-friendly table formatting, details option, correct CLI syntax (`--bundle`), non-interactive mode (`--no-interactive`)
+- [ ] **Promotion workflow** (if applicable): Coverage validation respected, suggestions to run `project devops-flow --stage develop` when categories are Missing
 - [ ] **Error handling**: Errors handled gracefully without assumptions
 
 ## Common Issues to Watch For
@@ -336,14 +329,14 @@ After testing, review:
 
 ### ❌ Wrong Argument Format (Positional vs Option)
 
-**Symptom**: LLM uses `--option` flag when command expects positional argument (e.g., `specfact project plan select --plan 20` instead of `specfact project plan select 20`)
+**Symptom**: LLM uses incorrect argument format when command expects a specific syntax (e.g., positional vs named arguments)
 
 **Fix**:
 
 - Verify actual CLI command signature (use `specfact <command> --help`)
 - Update prompt to explicitly state positional vs option arguments
 - Add examples showing correct syntax
-- Add warning about common mistakes (e.g., "NOT `specfact project plan select --plan 20` (this will fail)")
+- Add warning about common mistakes
 
 ### ❌ Wrong Boolean Flag Usage
 
@@ -365,7 +358,7 @@ After testing, review:
 
 ### ❌ Missing Coverage Validation
 
-**Symptom**: LLM promotes plans without checking coverage status, or doesn't suggest running `plan review` when categories are Missing
+**Symptom**: LLM promotes plans without checking coverage status, or doesn't suggest running `project devops-flow --stage develop` when categories are Missing
 
 **Fix**:
 
@@ -421,7 +414,7 @@ The following prompts are available for SpecFact CLI commands:
 - `specfact.04-sdd.md` - Create SDD manifest (new, based on `plan harden`)
 - `specfact.05-enforce.md` - SDD enforcement (replaces `specfact-enforce.md`)
 - `specfact.06-sync.md` - Sync operations (replaces `specfact-sync.md`)
-- `specfact.07-contracts.md` - Contract enhancement workflow: analyze → generate prompts → apply contracts sequentially (new, based on `analyze contracts`, `generate contracts-prompt`, `generate contracts-apply`)
+- `specfact.07-contracts.md` - Contract enhancement workflow: analyze → generate prompts → apply contracts sequentially (use `specfact govern enforce sdd [BUNDLE]` for SDD enforcement; contract prompt generation is handled via this IDE skill)
 
 ### Advanced Commands (No Numbering)
 
@@ -444,7 +437,7 @@ The following prompts are available for SpecFact CLI commands:
 
 - Added `specfact.07-contracts.md` to available prompts list
 - New contract enhancement workflow prompt for sequential contract application
-- Workflow: analyze contracts → generate prompts → apply contracts with careful review
+- Workflow: analyze contracts → apply contracts with careful review (via IDE skill; use `specfact govern enforce sdd [BUNDLE]` for SDD enforcement)
 
 ### Version 1.10 (2025-01-XX)
 

--- a/docs/prompts/README.md
+++ b/docs/prompts/README.md
@@ -50,7 +50,7 @@ SpecFact CLI provides slash commands that work with AI-assisted IDEs (Cursor, VS
 
 **Purpose**: Plan management (init, add-feature, add-story, update-idea, update-feature, update-story)
 
-**Equivalent CLI**: `specfact project plan init/add-feature/add-story/update-idea/update-feature/update-story`
+**Equivalent CLI**: `specfact project snapshot --bundle <bundle>` / `specfact project health-check` (plan editing subcommands removed)
 
 **Example**:
 
@@ -67,7 +67,7 @@ SpecFact CLI provides slash commands that work with AI-assisted IDEs (Cursor, VS
 
 **Purpose**: Review plan and promote
 
-**Equivalent CLI**: `specfact project plan review`
+**Equivalent CLI**: `specfact project devops-flow --stage develop --bundle <bundle>` or `specfact project health-check --bundle <bundle>`
 
 **Example**:
 
@@ -131,7 +131,7 @@ SpecFact CLI provides slash commands that work with AI-assisted IDEs (Cursor, VS
 
 **Purpose**: Contract management (analyze, generate prompts, apply contracts sequentially)
 
-**Equivalent CLI**: `specfact spec generate contracts-prompt`
+**Equivalent CLI**: `specfact govern enforce sdd [BUNDLE]` (contract enhancement workflows are handled via this slash command)
 
 **Example**:
 
@@ -149,7 +149,7 @@ SpecFact CLI provides slash commands that work with AI-assisted IDEs (Cursor, VS
 
 **Purpose**: Compare plans
 
-**Equivalent CLI**: `specfact project plan compare`
+**Equivalent CLI**: `specfact project regenerate --bundle <bundle>`
 
 **Example**:
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -30,10 +30,10 @@ Complete technical reference for SpecFact CLI.
 
 ### Commands
 
-- `specfact project import from-bridge --adapter speckit` - Import from external tools via bridge adapter
+- `specfact code import from-bridge --adapter speckit` - Import from external tools via bridge adapter
 - `specfact code import <bundle-name>` - Reverse-engineer plans from code
-- `specfact project plan init <bundle-name>` - Initialize new development plan
-- `specfact project plan compare` - Compare manual vs auto plans
+- `specfact project snapshot --bundle <bundle-name>` - Save current backlog graph as baseline snapshot
+- `specfact project devops-flow --stage <plan|develop|review|release|monitor>` - Run integrated DevOps stage actions
 - `specfact govern enforce stage` - Configure quality gates
 - `specfact code repro` - Run full validation suite
 - `specfact project sync bridge --adapter <adapter> --bundle <bundle-name>` - Sync with external tools via bridge adapter

--- a/docs/reference/command-syntax-policy.md
+++ b/docs/reference/command-syntax-policy.md
@@ -16,14 +16,14 @@ Always document commands exactly as implemented by `specfact <command> --help` i
 - Do not assume all commands use the same bundle argument style.
 - Do not convert positional bundle arguments to `--bundle` unless the command explicitly supports it.
 
-## Bundle Argument Conventions (v0.30.x baseline)
+## Bundle Argument Conventions
 
 - Positional bundle argument:
   - `specfact code import [BUNDLE]`
-  - `specfact project plan init BUNDLE`
-  - `specfact project plan review [BUNDLE]`
+  - `specfact project snapshot --bundle <bundle-name>`
+  - `specfact project devops-flow --stage <plan|develop|review|release|monitor>`
 - `--bundle` option:
-  - Supported by many plan mutation commands (for example `plan add-feature`, `plan add-story`, `plan update-feature`)
+  - Supported by many spec and govern commands (for example `spec validate`, `spec generate-tests`, `govern enforce sdd`)
   - Not universally supported across all commands
 
 ## IDE Init Syntax
@@ -44,8 +44,9 @@ Before merging command docs updates:
 
 ```bash
 hatch run specfact code import --help
-hatch run specfact project plan init --help
-hatch run specfact project plan review --help
-hatch run specfact project plan add-feature --help
+hatch run specfact project snapshot --help
+hatch run specfact project devops-flow --help
+hatch run specfact govern enforce --help
+hatch run specfact spec validate --help
 ```
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -38,31 +38,29 @@ After bundle install, command groups are mounted by category:
 
 | Bundle ID | Group | Main command families |
 |---|---|---|
-| `nold-ai/specfact-project` | `project` | `project ...`, `project plan ...`, `project import ...`, `project sync ...`, `project migrate ...` |
-| `nold-ai/specfact-backlog` | `backlog` | `backlog ...`, `backlog policy ...`, `backlog auth ...` |
-| `nold-ai/specfact-codebase` | `code` | `code analyze ...`, `code drift ...`, `code validate ...`, `code repro ...` |
-| `nold-ai/specfact-spec` | `spec` | `spec contract ...`, `spec api ...`, `spec sdd ...`, `spec generate ...` |
-| `nold-ai/specfact-govern` | `govern` | `govern enforce ...`, `govern patch ...` |
+| `nold-ai/specfact-project` | `project` | `project link-backlog`, `project health-check`, `project devops-flow`, `project snapshot`, `project regenerate`, `project export-roadmap`, `project import`, `project export`, `project sync` |
+| `nold-ai/specfact-backlog` | `backlog` | `backlog ceremony`, `backlog refine`, `backlog daily`, `backlog sync`, `backlog auth`, `backlog analyze-deps`, `backlog verify-readiness`, `backlog delta`, `backlog add` |
+| `nold-ai/specfact-codebase` | `code` | `code analyze`, `code drift`, `code validate`, `code repro`, `code import`, `code review` |
+| `nold-ai/specfact-spec` | `spec` | `spec validate`, `spec backward-compat`, `spec generate-tests`, `spec mock` |
+| `nold-ai/specfact-govern` | `govern` | `govern enforce`, `govern patch` |
 
 ## Migration: Removed Flat Commands
 
-Flat compatibility shims were removed in this change. Use grouped commands.
+Flat compatibility shims were removed in `0.40.0`. Use grouped commands.
 
 | Removed | Replacement |
 |---|---|
-| `specfact plan ...` | `specfact project plan ...` |
-| `specfact import ...` | `specfact project import ...` |
+| `specfact plan ...` | Removed — use `specfact project devops-flow` or `specfact project snapshot` |
+| `specfact import ...` | `specfact code import ...` (codebase import) or `specfact project import ...` (persona Markdown) |
 | `specfact sync ...` | `specfact project sync ...` |
-| `specfact migrate ...` | `specfact project migrate ...` |
 | `specfact backlog ...` (flat module) | `specfact backlog ...` (bundle group) |
 | `specfact analyze ...` | `specfact code analyze ...` |
 | `specfact drift ...` | `specfact code drift ...` |
 | `specfact validate ...` | `specfact code validate ...` |
 | `specfact repro ...` | `specfact code repro ...` |
-| `specfact contract ...` | `specfact spec contract ...` |
-| `specfact spec ...` (flat module) | `specfact spec api ...` |
-| `specfact sdd ...` | `specfact spec sdd ...` |
-| `specfact generate ...` | `specfact spec generate ...` |
+| `specfact contract ...` | Removed — use `specfact spec validate` |
+| `specfact sdd ...` | Removed — use `specfact govern enforce sdd [BUNDLE]` |
+| `specfact generate ...` | Removed — no direct replacement; use AI IDE skills for prompt generation |
 | `specfact enforce ...` | `specfact govern enforce ...` |
 | `specfact patch ...` | `specfact govern patch ...` |
 
@@ -77,7 +75,7 @@ specfact module install nold-ai/specfact-backlog
 
 # Project workflow examples
 specfact code import legacy-api --repo .
-specfact project plan review legacy-api
+specfact project snapshot --bundle legacy-api
 
 # Code workflow examples
 specfact code validate sidecar init legacy-api /path/to/repo
@@ -86,6 +84,10 @@ specfact code repro --verbose
 # Backlog workflow examples
 specfact backlog ceremony standup --help
 specfact backlog ceremony refinement --help
+
+# Spec validation examples
+specfact spec validate --bundle my-api
+specfact spec generate-tests --bundle my-api --output tests/
 ```
 
 ## See Also

--- a/docs/reference/directory-structure.md
+++ b/docs/reference/directory-structure.md
@@ -238,20 +238,14 @@ Plan bundles version 1.1 and later include summary metadata in the `metadata.sum
 
 **Upgrading Plan Bundles:**
 
-Use `specfact project plan upgrade` to migrate older plan bundles to the latest schema:
+Use `specfact project regenerate` to re-derive project state from the current bundle:
 
 ```bash
-# Upgrade active plan
-specfact project plan upgrade
-
-# Upgrade all plans
-specfact project plan upgrade --all
-
-# Preview upgrades
-specfact project plan upgrade --dry-run
+# Re-derive project state
+specfact project regenerate --bundle <bundle-name>
 ```
 
-See [`plan upgrade`](../reference/commands.md#plan-upgrade) for details.
+See the [Command Reference](../reference/commands.md) for details.
 
 **Example**:
 
@@ -424,35 +418,22 @@ specfact code import legacy-api --repo . --confidence 0.7
 # - .specfact/reports/brownfield/analysis-2025-10-31T14-30-00.md (gitignored)
 ```
 
-### `specfact project plan init` (Alternative)
+### Creating Project Bundles (Greenfield)
 
-**Alternative use case**: Create new project bundles for greenfield projects.
+For greenfield projects, use `code import` with your source, or create a bundle structure manually:
 
 ```bash
-# Command syntax
-specfact project plan init <bundle-name> [OPTIONS]
+# Analyze a new codebase and create a bundle
+specfact code import <bundle-name> --repo .
 
 # Creates modular bundle at:
 .specfact/projects/<bundle-name>/
 ├── bundle.manifest.yaml  # Bundle metadata and versioning
-├── product.yaml         # Product definition (required)
-├── idea.yaml           # Product vision (if provided via prompts)
-└── features/           # Empty features directory (created when first feature added)
+├── product.yaml         # Product definition
+└── features/           # Features directory
 
-# Also creates (if --interactive):
-.specfact/config.yaml
-```
-
-### `specfact project plan compare`
-
-```bash
-# Compare two bundles (explicit paths to bundle directories)
-specfact project plan compare \
-  --manual .specfact/projects/manual-plan \
-  --auto .specfact/projects/auto-derived \
-  --out .specfact/reports/comparison/report-*.md
-
-# Note: Commands accept bundle directory paths, not individual files
+# Snapshot current state
+specfact project snapshot --bundle <bundle-name>
 ```
 
 ### `specfact project sync bridge`
@@ -698,7 +679,7 @@ If you have existing artifacts in other locations:
 # Migration
 mkdir -p .specfact/projects/my-project .specfact/reports/brownfield
 # Convert monolithic bundle to modular bundle structure
-# (Use 'specfact project plan upgrade' or manual conversion)
+# (Use 'specfact project regenerate' or manual conversion)
 mv reports/analysis.md .specfact/reports/brownfield/
 ```
 
@@ -750,10 +731,9 @@ specfact code import legacy-api \
   --repo src/legacy-api \
   --confidence 0.7
 
-# Step 2: Compare legacy vs modernized (use bundle directories, not files)
-specfact project plan compare \
-  --manual .specfact/projects/legacy-api \
-  --auto .specfact/projects/modernized-api
+# Step 2: Snapshot and regenerate project state
+specfact project snapshot --bundle legacy-api
+specfact project regenerate --bundle legacy-api
 
 # Step 3: Analyze specific legacy component
 specfact code import legacy-payment \

--- a/docs/reference/feature-keys.md
+++ b/docs/reference/feature-keys.md
@@ -36,12 +36,8 @@ specfact code import --key-format classname
 specfact code import --key-format sequential
 ```
 
-**Manual creation**: When creating plans interactively, use `FEATURE-001` format:
-
-```bash
-specfact project plan init
-# Enter feature key: FEATURE-001
-```
+**Manual creation**: When creating project state interactively, use `FEATURE-001` format and
+manage it via `project snapshot` or `project devops-flow`.
 
 ### 3. Underscore Format (Legacy)
 
@@ -83,11 +79,7 @@ normalize_feature_key("FEATURE-001")
 
 ### Plan Comparison
 
-The `plan compare` command automatically normalizes keys:
-
-```bash
-specfact project plan compare --manual main.bundle.yaml --auto auto-derived.yaml
-```
+Key normalization is applied automatically when comparing or merging bundle data.
 
 **Behavior**: Features with different key formats but the same normalized key are matched correctly.
 
@@ -119,13 +111,12 @@ features_seq = convert_feature_keys(features, target_format="sequential", start_
 features_class = convert_feature_keys(features, target_format="classname")
 ```
 
-### Command-Line (Future)
+### Command-Line
 
-A `plan normalize` command may be added in the future to convert existing plans:
+Use `project regenerate` to re-derive project state from the current bundle:
 
 ```bash
-# (Future) Convert plan to sequential format
-specfact project plan normalize --from main.bundle.yaml --to main-sequential.yaml --output-format sequential
+specfact project regenerate --bundle <bundle-name>
 ```
 
 ## Best Practices
@@ -156,13 +147,7 @@ specfact project plan normalize --from main.bundle.yaml --to main-sequential.yam
 
 ### 3. Use Sequential for Manual Plans
 
-When creating plans manually or interactively:
-
-```bash
-specfact project plan init
-# Enter feature key: FEATURE-001  # ← Use sequential format
-# Enter feature title: User Authentication
-```
+When creating project bundles manually, use `FEATURE-001` sequential format for feature keys.
 
 **Why**: Sequential format is easier to reference and understand in documentation.
 

--- a/openspec/changes/docs-03-command-syntax-parity/TDD_EVIDENCE.md
+++ b/openspec/changes/docs-03-command-syntax-parity/TDD_EVIDENCE.md
@@ -1,0 +1,52 @@
+# TDD Evidence: docs-03-command-syntax-parity
+
+## Pre-Implementation Failing Run
+
+**Timestamp**: 2026-03-18
+
+**Command**:
+```
+cd /home/dom/git/nold-ai/specfact-cli-worktrees/feature/docs-03-command-syntax-parity
+hatch test -- tests/unit/docs/test_release_docs_parity.py -v -k "removed or current"
+```
+
+**Result**: 9 FAILED, 3 PASSED
+
+**Failing tests**:
+
+- `test_removed_project_plan_syntax_absent_from_authored_docs` — 'specfact project plan' still present in authored docs
+- `test_removed_project_import_from_bridge_syntax_absent_from_authored_docs` — 'project import from-bridge' still present
+- `test_removed_backlog_policy_syntax_absent_from_authored_docs` — 'backlog policy' still present
+- `test_removed_spec_contract_syntax_absent_from_authored_docs` — 'spec contract' still present
+- `test_removed_spec_api_syntax_absent_from_authored_docs` — 'spec api' still present
+- `test_removed_spec_sdd_syntax_absent_from_authored_docs` — 'spec sdd' still present
+- `test_removed_spec_generate_syntax_absent_from_authored_docs` — 'spec generate <subcommand>' still present
+- `test_current_spec_commands_documented_in_commands_reference` — 'spec validate' missing from commands.md (stale bundle mapping table still shows old spec commands)
+- `test_current_backlog_subcommands_documented_in_commands_reference` — 'backlog refine' missing from commands reference
+
+## Post-Implementation Passing Run
+
+**Timestamp**: 2026-03-18
+
+**Command**:
+```
+cd /home/dom/git/nold-ai/specfact-cli-worktrees/feature/docs-03-command-syntax-parity
+hatch test -- tests/unit/docs/test_release_docs_parity.py -v
+```
+
+**Result**: 21 PASSED (all)
+
+All new parity tests pass:
+- `test_removed_project_plan_syntax_absent_from_authored_docs` ✓
+- `test_removed_project_import_from_bridge_syntax_absent_from_authored_docs` ✓
+- `test_removed_backlog_policy_syntax_absent_from_authored_docs` ✓
+- `test_removed_spec_contract_syntax_absent_from_authored_docs` ✓
+- `test_removed_spec_api_syntax_absent_from_authored_docs` ✓
+- `test_removed_spec_sdd_syntax_absent_from_authored_docs` ✓
+- `test_removed_spec_generate_syntax_absent_from_authored_docs` ✓
+- `test_current_code_import_from_bridge_documented` ✓
+- `test_current_spec_commands_documented_in_commands_reference` ✓
+- `test_current_govern_enforce_sdd_documented` ✓
+- `test_current_backlog_subcommands_documented_in_commands_reference` ✓
+
+All 10 pre-existing tests also pass.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "specfact-cli"
-version = "0.42.1"
+version = "0.42.2"
 description = "The swiss knife CLI for agile DevOps teams. Keep backlog, specs, tests, and code in sync with validation and contract enforcement for new projects and long-lived codebases."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 if __name__ == "__main__":
     _setup = setup(
         name="specfact-cli",
-        version="0.42.1",
+        version="0.42.2",
         description=(
             "The swiss knife CLI for agile DevOps teams. Keep backlog, specs, tests, and code in sync with "
             "validation and contract enforcement for new projects and long-lived codebases."

--- a/src/specfact_cli/__init__.py
+++ b/src/specfact_cli/__init__.py
@@ -42,6 +42,6 @@ def _bootstrap_bundle_paths() -> None:
 
 _bootstrap_bundle_paths()
 
-__version__ = "0.42.1"
+__version__ = "0.42.2"
 
 __all__ = ["__version__"]

--- a/tests/unit/docs/test_release_docs_parity.py
+++ b/tests/unit/docs/test_release_docs_parity.py
@@ -89,3 +89,119 @@ def test_bundle_focused_pages_use_handoff_note_instead_of_future_migration_langu
     assert "canonical modules docs site" in github_adapter
     assert "planned to migrate to `specfact-cli-modules`" not in backlog_refinement
     assert "planned to migrate to `specfact-cli-modules`" not in github_adapter
+
+
+# ---------------------------------------------------------------------------
+# docs-03-command-syntax-parity: removed syntax families must be absent
+# ---------------------------------------------------------------------------
+
+_AUTHORED_DOC_ROOTS = ["README.md", "docs"]
+
+
+def _scan_authored_docs(pattern: str) -> list[tuple[str, int, str]]:
+    """Return list of (relative_path, line_number, line_text) for pattern hits.
+
+    Lines that are clearly labeled as historical/removed context are excluded:
+    - Code-block comment lines (stripped line starts with ``#``)
+    - Blockquote lines that reference a removed command (stripped starts with ``>``)
+    - Any line where the pattern co-occurs with the word "removed" or "(removed)"
+    """
+    hits: list[tuple[str, int, str]] = []
+    repo_root = Path(__file__).resolve().parents[3]
+    sources: list[Path] = [repo_root / "README.md"]
+    docs_dir = repo_root / "docs"
+    for p in docs_dir.rglob("*.md"):
+        if "_site" not in p.parts and "vendor" not in p.parts:
+            sources.append(p)
+    for src in sources:
+        if not src.exists():
+            continue
+        for lineno, line in enumerate(src.read_text(encoding="utf-8").splitlines(), 1):
+            if pattern not in line:
+                continue
+            stripped = line.strip()
+            # Skip comment lines in code blocks
+            if stripped.startswith("#"):
+                continue
+            # Skip blockquote lines (historical/migration notes)
+            if stripped.startswith(">"):
+                continue
+            # Skip lines that explicitly label the pattern as removed
+            lower = stripped.lower()
+            if "removed" in lower or "(removed)" in lower or "is removed" in lower:
+                continue
+            hits.append((str(src.relative_to(repo_root)), lineno, stripped))
+    return hits
+
+
+def _fmt_hits(hits: list[tuple[str, int, str]]) -> str:
+    return "\n".join(f"  {p}:{n}  {line}" for p, n, line in hits)
+
+
+def test_removed_project_plan_syntax_absent_from_authored_docs() -> None:
+    """specfact project plan is not a shipped command; must not appear as current syntax."""
+    hits = _scan_authored_docs("specfact project plan")
+    assert not hits, f"Removed syntax 'specfact project plan' still present:\n{_fmt_hits(hits)}"
+
+
+def test_removed_project_import_from_bridge_syntax_absent_from_authored_docs() -> None:
+    """project import from-bridge moved to code import from-bridge; old path must not appear."""
+    hits = _scan_authored_docs("project import from-bridge")
+    assert not hits, f"Removed syntax 'project import from-bridge' still present:\n{_fmt_hits(hits)}"
+
+
+def test_removed_backlog_policy_syntax_absent_from_authored_docs() -> None:
+    """backlog policy is not a shipped subcommand; must not appear as current syntax."""
+    hits = _scan_authored_docs("backlog policy")
+    assert not hits, f"Removed syntax 'backlog policy' still present:\n{_fmt_hits(hits)}"
+
+
+def test_removed_spec_contract_syntax_absent_from_authored_docs() -> None:
+    hits = _scan_authored_docs("spec contract")
+    assert not hits, f"Removed syntax 'spec contract' still present:\n{_fmt_hits(hits)}"
+
+
+def test_removed_spec_api_syntax_absent_from_authored_docs() -> None:
+    # Search for "specfact spec api" to avoid false positives from --spec api/openapi.yaml paths
+    hits = _scan_authored_docs("specfact spec api")
+    assert not hits, f"Removed syntax 'specfact spec api' still present:\n{_fmt_hits(hits)}"
+
+
+def test_removed_spec_sdd_syntax_absent_from_authored_docs() -> None:
+    hits = _scan_authored_docs("spec sdd")
+    assert not hits, f"Removed syntax 'spec sdd' still present:\n{_fmt_hits(hits)}"
+
+
+def test_removed_spec_generate_syntax_absent_from_authored_docs() -> None:
+    # "spec generate " (space) catches stale subcommands like fix-prompt, test-prompt,
+    # contracts-prompt etc. without matching the valid "spec generate-tests" (hyphen).
+    hits = _scan_authored_docs("spec generate ")
+    assert not hits, f"Removed syntax 'spec generate <subcommand>' still present:\n{_fmt_hits(hits)}"
+
+
+# ---------------------------------------------------------------------------
+# docs-03-command-syntax-parity: current command families must be present
+# ---------------------------------------------------------------------------
+
+
+def test_current_code_import_from_bridge_documented() -> None:
+    """Bridge import moved to code import from-bridge; at least one authored doc must show this."""
+    hits = _scan_authored_docs("code import")
+    assert hits, "Current syntax 'code import' must appear in at least one authored doc"
+
+
+def test_current_spec_commands_documented_in_commands_reference() -> None:
+    commands_doc = _repo_file("docs/reference/commands.md").read_text(encoding="utf-8")
+    for cmd in ("spec validate", "spec backward-compat", "spec generate-tests", "spec mock"):
+        assert cmd in commands_doc, f"Current command '{cmd}' missing from docs/reference/commands.md"
+
+
+def test_current_govern_enforce_sdd_documented() -> None:
+    commands_doc = _repo_file("docs/reference/commands.md").read_text(encoding="utf-8")
+    assert "govern enforce" in commands_doc, "'govern enforce' must appear in commands reference"
+
+
+def test_current_backlog_subcommands_documented_in_commands_reference() -> None:
+    commands_doc = _repo_file("docs/reference/commands.md").read_text(encoding="utf-8")
+    for sub in ("backlog ceremony", "backlog refine", "backlog daily", "backlog sync"):
+        assert sub in commands_doc, f"Current subcommand '{sub}' missing from commands reference"


### PR DESCRIPTION
## Summary

- Replace all stale CLI syntax families (`project plan`, `project import from-bridge`, `backlog policy`, `spec contract`, `spec sdd constitution`, `spec generate` prompt subcommands) across 37 authored doc files with current shipped commands
- Add 11 new docs parity tests that guard against stale syntax reappearing in future releases
- Bump to v0.42.2

## Changes

**Replaced syntax families:**
- `specfact project plan` → `project devops-flow` / `project snapshot` / `govern enforce sdd`
- `project import from-bridge` → `code import from-bridge`
- `specfact backlog policy` → `backlog verify-readiness` / `backlog refine`
- `specfact spec contract` → `spec validate` / `spec generate-tests` / `spec mock`
- `specfact spec sdd constitution` → `govern enforce sdd [BUNDLE]`
- `spec generate <prompt-subcommands>` → AI IDE skills or removed

**Files updated:** README.md, docs/index.md, docs/README.md, 5 reference docs, 4 getting-started docs, 21 guides, 5 examples, 2 prompt docs

**Tests added:** 11 new parity tests in `tests/unit/docs/test_release_docs_parity.py` — all 21 tests (10 pre-existing + 11 new) pass

## Test plan

- [x] `hatch test -- tests/unit/docs/test_release_docs_parity.py -v` → 21 passed
- [x] `hatch run yaml-lint` → exit 0
- [x] `openspec validate --type change docs-03-command-syntax-parity` → valid
- [x] Pre-commit hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)