### PR TITLE
fix: propagate docker actionlint exit code instead of masking failures

### DIFF
--- a/scripts/run_actionlint.sh
+++ b/scripts/run_actionlint.sh
@@ -15,33 +15,21 @@ has_actionlint() {
   command -v actionlint >/dev/null 2>&1
 }
 
-run_actionlint_local() {
-  actionlint -no-color
+has_docker() {
+  command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1
 }
 
-run_with_docker() {
-  if ! command -v docker >/dev/null 2>&1; then
-    return 1
-  fi
+if has_actionlint; then
+  actionlint -no-color
+  exit $?
+fi
 
-  if ! docker info >/dev/null 2>&1; then
-    echo "Docker daemon unavailable for actionlint; cannot run via Docker." >&2
-    return 1
-  fi
-
+if has_docker; then
   docker run --rm \
       -v "$REPO_ROOT":/repo \
       -w /repo \
       "$DOCKER_IMAGE" -no-color
-}
-
-if has_actionlint; then
-  run_actionlint_local
   exit $?
-fi
-
-if run_with_docker; then
-  exit 0
 fi
 
 echo "actionlint is required for workflow linting." >&2

--- a/tests/unit/workflows/test_trustworthy_green_checks.py
+++ b/tests/unit/workflows/test_trustworthy_green_checks.py
@@ -196,8 +196,5 @@ def test_legacy_actionlint_runner_does_not_mask_docker_failures() -> None:
     assert "docker info >/dev/null 2>&1" in raw, "Expected docker daemon reachability check"
     assert "tools/bin" not in raw, "Should not download binaries into repo tree"
     assert "go install github.com/rhysd/actionlint/cmd/actionlint@" in raw, "Expected global install guidance"
-    # Docker run must not be followed by unconditional return 0 (would swallow failures)
-    for i, line in enumerate(lines):
-        if "docker run --rm" in line:
-            remaining = "\n".join(lines[i:])
-            assert "return 0" not in remaining, "docker run must not be followed by unconditional return 0"
+    # Both execution paths (local binary and docker) must propagate exit codes
+    assert raw.count("exit $?") >= 2, "Expected exit code propagation for both local and docker paths"


### PR DESCRIPTION
# Description

Follow-up to #471 — addresses the remaining CodeRabbit finding about docker exit code masking in `run_actionlint.sh`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Summary

- Simplified `run_actionlint.sh` control flow so both local and docker paths propagate actionlint's exit code via `exit $?`
- Previously the docker path used `if run_with_docker; then exit 0; fi` which treated lint errors (non-zero exit) as "docker unavailable" and fell through to install guidance
- Removed redundant function wrappers; `has_actionlint()` and `has_docker()` check availability, execution is inline
- Updated test assertion from fragile `return 0` string check to `exit $?` count verification

## Quality Gates Status

- [x] **Formatting** ✅
- [x] **Tests** ✅ — 9/9 workflow tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)