### PR TITLE
fix: assert hook id stability and cd to repo root for local actionlint

### DIFF
--- a/scripts/run_actionlint.sh
+++ b/scripts/run_actionlint.sh
@@ -20,6 +20,7 @@ has_docker() {
 }
 
 if has_actionlint; then
+  cd "$REPO_ROOT"
   actionlint -no-color
   exit $?
 fi

--- a/tests/unit/workflows/test_trustworthy_green_checks.py
+++ b/tests/unit/workflows/test_trustworthy_green_checks.py
@@ -171,6 +171,7 @@ def test_pre_commit_config_installs_supported_smart_check_wrapper() -> None:
     matching = [hook for hook in hooks if hook.get("entry") == "scripts/pre-commit-smart-checks.sh"]
     assert matching, "Expected .pre-commit-config.yaml to expose the smart-check wrapper hook"
     hook = matching[0]
+    assert hook.get("id") == "specfact-smart-checks", "Hook id must remain stable for pre-commit consumers"
     assert hook.get("pass_filenames") is False
     assert hook.get("language") == "script"
 


### PR DESCRIPTION
# Description

Follow-up to #472 — addresses remaining CodeRabbit review findings.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Summary

- Assert `hook.get("id") == "specfact-smart-checks"` in pre-commit wrapper test to prevent silent id renames
- `cd "$REPO_ROOT"` before running local actionlint so it finds `.github/workflows/` regardless of caller's cwd

## Quality Gates Status

- [x] **Tests** ✅ — 9/9 workflow tests pass
- [x] **Formatting** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)