### PR TITLE
fix: address CodeRabbit review findings for ci-02

### DIFF
--- a/.github/workflows/pr-orchestrator.yml
+++ b/.github/workflows/pr-orchestrator.yml
@@ -43,6 +43,8 @@ jobs:
               - '!.github/workflows/**'
             workflow:
               - '.github/workflows/**'
+              - 'scripts/run_actionlint.sh'
+              - 'scripts/yaml-tools.sh'
       - id: out
         env:
           EVENT_NAME: ${{ github.event_name }}

--- a/openspec/CHANGE_ORDER.md
+++ b/openspec/CHANGE_ORDER.md
@@ -61,7 +61,7 @@ Only changes that are **archived**, shown as **✓ Complete** by `openspec list`
 | ✅ code-review-08-review-run-integration | archived 2026-03-17 |
 | ✅ code-review-09-f4-automation-upgrade | archived 2026-03-17 |
 | ✅ doc-frontmatter-schema | archived 2026-03-29 |
-| ✅ ci-02-trustworthy-green-checks | implemented 2026-03-30 (archive pending) |
+| ✅ ci-02-trustworthy-green-checks | implemented 2026-03-30; archive pending |
 
 ### Pending
 

--- a/scripts/run_actionlint.sh
+++ b/scripts/run_actionlint.sh
@@ -8,14 +8,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
-ACTIONLINT_TAG="${ACTIONLINT_TAG:-latest}"
+ACTIONLINT_TAG="${ACTIONLINT_TAG:-v1.7.11}"
 DOCKER_IMAGE="rhysd/actionlint:${ACTIONLINT_TAG}"
 
-run_installed_binary() {
-  if ! command -v actionlint >/dev/null 2>&1; then
-    return 1
-  fi
+has_actionlint() {
+  command -v actionlint >/dev/null 2>&1
+}
 
+run_actionlint_local() {
   actionlint -no-color
 }
 
@@ -35,8 +35,9 @@ run_with_docker() {
       "$DOCKER_IMAGE" -no-color
 }
 
-if run_installed_binary; then
-  exit 0
+if has_actionlint; then
+  run_actionlint_local
+  exit $?
 fi
 
 if run_with_docker; then
@@ -47,5 +48,5 @@ echo "actionlint is required for workflow linting." >&2
 echo "Install it globally or use a Docker-enabled environment." >&2
 echo "Official install options: https://github.com/rhysd/actionlint" >&2
 echo "Example global install:" >&2
-echo "  go install github.com/rhysd/actionlint/cmd/actionlint@latest" >&2
+echo "  go install github.com/rhysd/actionlint/cmd/actionlint@${ACTIONLINT_TAG}" >&2
 exit 2

--- a/tests/unit/modules/test_bundle_import.py
+++ b/tests/unit/modules/test_bundle_import.py
@@ -22,9 +22,12 @@ def test_bootstrap_local_bundle_sources_honors_specfact_modules_repo_env(monkeyp
     expected_src = str((modules_repo / "packages" / "specfact-codebase" / "src").resolve())
     monkeypatch.setenv("SPECFACT_MODULES_REPO", str(modules_repo))
     monkeypatch.delenv("SPECFACT_CLI_MODULES_REPO", raising=False)
+    original_path = sys.path.copy()
     if expected_src in sys.path:
         sys.path.remove(expected_src)
 
-    bootstrap_local_bundle_sources(str(anchor))
-
-    assert expected_src in sys.path
+    try:
+        bootstrap_local_bundle_sources(str(anchor))
+        assert expected_src in sys.path
+    finally:
+        sys.path[:] = original_path

--- a/tests/unit/workflows/test_trustworthy_green_checks.py
+++ b/tests/unit/workflows/test_trustworthy_green_checks.py
@@ -195,7 +195,7 @@ def test_legacy_actionlint_runner_does_not_mask_docker_failures() -> None:
     assert any("docker run --rm" in line for line in lines), "Expected docker run invocation"
     assert "docker info >/dev/null 2>&1" in raw, "Expected docker daemon reachability check"
     assert "tools/bin" not in raw, "Should not download binaries into repo tree"
-    assert "go install github.com/rhysd/actionlint/cmd/actionlint@latest" in raw, "Expected global install guidance"
+    assert "go install github.com/rhysd/actionlint/cmd/actionlint@" in raw, "Expected global install guidance"
     # Docker run must not be followed by unconditional return 0 (would swallow failures)
     for i, line in enumerate(lines):
         if "docker run --rm" in line:


### PR DESCRIPTION
# Description

Addresses valid CodeRabbit review findings from PR #469 (ci-02-trustworthy-green-checks).

**Fixes** #469 (review follow-up)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Summary

- **Workflow Lint trigger gap**: `workflow_changed` filter now includes `scripts/run_actionlint.sh` and `scripts/yaml-tools.sh` so the Workflow Lint job triggers on script changes
- **Actionlint version drift**: Default `ACTIONLINT_TAG` pinned to `v1.7.11` (matching CI) instead of `latest`; install hint uses the pinned version
- **Actionlint failure masking**: `run_installed_binary()` split into `has_actionlint()` (availability) and `run_actionlint_local()` (execution) so lint failures propagate instead of falling through to Docker
- **Test isolation**: `test_bundle_import.py` now saves/restores `sys.path` to prevent cross-test leakage
- **CHANGE_ORDER format**: Normalized status annotation to semicolon convention

### Findings triaged but not actioned (low value / already covered)

- CONTRIBUTING.md review gate detail — current text already accurate
- docs/modules/code-review.md actionlint prerequisite — already covered in CONTRIBUTING.md line 109-111
- tasks.md worktree cleanup steps — completed task, retroactive additions add no value
- TDD_EVIDENCE.md lint-workflows invocation — completed evidence, retroactive output adds no value
- migration test narrower allowlist — file-level allow is consistent with all other entries

## Quality Gates Status

- [x] **Type checking** ✅ (`hatch run type-check`) — 0 errors
- [x] **Formatting** ✅ (`hatch run format`)
- [x] **Tests** ✅ — 13/13 affected tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)