### PR TITLE
fix: keep imported change ids stable across title changes

### DIFF
--- a/src/specfact_cli/adapters/backlog_base.py
+++ b/src/specfact_cli/adapters/backlog_base.py
@@ -287,6 +287,14 @@ class BacklogAdapterMixin(ABC):
         tool_name: str,
         existing_proposals: dict[str, ChangeProposal],
     ) -> str:
+        existing_change_id = self._find_existing_imported_change_id_by_source(
+            item_data,
+            tool_name,
+            existing_proposals,
+        )
+        if existing_change_id:
+            return existing_change_id
+
         existing_proposal = existing_proposals.get(candidate)
         if existing_proposal is None:
             return candidate or raw_change_id or "unknown"
@@ -303,6 +311,19 @@ class BacklogAdapterMixin(ABC):
         if existing_deduped and self._matches_existing_import_source(existing_deduped, item_data, tool_name):
             return deduped_candidate
         return deduped_candidate
+
+    @beartype
+    @ensure(lambda result: result is None or isinstance(result, str), "Must return change id or None")
+    def _find_existing_imported_change_id_by_source(
+        self,
+        item_data: dict[str, Any],
+        tool_name: str,
+        existing_proposals: dict[str, ChangeProposal],
+    ) -> str | None:
+        for change_id, proposal in existing_proposals.items():
+            if self._matches_existing_import_source(proposal, item_data, tool_name):
+                return change_id
+        return None
 
     @beartype
     @ensure(lambda result: isinstance(result, str), "Must return source URL string")

--- a/tests/unit/adapters/test_ado.py
+++ b/tests/unit/adapters/test_ado.py
@@ -965,3 +965,71 @@ class TestAdoAdapter:
         assert "add-feature-x" in project_bundle.change_tracking.proposals
         assert "add-feature-x-123" not in project_bundle.change_tracking.proposals
         assert len(project_bundle.change_tracking.proposals) == 1
+
+    @beartype
+    @patch.object(AdoAdapter, "_get_work_item_comments", return_value=[])
+    def test_import_artifact_ado_work_item_reimport_with_renamed_title_keeps_original_slug(
+        self,
+        _mock_get_comments: MagicMock,
+        ado_adapter: AdoAdapter,
+        tmp_path: Path,
+    ) -> None:
+        """Re-importing the same work item with a new title should keep the original proposal name."""
+        project_bundle = MagicMock()
+        project_bundle.change_tracking = ChangeTracking(
+            proposals={
+                "add-feature-x": ChangeProposal(
+                    name="add-feature-x",
+                    title="Add Feature X",
+                    description="Existing",
+                    rationale="Existing rationale",
+                    timeline=None,
+                    owner=None,
+                    status="proposed",
+                    created_at="2025-01-01T10:00:00+00:00",
+                    applied_at=None,
+                    archived_at=None,
+                    source_tracking=SourceTracking(
+                        tool="ado",
+                        source_metadata={
+                            "source_id": 123,
+                            "source_url": "https://dev.azure.com/test-org/test-project/_workitems/edit/123",
+                            "source_type": "ado",
+                            "backlog_entries": [
+                                {
+                                    "source_id": "123",
+                                    "source_url": "https://dev.azure.com/test-org/test-project/_workitems/edit/123",
+                                    "source_type": "ado",
+                                }
+                            ],
+                        },
+                    ),
+                )
+            }
+        )
+        project_bundle.bundle_dir = tmp_path
+
+        work_item_data = {
+            "id": 123,
+            "fields": {
+                "System.Title": "Rename Feature X",
+                "System.Description": "## Why\n\nNeeded\n\n## What Changes\n\nImplement",
+                "System.State": "New",
+                "System.CreatedDate": "2025-01-01T10:00:00Z",
+                "System.WorkItemType": "User Story",
+            },
+            "_links": {
+                "html": {"href": "https://dev.azure.com/test-org/test-project/_workitems/edit/123"},
+            },
+        }
+
+        ado_adapter.import_artifact(
+            artifact_key="ado_work_item",
+            artifact_path=work_item_data,
+            project_bundle=project_bundle,
+        )
+
+        assert "add-feature-x" in project_bundle.change_tracking.proposals
+        assert "rename-feature-x" not in project_bundle.change_tracking.proposals
+        assert "rename-feature-x-123" not in project_bundle.change_tracking.proposals
+        assert len(project_bundle.change_tracking.proposals) == 1


### PR DESCRIPTION
# Description

Keep imported OpenSpec change IDs stable when the same backlog item is re-imported after its title changes. Without this, a renamed source item can create a second proposal under a new slug instead of reusing the existing one.

**Fixes** #425

**New Features** N/A

**Contract References**: No new `@icontract` surface; this change preserves the existing import idempotency behavior in shared backlog adapter logic.

## Type of Change

Please check all that apply:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Contract enforcement (adding/updating `@icontract` decorators)
- [x] 🧪 Test enhancement (scenario tests, property-based tests)
- [ ] 🔧 Refactoring (code improvement without functionality change)

## Contract-First Testing Evidence

**Required for all changes affecting CLI commands or public APIs:**

### Contract Validation

- [ ] **Runtime contracts added/updated** (`@icontract` decorators on public APIs)
- [x] **Type checking enforced** (`@beartype` decorators applied)
- [ ] **CrossHair exploration** completed: `hatch run contract-test-exploration`
- [x] **Contract violations** reviewed and addressed

### Test Execution

- [ ] **Contract validation**: `hatch run contract-test-contracts` ✅
- [ ] **Contract exploration**: `hatch run contract-test-exploration` ✅
- [ ] **Scenario tests**: `hatch run contract-test-scenarios` ✅
- [ ] **Full test suite**: `hatch run contract-test-full` ✅

### Test Quality

- [ ] **CLI commands tested** with typer test client
- [ ] **Edge cases covered** with Hypothesis property tests
- [x] **Error handling tested** with invalid inputs
- [ ] **Rich console output verified** manually or with snapshots

## How Has This Been Tested?

**Contract-First Approach**: The shared backlog import dedupe logic now resolves an existing proposal by source metadata before accepting a new title-derived slug. Regression coverage was added for re-importing the same ADO work item after a title change.

### Manual Testing

- [ ] Tested CLI commands manually
- [ ] Verified rich console output
- [ ] Tested with different input scenarios
- [ ] Checked error messages for clarity

### Automated Testing

- [x] Contract validation passes
- [ ] Property-based tests cover edge cases
- [x] Scenario tests cover user workflows
- [x] All existing tests still pass

### Test Environment

- Python version: 3.12
- OS: Ubuntu

## Checklist

- [x] My code follows the style guidelines (PEP 8, ruff format, isort)
- [x] I have performed a self-review of my code
- [x] I have added/updated contracts (`@icontract`, `@beartype`)
- [ ] I have added/updated docstrings (Google style)
- [ ] I have made corresponding changes to documentation
- [x] My changes generate no new warnings (basedpyright, ruff, pylint)
- [x] All tests pass locally
- [x] I have added tests that prove my fix/feature works
- [x] Any dependent changes have been merged

## Quality Gates Status

- [ ] **Type checking** ✅ (`hatch run type-check`)
- [ ] **Linting** ✅ (`hatch run lint`)
- [ ] **Contract validation** ✅ (`hatch run contract-test-contracts`)
- [ ] **Contract exploration** ✅ (`hatch run contract-test-exploration`)
- [ ] **Scenario tests** ✅ (`hatch run contract-test-scenarios`)

## Screenshots/Recordings (if applicable)

N/A
