### PR TITLE
fix(scripts): CliRunner compat without mix_stderr (Click 8.3+)

### DIFF
--- a/scripts/check-docs-commands.py
+++ b/scripts/check-docs-commands.py
@@ -143,7 +143,7 @@ def validate_command_tokens(tokens: list[str]) -> tuple[bool, str]:
     if not tokens:
         return True, ""
 
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     last_err = ""
     for k in range(len(tokens), 0, -1):
         prefix = tokens[:k]
@@ -151,7 +151,8 @@ def validate_command_tokens(tokens: list[str]) -> tuple[bool, str]:
         exc = getattr(result, "exception", None)
         if result.exit_code == 0 and exc is None:
             return True, ""
-        err = (result.stderr or result.stdout or getattr(result, "output", None) or "").strip()
+        # CliRunner default merges stderr into stdout; ``result.stderr`` raises if not split.
+        err = (result.stdout or "").strip()
         if exc is not None:
             last_err = f"{type(exc).__name__}: {exc!s}"[:800]
         else:


### PR DESCRIPTION
## Summary
- Drop `CliRunner(mix_stderr=False)` so Typer/Click versions that removed the `mix_stderr` keyword do not raise `TypeError` at import/invoke time.
- Read `result.stdout` only for error text: default `CliRunner()` merges stderr into stdout, and accessing `result.stderr` raises `ValueError: stderr not separately captured`.

## Testing
- `hatch run check-docs-commands`
- `hatch run pytest tests/unit/docs/test_docs_validation_scripts.py -v`


Made with [Cursor](https://cursor.com)