### PR TITLE
[codex] stabilize module install and init state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.46.5] - 2026-04-28
+
+### Fixed
+
+- **Module install and init**: repair module availability, install, upgrade, uninstall, and profile-init state handling so repeated runs across repos and envs stay consistent.
+
+---
+
 ## [0.46.4] - 2026-04-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.46.7] - 2026-04-28
+
+### Fixed
+
+- **Review follow-up**: normalize project install `--repo` to the workspace root
+  and require exact matching for fully qualified module ids during availability
+  classification.
+
+---
+
 ## [0.46.6] - 2026-04-28
 
 ### Fixed
@@ -20,9 +30,21 @@ All notable changes to this project will be documented in this file.
 
 ## [0.46.5] - 2026-04-28
 
+### Added
+
+- **Reality-test coverage**: add isolated `hatch run specfact` verification for
+  install, upgrade, uninstall, and profile-init workflows.
+
+### Changed
+
+- **Diagnostics behavior**: missing-command guidance now distinguishes absent,
+  disabled, skipped, and shadowed module states with matching recovery hints.
+
 ### Fixed
 
-- **Module install and init**: repair module availability, install, upgrade, uninstall, and profile-init state handling so repeated runs across repos and envs stay consistent.
+- **Module install and init**: repair module availability, install, upgrade,
+  uninstall, and profile-init state handling so repeated runs across repos and
+  envs stay consistent.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.46.6] - 2026-04-28
+
+### Fixed
+
+- **PR follow-up**: fix project-scope module re-enable to honor `--repo` and restore reachable shadowed-module diagnostics during availability checks.
+
+---
+
 ## [0.46.5] - 2026-04-28
 
 ### Fixed

--- a/docs/core-cli/init.md
+++ b/docs/core-cli/init.md
@@ -15,8 +15,6 @@ exempt: false
 exempt_reason: ""
 ---
 
-# specfact init
-
 Bootstrap SpecFact CLI in a repository. Use `init ide` for IDE-specific setup; module lifecycle is under `specfact module`.
 
 ## Usage
@@ -53,6 +51,8 @@ specfact init --profile solo-developer
 # Install specific bundles during init
 specfact init --install backlog,code-review
 ```
+
+Profile and install selections are treated as explicit enable requests for the selected marketplace module ids. `init` discovers project modules relative to `--repo` and merges the refreshed rows into `modules.json`, preserving unrelated module lifecycle state from other repositories or scopes.
 
 ## IDE Setup
 

--- a/docs/module-system/installing-modules.md
+++ b/docs/module-system/installing-modules.md
@@ -10,8 +10,6 @@ audience: [solo, team, enterprise]
 expertise_level: [beginner, intermediate]
 ---
 
-# Installing Modules
-
 Use the `specfact module` command group to manage marketplace and locally discovered modules.
 Use plain `specfact ...` commands in this guide (not `hatch run specfact ...`) so steps work across pipx, pip, uv tool installs, and packaged runtimes.
 
@@ -42,7 +40,9 @@ Notes:
 - Install source defaults to `auto` (bundled first, then marketplace fallback).
 - Use `--source bundled` or `--source marketplace` for explicit source selection.
 - Use `--trust-non-official` when running non-interactive installs for community/non-official publishers.
-- If a module is already available locally (`built-in` or `custom`), install is skipped with a clear message.
+- If a module is already available locally (`built-in`, project, user, or `custom`), install is skipped with a clear message.
+- If the requested module is already installed but disabled in `modules.json`, install repairs the lifecycle state by enabling the manifest module id and reports that action.
+- Missing command guidance distinguishes truly absent modules from installed-but-disabled or installed-but-skipped modules and suggests the matching recovery command.
 - Invalid ids show an explicit error (`name` or `namespace/name` only).
 
 ## Dependency resolution
@@ -156,6 +156,8 @@ specfact module disable plan --force
 
 Use `--force` to allow dependency-aware cascades when required.
 
+Running `specfact init --profile <profile>` or `specfact init --install <bundles>` directly enables the selected marketplace module ids. Rediscovered modules keep their previous enabled or disabled state unless they were selected by the profile/install request.
+
 ## Uninstall Behavior
 
 ```bash
@@ -187,6 +189,4 @@ Upgrade applies only to modules with origin `marketplace`.
 
 > Modules docs handoff: this page remains in the core docs set as release-line overview content.
 > Canonical bundle-specific deep guidance now lives in the canonical modules docs site, currently
-> published at `https://modules.specfact.io/`.
-
-> core docs set for the current release line and are planned to migrate to `specfact-cli-modules`.
+> published at `https://modules.specfact.io/` and is planned to migrate from `specfact-cli-modules`.

--- a/openspec/changes/marketplace-07-module-install-state-consistency/.openspec.yaml
+++ b/openspec/changes/marketplace-07-module-install-state-consistency/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/marketplace-07-module-install-state-consistency/TDD_EVIDENCE.md
+++ b/openspec/changes/marketplace-07-module-install-state-consistency/TDD_EVIDENCE.md
@@ -1,0 +1,72 @@
+# TDD Evidence
+
+## 2026-04-28 - Failing regression run
+
+Command:
+
+```bash
+hatch run pytest tests/unit/specfact_cli/registry/test_module_availability.py tests/unit/modules/module_registry/test_commands.py::test_install_command_existing_disabled_module_enables_state tests/unit/specfact_cli/test_module_not_found_error.py::test_module_not_found_error_reports_disabled_installed_module tests/unit/modules/init/test_first_run_selection.py::test_init_profile_enables_profile_modules_and_uses_repo_for_discovery tests/unit/specfact_cli/registry/test_init_module_state.py::test_refresh_preserves_unseen_module_state_when_requested -q
+```
+
+Result: failed during collection as expected before implementation.
+
+Key failure:
+
+```text
+ModuleNotFoundError: No module named 'specfact_cli.registry.module_availability'
+```
+
+## 2026-04-28 - Passing regression and touched-scope verification
+
+Focused regression command:
+
+```bash
+hatch run pytest tests/unit/specfact_cli/registry/test_module_availability.py tests/unit/modules/module_registry/test_commands.py::test_install_command_existing_disabled_module_enables_state tests/unit/specfact_cli/test_module_not_found_error.py tests/unit/modules/init/test_first_run_selection.py::test_init_profile_enables_profile_modules_and_uses_repo_for_discovery tests/unit/specfact_cli/registry/test_init_module_state.py::test_refresh_preserves_unseen_module_state_when_requested -q
+```
+
+Result: 11 passed, 2 warnings.
+
+Touched-area regression command:
+
+```bash
+hatch run pytest tests/unit/specfact_cli/registry/test_module_availability.py tests/unit/modules/module_registry/test_commands.py tests/unit/specfact_cli/test_module_not_found_error.py tests/unit/modules/init/test_first_run_selection.py tests/unit/specfact_cli/registry/test_init_module_state.py tests/unit/registry/test_module_lifecycle.py tests/unit/specfact_cli/registry/test_command_registry.py -q
+```
+
+Result: 96 passed, 2 warnings.
+
+Quality gates:
+
+```bash
+hatch run lint
+hatch run specfact code review run --json --out .specfact/code-review.changed.json --scope changed
+openspec validate marketplace-07-module-install-state-consistency --strict
+```
+
+Results: lint passed; changed-scope SpecFact code review passed with 0 blocking findings; strict OpenSpec validation passed.
+
+## 2026-04-28 - Isolated CLI reality test
+
+Command shape:
+
+```bash
+HOME=/tmp/specfact-reality-*/home \
+SPECFACT_REGISTRY_DIR=/tmp/specfact-reality-*/registry \
+HATCH_DATA_DIR=/home/dom/.local/share/hatch \
+HATCH_CACHE_DIR=/home/dom/.cache/hatch \
+/home/dom/.local/pipx/venvs/hatch/bin/hatch run specfact ...
+```
+
+Scenarios covered with local fixture modules:
+
+- `specfact code` reports `nold-ai/specfact-codebase` as installed but disabled and suggests `specfact module enable nold-ai/specfact-codebase`.
+- `specfact module install nold-ai/specfact-codebase` repairs disabled existing install state and preserves an unrelated disabled `modules.json` row.
+- `specfact init --repo <tmp-repo> --profile solo-developer` enables `nold-ai/specfact-codebase` and `nold-ai/specfact-code-review` while preserving unrelated state.
+- `specfact module upgrade nold-ai/specfact-backlog` takes the deterministic offline path and reports the marketplace registry as unavailable instead of corrupting state.
+- `specfact module uninstall nold-ai/specfact-backlog --scope user` removes the user-scoped module directory.
+
+Result: `REALITY_TEST_PASS`.
+
+Reality test fixes added:
+
+- Availability classification now prioritizes an explicit requested module id over other modules sharing the same top-level command group.
+- Install repair now merges with existing module lifecycle state instead of replacing unrelated rows.

--- a/openspec/changes/marketplace-07-module-install-state-consistency/design.md
+++ b/openspec/changes/marketplace-07-module-install-state-consistency/design.md
@@ -1,0 +1,83 @@
+## Context
+
+Module availability currently has several independent truth sources:
+
+- physical artifacts under builtin, project, user, marketplace, and custom module roots;
+- manifest identity and command metadata from `module-package.yaml`;
+- lifecycle state in `~/.specfact/registry/modules.json`;
+- runtime registration decisions after compatibility, dependency, schema, and integrity checks;
+- user-facing install and missing-command diagnostics.
+
+The bug appears when one layer reports success while a later layer refuses to expose the command. The most visible path is: command missing help says a module is not installed, `specfact module install` sees a manifest already present and returns early, and the disabled/skipped/shadowed state remains unresolved.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make install no-op checks reconcile the selected module with lifecycle state and command availability.
+- Make missing-command diagnostics identify installed-but-unavailable causes when they can be derived locally.
+- Make `specfact init --repo ... --profile ...` refresh module state from the intended repository context, not an unrelated cwd.
+- Preserve user disabled-module choices while preventing init/profile flows from silently dropping unrelated modules.
+- Keep user and project scope behavior deterministic and offline-first.
+
+**Non-Goals:**
+
+- Replacing the module marketplace registry format.
+- Removing project-scope precedence over user-scope modules.
+- Installing Python package dependencies differently.
+- Implementing remote registry changes in `specfact-cli-modules`.
+
+## Decisions
+
+1. Introduce a local module availability classification helper.
+
+   Runtime diagnostics and install no-op paths need the same vocabulary. The helper should derive, for a requested command or module ID, whether the module is absent, installed-and-enabled, installed-but-disabled, shadowed by a higher-priority scope, skipped by compatibility/dependencies/schema/integrity, or ambiguous. This keeps CLI output consistent without loading module command apps eagerly.
+
+   Alternative considered: leave install and missing-command diagnostics separate. That preserves current contradictions and forces each command path to rediscover partial state.
+
+2. Canonicalize module identity before state or install decisions.
+
+   A request such as `specfact-codebase`, `specfact/specfact-codebase`, and `nold-ai/specfact-codebase` should resolve to the same discovered module record when the manifest identifies the installed package as `nold-ai/specfact-codebase`. State updates should use manifest IDs, while user-facing commands may continue accepting bare names.
+
+   Alternative considered: store aliases in `modules.json`. That makes state harder to reason about and risks duplicate rows for the same physical module.
+
+3. Treat install no-op as lifecycle reconciliation, not a terminal success.
+
+   If the target manifest exists and `--reinstall` is not set, install should check whether the manifest's module is enabled and eligible. If disabled, the command should either enable it for the selected module state workflow or report the exact `specfact module enable <id>` command. If skipped for integrity, compatibility, schema, or dependency reasons, install should print that reason and suggest the appropriate recovery path.
+
+   Alternative considered: always reinstall when a command is unavailable. This hides disabled-state bugs and can mutate user/project scopes unnecessarily.
+
+4. Make init state refresh repo-aware and merge-based.
+
+   `specfact init --repo <repo>` should discover project modules relative to `<repo>` for state refresh and prompt audit. The write to `modules.json` should merge the current discovery view with existing state so user-disabled choices and modules outside the current view are not accidentally lost.
+
+   Alternative considered: keep global replacement semantics. That remains fragile when users run init from different directories or environments.
+
+5. Keep shadowing behavior but surface it at the point of confusion.
+
+   Project modules should still take precedence over user modules. When the selected command or module is unavailable because a project copy shadows a user copy, diagnostics should identify both origins and the active origin.
+
+   Alternative considered: remove project precedence. That would break intentional repo-local module overrides.
+
+## Risks / Trade-offs
+
+- [Risk] Availability classification duplicates parts of registration filtering. -> Mitigation: keep it metadata-only and share small helpers for state, dependencies, and integrity checks where practical.
+- [Risk] Merging old state rows can preserve stale entries forever. -> Mitigation: preserve only rows with explicit disabled state or known source tracking; discovered rows remain the authoritative visible set for `module list`.
+- [Risk] Enabling during install may surprise users who intentionally disabled a module. -> Mitigation: require explicit output and prefer an actionable message unless the command is clearly a user-requested install of that exact module.
+- [Risk] Integrity checks can be expensive on startup diagnostics. -> Mitigation: only run deeper checks for requested missing-command/install paths, not every root help render.
+
+## Migration Plan
+
+1. Add regression tests for disabled modules, shadowed project/user modules, init/profile state refresh, and missing-command diagnostics.
+2. Add the availability classification helper and route install skip checks through it.
+3. Update missing-command help to use local classification when available.
+4. Update init/profile state refresh to use the selected repo path and merge state deterministically.
+5. Update user-facing docs for module install/list/init recovery guidance if command text changes.
+6. Record failing-before and passing-after evidence in `TDD_EVIDENCE.md`.
+
+Rollback is straightforward: these changes are local CLI behavior changes and can be reverted without data migration. Existing module roots and `modules.json` remain compatible.
+
+## Open Questions
+
+- Should install automatically re-enable an installed disabled module, or should it stop with an explicit `specfact module enable <id>` command? The implementation should choose the least surprising option and document it in tests.
+- Should `module list --show-origin` expose unavailable/skipped reasons for all modules, or only missing-command and install paths?

--- a/openspec/changes/marketplace-07-module-install-state-consistency/proposal.md
+++ b/openspec/changes/marketplace-07-module-install-state-consistency/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+SpecFact module installation, discovery, init profile bootstrap, and command registration can disagree about whether a module is usable. Users can see a command group reported as not installed, then be told by `specfact module install` that the same module is already installed or already available, which makes recovery unreliable across user and project scopes.
+
+## What Changes
+
+- Reconcile module install no-op paths with lifecycle state so an already-present module is either enabled for the selected scope or reported as installed-but-disabled with an actionable command.
+- Improve missing command diagnostics so they distinguish absent modules from disabled, shadowed, incompatible, dependency-skipped, or integrity/schema-skipped modules.
+- Make init/profile state refreshes preserve unrelated module state and avoid cwd-derived surprises when `--repo` selects a repository.
+- Normalize install/discovery/state identity comparisons so bare names, marketplace IDs, and manifest IDs resolve to one canonical module record before deciding that work is already satisfied.
+- Add focused regression tests for repeated `module install`, `init --profile`, user/project scope shadowing, and disabled-module recovery.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `module-installation`: install no-op behavior must account for module lifecycle state and command availability, not just the presence of `module-package.yaml`.
+- `user-module-root`: user/project scope discovery and shadowing must remain deterministic and must surface actionable guidance when an installed module is shadowed or scope-specific.
+- `init-module-state`: init/profile bootstrap must preserve user lifecycle choices while avoiding accidental global state churn from a different cwd or repo context.
+
+## Impact
+
+- Affected code: `src/specfact_cli/modules/module_registry/src/commands.py`, `src/specfact_cli/registry/module_packages.py`, `src/specfact_cli/registry/module_discovery.py`, `src/specfact_cli/registry/module_state.py`, `src/specfact_cli/modules/init/src/commands.py`, and `src/specfact_cli/cli.py`.
+- Affected tests: module registry command tests, lifecycle/state tests, discovery tests, init/profile tests, and CLI missing-command tests.
+- User impact: module commands become recoverable and diagnostics stop sending users through contradictory install loops.
+- GitHub tracking: fixes bug [#533](https://github.com/nold-ai/specfact-cli/issues/533), syncs to user story [#534](https://github.com/nold-ai/specfact-cli/issues/534), and both issues are children of Feature [#353](https://github.com/nold-ai/specfact-cli/issues/353).
+
+## Source Tracking
+
+- Source type: GitHub + OpenSpec
+- Source repo: `nold-ai/specfact-cli`
+- Bug report: [#533](https://github.com/nold-ai/specfact-cli/issues/533)
+- Synced user story: [#534](https://github.com/nold-ai/specfact-cli/issues/534)
+- Parent feature: [#353](https://github.com/nold-ai/specfact-cli/issues/353) `[Feature] Marketplace Module Distribution`
+- Report origin: direct user workflow feedback on 2026-04-28

--- a/openspec/changes/marketplace-07-module-install-state-consistency/specs/init-module-state/spec.md
+++ b/openspec/changes/marketplace-07-module-install-state-consistency/specs/init-module-state/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Init Profile State Refresh Is Repo-Aware and Merge-Based
+
+When `specfact init` installs or refreshes modules, the system SHALL discover project-scope modules relative to the selected repository path and SHALL merge discovered module rows with existing lifecycle state instead of replacing unrelated state blindly.
+
+#### Scenario: Init profile uses repo option for project discovery
+
+- **GIVEN** the current working directory is outside `<repo>`
+- **AND** `<repo>/.specfact/modules/<module-name>` exists
+- **WHEN** the user runs `specfact init --repo <repo> --profile <profile>`
+- **THEN** init SHALL use `<repo>` when discovering project-scope modules for state refresh and prompt audits
+- **AND** init SHALL NOT use an unrelated current working directory as the project module root
+
+#### Scenario: Init preserves disabled state for rediscovered modules
+
+- **GIVEN** `modules.json` marks a discovered module as disabled
+- **WHEN** the user runs `specfact init --profile <profile>`
+- **THEN** init SHALL preserve that module's disabled state unless the user explicitly enables it
+- **AND** init SHALL report actionable re-enable guidance when the disabled module belongs to the selected profile
+
+#### Scenario: Init does not drop unrelated module state from another context
+
+- **GIVEN** `modules.json` contains a module row that is not visible from the current repository discovery context
+- **WHEN** the user runs `specfact init --repo <repo> --profile <profile>`
+- **THEN** init SHALL NOT delete or reset that unrelated row solely because it is absent from the current discovery view
+- **AND** discovered rows for the selected repository SHALL still have current version and enabled metadata
+
+#### Scenario: Init profile install repairs installed-but-disabled profile module
+
+- **GIVEN** a profile-selected module artifact already exists
+- **AND** lifecycle state marks that module as disabled
+- **WHEN** the user runs `specfact init --profile <profile>`
+- **THEN** init SHALL not leave the profile command group in a contradictory not-installed/already-installed state
+- **AND** init SHALL either enable the profile-selected module or report the exact disabled-state recovery command

--- a/openspec/changes/marketplace-07-module-install-state-consistency/specs/module-installation/spec.md
+++ b/openspec/changes/marketplace-07-module-install-state-consistency/specs/module-installation/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Install Reconciles Existing Module Availability
+
+When a user installs a module whose artifact already exists in the selected scope, the system SHALL reconcile the artifact with lifecycle state and runtime availability before reporting success.
+
+#### Scenario: Existing installed module is disabled
+
+- **GIVEN** a module artifact exists under the selected install scope
+- **AND** the module state file marks the manifest module id as disabled
+- **WHEN** the user runs `specfact module install <module-id>`
+- **THEN** the command SHALL NOT report only that the module is already installed
+- **AND** the command SHALL either enable that module for the user-requested install or print an explicit installed-but-disabled diagnostic with `specfact module enable <manifest-module-id>`
+
+#### Scenario: Existing installed module is skipped by runtime eligibility checks
+
+- **GIVEN** a module artifact exists under the selected install scope
+- **AND** runtime registration would skip that module because of compatibility, dependency, schema, or integrity validation
+- **WHEN** the user runs `specfact module install <module-id>`
+- **THEN** the command SHALL report the specific local reason that the module is installed but unavailable
+- **AND** the command SHALL include a recovery action such as reinstall, enable dependency modules, update SpecFact CLI, or inspect origins
+
+#### Scenario: Existing installed module is available
+
+- **GIVEN** a module artifact exists under the selected install scope
+- **AND** lifecycle state and runtime eligibility allow its command group to register
+- **WHEN** the user runs `specfact module install <module-id>`
+- **THEN** the command MAY skip reinstalling the artifact
+- **AND** the command SHALL report that the module is already installed and available from the selected scope
+
+### Requirement: Missing Command Diagnostics Explain Installed-Unavailable Causes
+
+When a known module-provided command group is not registered, the system SHALL distinguish an absent module from an installed module that is unavailable for another local reason.
+
+#### Scenario: Missing command is provided by disabled module
+
+- **GIVEN** a known command group is provided by a discovered module
+- **AND** that module is disabled in lifecycle state
+- **WHEN** the user invokes the command group
+- **THEN** the CLI SHALL report that the module is installed but disabled
+- **AND** the CLI SHALL include `specfact module enable <manifest-module-id>` guidance
+
+#### Scenario: Missing command is provided by skipped module
+
+- **GIVEN** a known command group is provided by a discovered module
+- **AND** command registration skipped the module for compatibility, dependency, schema, or integrity reasons
+- **WHEN** the user invokes the command group
+- **THEN** the CLI SHALL report that the module is installed but unavailable
+- **AND** the CLI SHALL include the specific skipped reason when it can be derived without importing the module command app
+
+#### Scenario: Missing command has no discovered provider
+
+- **GIVEN** no discovered module provider exists for a known command group
+- **WHEN** the user invokes the command group
+- **THEN** the CLI SHALL keep reporting that the module is not installed
+- **AND** the CLI SHALL include install or init profile guidance
+
+### Requirement: Module Install Uses Canonical Module Identity
+
+The system SHALL resolve install requests, discovered manifest IDs, and lifecycle state rows to a canonical module identity before deciding whether an install is already satisfied.
+
+#### Scenario: Bare name resolves to installed marketplace manifest id
+
+- **GIVEN** `~/.specfact/modules/specfact-codebase/module-package.yaml` declares `name: nold-ai/specfact-codebase`
+- **WHEN** the user runs `specfact module install specfact-codebase`
+- **THEN** the command SHALL treat `specfact-codebase` and `nold-ai/specfact-codebase` as the same installed module for lifecycle-state checks
+- **AND** any state update or enable guidance SHALL use `nold-ai/specfact-codebase`
+
+#### Scenario: Legacy namespace request resolves to installed marketplace manifest id
+
+- **GIVEN** an installed module manifest declares `name: nold-ai/specfact-codebase`
+- **WHEN** the user runs `specfact module install specfact/specfact-codebase`
+- **THEN** the command SHALL NOT create or require a duplicate lifecycle state entry for `specfact/specfact-codebase`
+- **AND** the command SHALL explain the canonical installed module identity if it skips installation

--- a/openspec/changes/marketplace-07-module-install-state-consistency/specs/user-module-root/spec.md
+++ b/openspec/changes/marketplace-07-module-install-state-consistency/specs/user-module-root/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Scope Diagnostics Preserve Deterministic Precedence
+
+The system SHALL preserve project-before-user module precedence while making scope-related availability decisions explicit when they affect install or command availability.
+
+#### Scenario: Project module shadows user module during install check
+
+- **GIVEN** `<repo>/.specfact/modules/<module-name>` exists
+- **AND** `<user-home>/.specfact/modules/<module-name>` exists
+- **WHEN** the user runs `specfact module install <module-id> --scope user` from within `<repo>`
+- **THEN** the command SHALL decide whether user-scope installation is satisfied using the user-scope target root
+- **AND** the command SHALL warn if runtime command behavior in the current repository is still governed by the project-scope copy
+
+#### Scenario: Project module shadows user module during missing command diagnostic
+
+- **GIVEN** a project-scope module copy shadows a user-scope module copy with the same manifest id
+- **AND** the active project-scope copy is disabled or skipped
+- **WHEN** the user invokes a command group provided by that module
+- **THEN** the CLI SHALL identify the active project-scope origin as the source that controls command availability
+- **AND** the CLI SHALL mention that a user-scope copy exists but is shadowed in the current repository
+
+#### Scenario: User module remains available outside project scope
+
+- **GIVEN** a user-scope module is installed and enabled
+- **AND** no project-scope copy exists in the current repository root
+- **WHEN** module discovery runs from that repository
+- **THEN** command availability SHALL be based on the user-scope module
+- **AND** install diagnostics SHALL NOT imply that a project-scope module is required

--- a/openspec/changes/marketplace-07-module-install-state-consistency/tasks.md
+++ b/openspec/changes/marketplace-07-module-install-state-consistency/tasks.md
@@ -1,0 +1,44 @@
+## 1. Regression Tests and Evidence
+
+- [x] 1.1 Add a regression test where a module artifact exists but `modules.json` marks the manifest module id disabled, then `specfact module install <module-id>` reports or repairs disabled state instead of only "already installed".
+- [x] 1.2 Add a regression test where a known command group is unavailable because its module is disabled, and the CLI prints installed-but-disabled guidance.
+- [x] 1.3 Add a regression test for installed-but-skipped diagnostics covering at least one local skip reason: missing dependency, incompatible core version, schema mismatch, or integrity failure.
+- [x] 1.4 Add a regression test for bare/legacy/marketplace module identity normalization against a manifest id such as `nold-ai/specfact-codebase`.
+- [x] 1.5 Add a regression test where project and user scope contain the same module and diagnostics identify the active project origin plus the shadowed user copy.
+- [x] 1.6 Add a regression test where `specfact init --repo <repo> --profile <profile>` discovers project modules relative to `<repo>` while preserving unrelated lifecycle state.
+- [x] 1.7 Run the focused tests before implementation and record the failing-before output in `TDD_EVIDENCE.md`.
+
+## 2. Availability Classification
+
+- [x] 2.1 Add a metadata-only module availability classifier that accepts a requested module id or command group and returns absent, available, disabled, shadowed, skipped, or ambiguous status.
+- [x] 2.2 Reuse existing discovery, state merge, dependency, compatibility, schema, and integrity helpers where practical so classification matches runtime registration decisions.
+- [x] 2.3 Add canonical module identity resolution for bare names, legacy namespace names, marketplace ids, and manifest ids.
+- [x] 2.4 Cover the classifier with unit tests that do not import module command app code eagerly.
+
+## 3. Install and Missing-Command UX
+
+- [x] 3.1 Route `specfact module install` already-present checks through the availability classifier before returning success.
+- [x] 3.2 Make install report or repair installed-but-disabled modules according to the final implementation decision documented in tests.
+- [x] 3.3 Make install report installed-but-unavailable reasons for compatibility, dependency, schema, and integrity skips when those reasons are locally derivable.
+- [x] 3.4 Update known missing-command help to show installed-but-disabled, installed-but-skipped, or truly-not-installed messages.
+- [x] 3.5 Ensure normal non-debug command output remains concise and free of duplicate shadow warnings.
+
+## 4. Init/Profile State Refresh
+
+- [x] 4.1 Make `specfact init --repo <repo>` pass the selected repository path into project-scope module discovery for state refresh and prompt audits.
+- [x] 4.2 Change init/profile state writes to merge discovered rows with existing lifecycle state rather than replacing unrelated rows blindly.
+- [x] 4.3 Preserve explicit disabled states for rediscovered modules unless the user directly requests enablement.
+- [x] 4.4 Ensure profile-selected installed-but-disabled modules cannot remain in a contradictory not-installed/already-installed state without actionable output.
+
+## 5. Documentation and Source Tracking
+
+- [x] 5.1 Review and update affected user docs: `docs/module-system/installing-modules.md`, `docs/module-system/module-marketplace.md`, `docs/reference/README.md`, and `docs/core-cli/init.md` if command output or recovery guidance changes.
+- [x] 5.2 Keep GitHub issue #533 linked to the synced user story and OpenSpec change in source tracking comments or issue body.
+- [x] 5.3 Update `/home/dom/git/nold-ai/specfact-cli-internal/wiki/sources/marketplace-07-module-install-state-consistency.md` and run `python3 scripts/wiki_rebuild_graph.py` from the internal repo root when scope, dependency, or status changes.
+
+## 6. Verification
+
+- [x] 6.1 Run focused unit tests for module registry, module discovery, init module state, and missing-command diagnostics.
+- [x] 6.2 Run `openspec validate marketplace-07-module-install-state-consistency --strict`.
+- [x] 6.3 Run the repository quality gates required by the touched scope, including code review JSON generation.
+- [x] 6.4 Record passing-after verification output in `TDD_EVIDENCE.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "specfact-cli"
-version = "0.46.5"
+version = "0.46.6"
 description = "The swiss knife CLI for agile DevOps teams. Keep backlog, specs, tests, and code in sync with validation and contract enforcement for new projects and long-lived codebases."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "specfact-cli"
-version = "0.46.6"
+version = "0.46.7"
 description = "The swiss knife CLI for agile DevOps teams. Keep backlog, specs, tests, and code in sync with validation and contract enforcement for new projects and long-lived codebases."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "specfact-cli"
-version = "0.46.4"
+version = "0.46.5"
 description = "The swiss knife CLI for agile DevOps teams. Keep backlog, specs, tests, and code in sync with validation and contract enforcement for new projects and long-lived codebases."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/pre_commit_code_review.py
+++ b/scripts/pre_commit_code_review.py
@@ -111,6 +111,13 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
 
 
+def _ensure_review_runtime_dir(repo_root: Path, relative: str) -> str:
+    """Create and return a stable repo-local runtime directory for nested review tools."""
+    path = (repo_root / relative).resolve()
+    path.mkdir(parents=True, exist_ok=True)
+    return str(path)
+
+
 @beartype
 @ensure(lambda result: result is None or (isinstance(result, Path) and result.is_absolute()))
 def discover_specfact_modules_repo() -> Path | None:
@@ -153,11 +160,19 @@ def build_review_subprocess_env() -> dict[str, str]:
     installs and shell exports are left unchanged.
     """
     env: dict[str, str] = dict(os.environ)
+    repo_root = _repo_root()
     if env.get("SPECFACT_MODULES_REPO", "").strip():
-        return env
-    discovered = discover_specfact_modules_repo()
-    if discovered is not None:
-        env["SPECFACT_MODULES_REPO"] = str(discovered)
+        pass
+    else:
+        discovered = discover_specfact_modules_repo()
+        if discovered is not None:
+            env["SPECFACT_MODULES_REPO"] = str(discovered)
+
+    env["XDG_CONFIG_HOME"] = _ensure_review_runtime_dir(repo_root, ".specfact/config")
+    env["XDG_CACHE_HOME"] = _ensure_review_runtime_dir(repo_root, ".specfact/cache")
+    env["SEMGREP_VERSION_CACHE_PATH"] = _ensure_review_runtime_dir(repo_root, ".specfact/cache/semgrep")
+    semgrep_log_dir = _ensure_review_runtime_dir(repo_root, ".specfact/logs")
+    env["SEMGREP_LOG_FILE"] = str((Path(semgrep_log_dir) / "semgrep.log").resolve())
     return env
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 if __name__ == "__main__":
     _setup = setup(
         name="specfact-cli",
-        version="0.46.5",
+        version="0.46.6",
         description=(
             "The swiss knife CLI for agile DevOps teams. Keep backlog, specs, tests, and code in sync with "
             "validation and contract enforcement for new projects and long-lived codebases."

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 if __name__ == "__main__":
     _setup = setup(
         name="specfact-cli",
-        version="0.46.4",
+        version="0.46.5",
         description=(
             "The swiss knife CLI for agile DevOps teams. Keep backlog, specs, tests, and code in sync with "
             "validation and contract enforcement for new projects and long-lived codebases."

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 if __name__ == "__main__":
     _setup = setup(
         name="specfact-cli",
-        version="0.46.6",
+        version="0.46.7",
         description=(
             "The swiss knife CLI for agile DevOps teams. Keep backlog, specs, tests, and code in sync with "
             "validation and contract enforcement for new projects and long-lived codebases."

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,4 +3,4 @@ SpecFact CLI - Spec→Contract→Sentinel tool for contract-driven development.
 """
 
 # Package version: keep in sync with pyproject.toml, setup.py, src/specfact_cli/__init__.py
-__version__ = "0.46.4"
+__version__ = "0.46.5"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,4 +3,4 @@ SpecFact CLI - Spec→Contract→Sentinel tool for contract-driven development.
 """
 
 # Package version: keep in sync with pyproject.toml, setup.py, src/specfact_cli/__init__.py
-__version__ = "0.46.5"
+__version__ = "0.46.6"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,4 +3,4 @@ SpecFact CLI - Spec→Contract→Sentinel tool for contract-driven development.
 """
 
 # Package version: keep in sync with pyproject.toml, setup.py, src/specfact_cli/__init__.py
-__version__ = "0.46.6"
+__version__ = "0.46.7"

--- a/src/specfact_cli/__init__.py
+++ b/src/specfact_cli/__init__.py
@@ -45,6 +45,6 @@ def _bootstrap_bundle_paths() -> None:
 
 _bootstrap_bundle_paths()
 
-__version__ = "0.46.5"
+__version__ = "0.46.6"
 
 __all__ = ["__version__"]

--- a/src/specfact_cli/__init__.py
+++ b/src/specfact_cli/__init__.py
@@ -45,6 +45,6 @@ def _bootstrap_bundle_paths() -> None:
 
 _bootstrap_bundle_paths()
 
-__version__ = "0.46.4"
+__version__ = "0.46.5"
 
 __all__ = ["__version__"]

--- a/src/specfact_cli/__init__.py
+++ b/src/specfact_cli/__init__.py
@@ -45,6 +45,6 @@ def _bootstrap_bundle_paths() -> None:
 
 _bootstrap_bundle_paths()
 
-__version__ = "0.46.6"
+__version__ = "0.46.7"
 
 __all__ = ["__version__"]

--- a/src/specfact_cli/analyzers/code_analyzer.py
+++ b/src/specfact_cli/analyzers/code_analyzer.py
@@ -32,6 +32,24 @@ from specfact_cli.utils.feature_keys import to_classname_key, to_sequential_key
 console = Console()
 
 
+def _ensure_semgrep_runtime_dir(repo_path: Path, relative: str) -> str:
+    """Create and return a stable repo-local runtime directory for Semgrep."""
+    path = (repo_path / relative).resolve()
+    path.mkdir(parents=True, exist_ok=True)
+    return str(path)
+
+
+def _build_semgrep_env(repo_path: Path) -> dict[str, str]:
+    """Build a repo-local Semgrep runtime env so CLI startup stays deterministic."""
+    env = dict(os.environ)
+    env["XDG_CONFIG_HOME"] = _ensure_semgrep_runtime_dir(repo_path, ".specfact/config")
+    env["XDG_CACHE_HOME"] = _ensure_semgrep_runtime_dir(repo_path, ".specfact/cache")
+    env["SEMGREP_VERSION_CACHE_PATH"] = _ensure_semgrep_runtime_dir(repo_path, ".specfact/cache/semgrep")
+    semgrep_log_dir = _ensure_semgrep_runtime_dir(repo_path, ".specfact/logs")
+    env["SEMGREP_LOG_FILE"] = str((Path(semgrep_log_dir) / "semgrep.log").resolve())
+    return env
+
+
 @dataclass
 class _SemgrepFeatureBuckets:
     api_endpoints: list[str] = field(default_factory=list)
@@ -457,6 +475,7 @@ class CodeAnalyzer:
                 capture_output=True,
                 text=True,
                 timeout=5,  # Increased timeout to 5s (Semgrep may need time to initialize)
+                env=_build_semgrep_env(self.repo_path),
             )
             return result.returncode == 0
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
@@ -566,6 +585,7 @@ class CodeAnalyzer:
                 capture_output=True,
                 text=True,
                 timeout=timeout,
+                env=_build_semgrep_env(self.repo_path),
             )
 
             # Semgrep may return non-zero for valid findings

--- a/src/specfact_cli/cli.py
+++ b/src/specfact_cli/cli.py
@@ -66,6 +66,7 @@ from specfact_cli.registry import CommandRegistry
 from specfact_cli.registry.alias_manager import resolve_command
 from specfact_cli.registry.bootstrap import register_builtin_commands
 from specfact_cli.registry.metadata import CommandMetadata
+from specfact_cli.registry.module_availability import ModuleAvailabilityStatus, classify_module_availability
 from specfact_cli.runtime import get_configured_console, init_debug_log_file, set_debug_mode
 from specfact_cli.utils.progressive_disclosure import ProgressiveDisclosureGroup
 from specfact_cli.utils.structured_io import StructuredFormat
@@ -124,6 +125,28 @@ def _print_missing_bundle_command_help(invoked: str) -> None:
     module_id = _INVOKED_TO_MARKETPLACE_MODULE.get(invoked)
     console = get_configured_console()
     if module_id is not None:
+        availability = classify_module_availability(module_id=module_id, command_name=invoked)
+        if availability.status is ModuleAvailabilityStatus.DISABLED:
+            console.print(
+                f"[bold red]Module '{availability.module_id or module_id}' is installed but disabled.[/bold red]\n"
+                f"The [bold]{invoked}[/bold] command group is provided by that module. "
+                f"Enable with [bold]{availability.recovery_command}[/bold]."
+            )
+            return
+        if availability.status is ModuleAvailabilityStatus.SKIPPED:
+            console.print(
+                f"[bold red]Module '{availability.module_id or module_id}' is installed but skipped.[/bold red]\n"
+                f"Reason: {availability.reason}. "
+                "Inspect with [bold]specfact module list --show-origin[/bold]."
+            )
+            return
+        if availability.status is ModuleAvailabilityStatus.SHADOWED:
+            console.print(
+                f"[bold red]Module '{availability.module_id or module_id}' is shadowed in this workspace.[/bold red]\n"
+                f"Shadowed by: {availability.shadowed_by}. "
+                "Inspect with [bold]specfact module list --show-origin[/bold]."
+            )
+            return
         console.print(
             f"[bold red]Module '{module_id}' is not installed.[/bold red]\n"
             f"The [bold]{invoked}[/bold] command group is provided by that module. "

--- a/src/specfact_cli/modules/init/module-package.yaml
+++ b/src/specfact_cli/modules/init/module-package.yaml
@@ -1,5 +1,5 @@
 name: init
-version: 0.1.30
+version: 0.1.31
 commands:
   - init
 category: core
@@ -17,5 +17,4 @@ publisher:
 description: Initialize SpecFact workspace and bootstrap local configuration.
 license: Apache-2.0
 integrity:
-  checksum: sha256:9e03421972d3254082307834b474e7673957de8c11ffacc563f2da3f35e7cf05
-  signature: ikUYhUJ8AFU9RkB+ZBnp0lKrDLT7ZIqkauRYUMRY/swrIjRCTRzHIpNcvCmujK6h1w6EtT/+wGG1v5bZtZB8CQ==
+  checksum: sha256:0f7bc54a823bea14033fcb143ecb6c83d2bca2b5da661f03a0b545100acebe5b

--- a/src/specfact_cli/modules/init/src/commands.py
+++ b/src/specfact_cli/modules/init/src/commands.py
@@ -106,7 +106,7 @@ def _resolve_field_mapping_templates_dir(repo_path: Path) -> Path | None:
         package_templates_dir = Path(str(templates_ref)).resolve()
         if package_templates_dir.exists():
             return package_templates_dir
-    except Exception:
+    except (ImportError, OSError, ValueError):
         try:
             import importlib.util
 
@@ -118,8 +118,8 @@ def _resolve_field_mapping_templates_dir(repo_path: Path) -> Path | None:
                 ).resolve()
                 if package_templates_dir.exists():
                     return package_templates_dir
-        except Exception:
-            pass
+        except (ImportError, OSError, ValueError):
+            return None
     return None
 
 
@@ -434,7 +434,15 @@ def _is_valid_repo_path(repo: Path) -> bool:
 
 
 @beartype
-def _install_profile_bundles(profile: str, install_root: Path, non_interactive: bool) -> None:
+def _marketplace_ids_for_bundles(bundle_ids: list[str]) -> list[str]:
+    return [
+        first_run_selection.MARKETPLACE_ONLY_BUNDLES[bid]
+        for bid in bundle_ids
+        if bid in first_run_selection.MARKETPLACE_ONLY_BUNDLES
+    ]
+
+
+def _install_profile_bundles(profile: str, install_root: Path, non_interactive: bool) -> list[str]:
     """Resolve profile to bundle list and install via module installer."""
     bundle_ids = first_run_selection.resolve_profile_bundles(profile)
     if bundle_ids:
@@ -444,10 +452,11 @@ def _install_profile_bundles(profile: str, install_root: Path, non_interactive: 
             install_root,
             non_interactive=non_interactive,
         )
+    return _marketplace_ids_for_bundles(bundle_ids)
 
 
 @beartype
-def _install_bundle_list(install_arg: str, install_root: Path, non_interactive: bool) -> None:
+def _install_bundle_list(install_arg: str, install_root: Path, non_interactive: bool) -> list[str]:
     """Parse comma-separated or 'all' and install bundles via module installer."""
     bundle_ids = first_run_selection.resolve_install_bundles(install_arg)
     if bundle_ids:
@@ -457,18 +466,30 @@ def _install_bundle_list(install_arg: str, install_root: Path, non_interactive: 
             install_root,
             non_interactive=non_interactive,
         )
+    return _marketplace_ids_for_bundles(bundle_ids)
 
 
-def _apply_profile_or_install_bundles(profile: str | None, install: str | None) -> None:
+def _apply_profile_or_install_bundles(profile: str | None, install: str | None) -> list[str]:
     try:
         non_interactive = is_non_interactive()
         if profile is not None:
-            _install_profile_bundles(profile, INIT_USER_MODULES_ROOT, non_interactive=non_interactive)
-        else:
-            _install_bundle_list(install or "", INIT_USER_MODULES_ROOT, non_interactive=non_interactive)
+            return _install_profile_bundles(profile, INIT_USER_MODULES_ROOT, non_interactive=non_interactive)
+        return _install_bundle_list(install or "", INIT_USER_MODULES_ROOT, non_interactive=non_interactive)
     except ValueError as e:
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1) from e
+
+
+def _refresh_init_module_state(repo_path: Path, enabled_module_ids: list[str]) -> list[dict[str, Any]]:
+    modules_list = get_discovered_modules_for_state(
+        enable_ids=enabled_module_ids,
+        disable_ids=[],
+        base_path=repo_path,
+        preserve_existing=True,
+    )
+    if modules_list:
+        write_modules_state(modules_list)
+    return modules_list
 
 
 def _run_interactive_first_run_install() -> None:
@@ -702,8 +723,9 @@ def init(
 
         repo_path = repo.resolve()
 
+        enabled_module_ids: list[str] = []
         if profile is not None or install is not None:
-            _apply_profile_or_install_bundles(profile, install)
+            enabled_module_ids = _apply_profile_or_install_bundles(profile, install)
         elif is_first_run(user_root=INIT_USER_MODULES_ROOT) and is_non_interactive():
             console.print(
                 "[red]Error:[/red] In CI/CD (non-interactive) mode, first-run init requires "
@@ -718,9 +740,7 @@ def init(
             _run_interactive_first_run_install()
 
         _init_user_visible_step("[cyan]→[/cyan] Discovering installed modules and writing registry state…")
-        modules_list = get_discovered_modules_for_state(enable_ids=[], disable_ids=[])
-        if modules_list:
-            write_modules_state(modules_list)
+        modules_list = _refresh_init_module_state(repo_path, enabled_module_ids)
 
         _init_user_visible_step("[cyan]→[/cyan] Indexing CLI commands for help cache…")
         run_discovery_and_write_cache(__version__)

--- a/src/specfact_cli/modules/module_registry/module-package.yaml
+++ b/src/specfact_cli/modules/module_registry/module-package.yaml
@@ -1,5 +1,5 @@
 name: module-registry
-version: 0.1.20
+version: 0.1.21
 commands:
   - module
 category: core
@@ -17,5 +17,4 @@ publisher:
 description: 'Manage modules: search, list, show, install, and upgrade.'
 license: Apache-2.0
 integrity:
-  checksum: sha256:a92afa757a54ee63b84ae4a5f5b232cb5dbddacfcb31fcde3abcdb4927eada8c
-  signature: jelDGPZyCLLpyzqH4+S2t7V9ICy/puYEzdUu/GX0oPiWgMZRg8aZlnECZGy+m+sHvS0XX3hPAXCSp3IJf6hHDg==
+  checksum: sha256:b14f0a8720f0fb87d1dbbf6ff7f0501564453a21d29b2815cedb228b72d951ae

--- a/src/specfact_cli/modules/module_registry/module-package.yaml
+++ b/src/specfact_cli/modules/module_registry/module-package.yaml
@@ -1,5 +1,5 @@
 name: module-registry
-version: 0.1.22
+version: 0.1.23
 commands:
   - module
 category: core

--- a/src/specfact_cli/modules/module_registry/module-package.yaml
+++ b/src/specfact_cli/modules/module_registry/module-package.yaml
@@ -1,5 +1,5 @@
 name: module-registry
-version: 0.1.21
+version: 0.1.22
 commands:
   - module
 category: core

--- a/src/specfact_cli/modules/module_registry/src/commands.py
+++ b/src/specfact_cli/modules/module_registry/src/commands.py
@@ -27,7 +27,7 @@ from specfact_cli.registry.alias_manager import create_alias, list_aliases, remo
 from specfact_cli.registry.custom_registries import add_registry, fetch_all_indexes, list_registries, remove_registry
 from specfact_cli.registry.help_cache import run_discovery_and_write_cache
 from specfact_cli.registry.marketplace_client import fetch_registry_index
-from specfact_cli.registry.module_discovery import discover_all_modules
+from specfact_cli.registry.module_discovery import discover_all_modules, discover_all_modules_for_project
 from specfact_cli.registry.module_installer import (
     REGISTRY_ID_FILE,
     USER_MODULES_ROOT,
@@ -195,27 +195,33 @@ def _read_installed_manifest_id(module_dir: Path, fallback_name: str) -> str:
     return fallback_name
 
 
-def _enable_if_disabled(module_id: str) -> bool:
+def _enable_if_disabled(module_id: str, base_path: Path | None = None) -> bool:
     state = read_modules_state()
     if state.get(module_id, {}).get("enabled", True) is not False:
         return False
-    modules = get_discovered_modules_for_state(enable_ids=[module_id], disable_ids=[], preserve_existing=True)
+    modules = get_discovered_modules_for_state(
+        enable_ids=[module_id],
+        disable_ids=[],
+        base_path=base_path,
+        preserve_existing=True,
+    )
     write_modules_state(modules)
     run_discovery_and_write_cache(__version__)
-    return True
+    return any(str(row.get("id", "")) == module_id and bool(row.get("enabled", True)) for row in modules)
 
 
 def _install_skip_if_already_satisfied(
     scope_normalized: str,
     requested_name: str,
     target_root: Path,
+    repo: Path | None,
     reinstall: bool,
     discovered_by_name: dict[str, Any],
 ) -> bool:
     installed_dir = target_root / requested_name
     if (installed_dir / "module-package.yaml").exists() and not reinstall:
         module_id = _read_installed_manifest_id(installed_dir, requested_name)
-        enabled = _enable_if_disabled(module_id)
+        enabled = _enable_if_disabled(module_id, base_path=repo if scope_normalized == "project" else None)
         if enabled:
             console.print(
                 f"[yellow]Module '{module_id}' is already installed in {target_root}; "
@@ -231,7 +237,10 @@ def _install_skip_if_already_satisfied(
         skip_sources.discard("project")
     existing = discovered_by_name.get(requested_name)
     if existing is not None and existing.source in skip_sources:
-        enabled = _enable_if_disabled(existing.metadata.name)
+        enabled = _enable_if_disabled(
+            existing.metadata.name,
+            base_path=repo if scope_normalized == "project" else None,
+        )
         state_hint = " Enabled it in module state." if enabled else ""
         console.print(
             f"[yellow]Module '{existing.metadata.name}' is already available from source '{existing.source}'. "
@@ -312,6 +321,7 @@ class _InstallOneParams:
     scope_normalized: str
     source_normalized: str
     target_root: Path
+    repo: Path | None
     version: str | None
     reinstall: bool
     trust_non_official: bool
@@ -327,6 +337,7 @@ def _install_one(module_id: str, params: _InstallOneParams) -> bool:
         params.scope_normalized,
         requested_name,
         params.target_root,
+        params.repo,
         params.reinstall,
         params.discovered_by_name,
     ):
@@ -431,11 +442,13 @@ def _install_impl(module_ids: list[str], **kwargs: Any) -> None:
         raise typer.Exit(1)
     scope_normalized, source_normalized = _parse_install_scope_and_source(scope, source)
     target_root = _resolve_install_target_root(scope_normalized, repo)
-    discovered_by_name = {entry.metadata.name: entry for entry in discover_all_modules()}
+    discovered = discover_all_modules_for_project(repo) if repo is not None else discover_all_modules()
+    discovered_by_name = {entry.metadata.name: entry for entry in discovered}
     params = _InstallOneParams(
         scope_normalized=scope_normalized,
         source_normalized=source_normalized,
         target_root=target_root,
+        repo=repo,
         version=version,
         reinstall=reinstall,
         trust_non_official=trust_non_official,

--- a/src/specfact_cli/modules/module_registry/src/commands.py
+++ b/src/specfact_cli/modules/module_registry/src/commands.py
@@ -182,6 +182,17 @@ def _resolve_install_target_root(scope_normalized: str, repo: Path | None) -> Pa
     return USER_MODULES_ROOT if scope_normalized == "user" else repo_path / ".specfact" / "modules"
 
 
+def _normalize_project_repo(repo: Path | None) -> Path | None:
+    """Resolve a project-scoped repo argument to the nearest workspace root."""
+    if repo is None:
+        return None
+    repo_path = repo.resolve()
+    for candidate in [repo_path, *repo_path.parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    return repo_path
+
+
 def _read_installed_manifest_id(module_dir: Path, fallback_name: str) -> str:
     manifest_path = module_dir / "module-package.yaml"
     try:
@@ -441,14 +452,17 @@ def _install_impl(module_ids: list[str], **kwargs: Any) -> None:
         )
         raise typer.Exit(1)
     scope_normalized, source_normalized = _parse_install_scope_and_source(scope, source)
-    target_root = _resolve_install_target_root(scope_normalized, repo)
-    discovered = discover_all_modules_for_project(repo) if repo is not None else discover_all_modules()
+    normalized_repo = _normalize_project_repo(repo) if scope_normalized == "project" else None
+    target_root = _resolve_install_target_root(scope_normalized, normalized_repo)
+    discovered = (
+        discover_all_modules_for_project(normalized_repo) if normalized_repo is not None else discover_all_modules()
+    )
     discovered_by_name = {entry.metadata.name: entry for entry in discovered}
     params = _InstallOneParams(
         scope_normalized=scope_normalized,
         source_normalized=source_normalized,
         target_root=target_root,
-        repo=repo,
+        repo=normalized_repo,
         version=version,
         reinstall=reinstall,
         trust_non_official=trust_non_official,

--- a/src/specfact_cli/modules/module_registry/src/commands.py
+++ b/src/specfact_cli/modules/module_registry/src/commands.py
@@ -20,10 +20,12 @@ from packaging.version import InvalidVersion, Version
 from rich.console import Console
 from rich.table import Table
 
+from specfact_cli import __version__
 from specfact_cli.models.module_package import ModulePackageMetadata
 from specfact_cli.modules import module_io_shim
 from specfact_cli.registry.alias_manager import create_alias, list_aliases, remove_alias
 from specfact_cli.registry.custom_registries import add_registry, fetch_all_indexes, list_registries, remove_registry
+from specfact_cli.registry.help_cache import run_discovery_and_write_cache
 from specfact_cli.registry.marketplace_client import fetch_registry_index
 from specfact_cli.registry.module_discovery import discover_all_modules
 from specfact_cli.registry.module_installer import (
@@ -42,7 +44,9 @@ from specfact_cli.registry.module_lifecycle import (
     render_modules_table,
     select_module_ids_interactive,
 )
+from specfact_cli.registry.module_packages import get_discovered_modules_for_state
 from specfact_cli.registry.module_security import ensure_publisher_trusted, is_official_publisher
+from specfact_cli.registry.module_state import read_modules_state, write_modules_state
 from specfact_cli.registry.registry import CommandRegistry
 from specfact_cli.runtime import is_non_interactive
 
@@ -178,6 +182,29 @@ def _resolve_install_target_root(scope_normalized: str, repo: Path | None) -> Pa
     return USER_MODULES_ROOT if scope_normalized == "user" else repo_path / ".specfact" / "modules"
 
 
+def _read_installed_manifest_id(module_dir: Path, fallback_name: str) -> str:
+    manifest_path = module_dir / "module-package.yaml"
+    try:
+        raw = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return fallback_name
+    if isinstance(raw, dict):
+        manifest = cast(dict[str, Any], raw)
+        if manifest.get("name"):
+            return str(manifest["name"])
+    return fallback_name
+
+
+def _enable_if_disabled(module_id: str) -> bool:
+    state = read_modules_state()
+    if state.get(module_id, {}).get("enabled", True) is not False:
+        return False
+    modules = get_discovered_modules_for_state(enable_ids=[module_id], disable_ids=[], preserve_existing=True)
+    write_modules_state(modules)
+    run_discovery_and_write_cache(__version__)
+    return True
+
+
 def _install_skip_if_already_satisfied(
     scope_normalized: str,
     requested_name: str,
@@ -185,8 +212,17 @@ def _install_skip_if_already_satisfied(
     reinstall: bool,
     discovered_by_name: dict[str, Any],
 ) -> bool:
-    if (target_root / requested_name / "module-package.yaml").exists() and not reinstall:
-        console.print(f"[yellow]Module '{requested_name}' is already installed in {target_root}.[/yellow]")
+    installed_dir = target_root / requested_name
+    if (installed_dir / "module-package.yaml").exists() and not reinstall:
+        module_id = _read_installed_manifest_id(installed_dir, requested_name)
+        enabled = _enable_if_disabled(module_id)
+        if enabled:
+            console.print(
+                f"[yellow]Module '{module_id}' is already installed in {target_root}; "
+                "enabled it in module state.[/yellow]"
+            )
+        else:
+            console.print(f"[yellow]Module '{module_id}' is already installed in {target_root}.[/yellow]")
         return True
     skip_sources = {"builtin", "project", "user", "custom"}
     if scope_normalized == "project":
@@ -195,9 +231,11 @@ def _install_skip_if_already_satisfied(
         skip_sources.discard("project")
     existing = discovered_by_name.get(requested_name)
     if existing is not None and existing.source in skip_sources:
+        enabled = _enable_if_disabled(existing.metadata.name)
+        state_hint = " Enabled it in module state." if enabled else ""
         console.print(
-            f"[yellow]Module '{requested_name}' is already available from source '{existing.source}'. "
-            "No marketplace install needed.[/yellow]"
+            f"[yellow]Module '{existing.metadata.name}' is already available from source '{existing.source}'. "
+            f"No marketplace install needed.{state_hint}[/yellow]"
         )
         return True
     return False

--- a/src/specfact_cli/registry/module_availability.py
+++ b/src/specfact_cli/registry/module_availability.py
@@ -53,6 +53,8 @@ def _module_id_matches(requested: str | None, discovered_id: str) -> bool:
     if requested is None:
         return False
     requested_clean = requested.strip()
+    if "/" in requested_clean:
+        return requested_clean == discovered_id
     return requested_clean == discovered_id or _module_id_tail(requested_clean) == _module_id_tail(discovered_id)
 
 
@@ -74,6 +76,8 @@ def _availability_matches(
     module_matches = [entry for entry in discovered if _module_id_matches(module_id, entry.metadata.name)]
     if module_matches:
         return module_matches
+    if module_id is not None and "/" in module_id.strip():
+        return []
     return [entry for entry in discovered if _entry_matches(entry, module_id=module_id, command_name=command_name)]
 
 

--- a/src/specfact_cli/registry/module_availability.py
+++ b/src/specfact_cli/registry/module_availability.py
@@ -1,0 +1,187 @@
+"""Metadata-only module availability classification for user-facing diagnostics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+from beartype import beartype
+from icontract import ensure, require
+
+from specfact_cli import __version__ as cli_version
+from specfact_cli.registry.module_discovery import DiscoveredModule, discover_all_modules_for_project
+from specfact_cli.registry.module_packages import (
+    _check_core_compatibility,
+    _validate_module_dependencies,
+    merge_module_state,
+)
+from specfact_cli.registry.module_state import read_modules_state
+
+
+class ModuleAvailabilityStatus(StrEnum):
+    """User-facing module availability states."""
+
+    ABSENT = "absent"
+    AVAILABLE = "available"
+    DISABLED = "disabled"
+    SKIPPED = "skipped"
+    SHADOWED = "shadowed"
+    AMBIGUOUS = "ambiguous"
+
+
+@dataclass(frozen=True)
+class ModuleAvailability:
+    """Availability classification without importing module command code."""
+
+    status: ModuleAvailabilityStatus
+    module_id: str | None = None
+    source: str | None = None
+    package_dir: Path | None = None
+    reason: str = ""
+    recovery_command: str = ""
+    shadowed_by: Path | None = None
+
+
+def _module_id_tail(module_id: str) -> str:
+    """Return the final path segment of a module id."""
+    return module_id.rsplit("/", 1)[-1].strip()
+
+
+def _module_id_matches(requested: str | None, discovered_id: str) -> bool:
+    """Return True when a requested module id refers to a discovered manifest id."""
+    if requested is None:
+        return False
+    requested_clean = requested.strip()
+    return requested_clean == discovered_id or _module_id_tail(requested_clean) == _module_id_tail(discovered_id)
+
+
+def _entry_matches(entry: DiscoveredModule, *, module_id: str | None, command_name: str | None) -> bool:
+    meta = entry.metadata
+    if _module_id_matches(module_id, meta.name):
+        return True
+    if command_name is None:
+        return False
+    return command_name in set(meta.commands) or getattr(meta, "bundle_group_command", None) == command_name
+
+
+def _availability_matches(
+    discovered: list[DiscoveredModule],
+    *,
+    module_id: str | None,
+    command_name: str | None,
+) -> list[DiscoveredModule]:
+    module_matches = [entry for entry in discovered if _module_id_matches(module_id, entry.metadata.name)]
+    if module_matches:
+        return module_matches
+    return [entry for entry in discovered if _entry_matches(entry, module_id=module_id, command_name=command_name)]
+
+
+def _recovery_command(status: ModuleAvailabilityStatus, module_id: str) -> str:
+    if status is ModuleAvailabilityStatus.DISABLED:
+        return f"specfact module enable {module_id}"
+    if status is ModuleAvailabilityStatus.ABSENT:
+        return f"specfact module install {module_id}"
+    return ""
+
+
+def _skip_reason(entry: DiscoveredModule, enabled_map: dict[str, bool]) -> str:
+    meta = entry.metadata
+    if not _check_core_compatibility(meta, cli_version):
+        return f"requires {meta.core_compatibility}, cli is {cli_version}"
+    deps_ok, missing = _validate_module_dependencies(meta, enabled_map)
+    if not deps_ok:
+        return f"missing dependencies: {', '.join(missing)}"
+    return ""
+
+
+def _absent_availability(module_id: str | None, requested_id: str) -> ModuleAvailability:
+    return ModuleAvailability(
+        status=ModuleAvailabilityStatus.ABSENT,
+        module_id=module_id,
+        reason="not installed",
+        recovery_command=_recovery_command(ModuleAvailabilityStatus.ABSENT, requested_id) if requested_id else "",
+    )
+
+
+def _shadowed_duplicate(primary: DiscoveredModule, matches: list[DiscoveredModule]) -> DiscoveredModule | None:
+    duplicate = next((entry for entry in matches[1:] if entry.metadata.name == primary.metadata.name), None)
+    if duplicate is None:
+        return None
+    if primary.source == "project" and duplicate.source in {"user", "marketplace"}:
+        return duplicate
+    return None
+
+
+def _shadowed_availability(primary: DiscoveredModule, duplicate: DiscoveredModule) -> ModuleAvailability:
+    return ModuleAvailability(
+        status=ModuleAvailabilityStatus.SHADOWED,
+        module_id=duplicate.metadata.name,
+        source=duplicate.source,
+        package_dir=duplicate.package_dir,
+        reason=f"shadowed by {primary.source} scope",
+        shadowed_by=primary.package_dir,
+    )
+
+
+def _disabled_availability(primary: DiscoveredModule) -> ModuleAvailability:
+    module_name = primary.metadata.name
+    return ModuleAvailability(
+        status=ModuleAvailabilityStatus.DISABLED,
+        module_id=module_name,
+        source=primary.source,
+        package_dir=primary.package_dir,
+        reason="disabled in modules.json",
+        recovery_command=_recovery_command(ModuleAvailabilityStatus.DISABLED, module_name),
+    )
+
+
+def _available_or_skipped_availability(
+    primary: DiscoveredModule,
+    enabled_map: dict[str, bool],
+) -> ModuleAvailability:
+    reason = _skip_reason(primary, enabled_map)
+    if reason:
+        return ModuleAvailability(
+            status=ModuleAvailabilityStatus.SKIPPED,
+            module_id=primary.metadata.name,
+            source=primary.source,
+            package_dir=primary.package_dir,
+            reason=reason,
+        )
+    return ModuleAvailability(
+        status=ModuleAvailabilityStatus.AVAILABLE,
+        module_id=primary.metadata.name,
+        source=primary.source,
+        package_dir=primary.package_dir,
+    )
+
+
+@beartype
+@require(
+    lambda module_id, command_name, base_path: bool(module_id or command_name), "module_id or command_name required"
+)
+@ensure(lambda result: isinstance(result, ModuleAvailability), "must return module availability")
+def classify_module_availability(
+    *,
+    module_id: str | None = None,
+    command_name: str | None = None,
+    base_path: Path | None = None,
+) -> ModuleAvailability:
+    """Classify module availability using manifests and modules.json only."""
+    discovered = discover_all_modules_for_project(base_path)
+    matches = _availability_matches(discovered, module_id=module_id, command_name=command_name)
+    requested_id = module_id or command_name or ""
+    if not matches:
+        return _absent_availability(module_id, requested_id)
+
+    discovered_list = [(entry.metadata.name, entry.metadata.version) for entry in discovered]
+    enabled_map = merge_module_state(discovered_list, read_modules_state(), [], [])
+    primary = matches[0]
+    module_name = primary.metadata.name
+    duplicate = _shadowed_duplicate(primary, matches)
+    if duplicate is not None:
+        return _shadowed_availability(primary, duplicate)
+    if not enabled_map.get(module_name, True):
+        return _disabled_availability(primary)
+    return _available_or_skipped_availability(primary, enabled_map)

--- a/src/specfact_cli/registry/module_availability.py
+++ b/src/specfact_cli/registry/module_availability.py
@@ -10,7 +10,7 @@ from beartype import beartype
 from icontract import ensure, require
 
 from specfact_cli import __version__ as cli_version
-from specfact_cli.registry.module_discovery import DiscoveredModule, discover_all_modules_for_project
+from specfact_cli.registry.module_discovery import DiscoveredModule, discover_all_modules_for_project_with_shadowed
 from specfact_cli.registry.module_packages import (
     _check_core_compatibility,
     _validate_module_dependencies,
@@ -169,7 +169,7 @@ def classify_module_availability(
     base_path: Path | None = None,
 ) -> ModuleAvailability:
     """Classify module availability using manifests and modules.json only."""
-    discovered = discover_all_modules_for_project(base_path)
+    discovered = discover_all_modules_for_project_with_shadowed(base_path)
     matches = _availability_matches(discovered, module_id=module_id, command_name=command_name)
     requested_id = module_id or command_name or ""
     if not matches:

--- a/src/specfact_cli/registry/module_discovery.py
+++ b/src/specfact_cli/registry/module_discovery.py
@@ -29,6 +29,23 @@ class DiscoveredModule:
     source: str
 
 
+@dataclass(frozen=True)
+class _DiscoveryRootOptions:
+    builtin_root: Path | None = None
+    user_root: Path | None = None
+    marketplace_root: Path | None = None
+    custom_root: Path | None = None
+    include_legacy_roots: bool | None = None
+    project_base_path: Path | None = None
+
+
+@dataclass
+class _DiscoveryMergeState:
+    seen_by_name: dict[str, DiscoveredModule]
+    discovered: list[DiscoveredModule]
+    logger: Any
+
+
 def _resolve_include_legacy_roots(
     include_legacy_roots: bool | None,
     builtin_root: Path | None,
@@ -53,20 +70,14 @@ def _append_legacy_module_roots(roots: list[tuple[str, Path]]) -> None:
         roots.append(("custom", extra_root))
 
 
-def _discovery_root_list(
-    builtin_root: Path | None,
-    user_root: Path | None,
-    marketplace_root: Path | None,
-    custom_root: Path | None,
-    include_legacy_roots: bool | None,
-) -> list[tuple[str, Path]]:
+def _discovery_root_list(options: _DiscoveryRootOptions) -> list[tuple[str, Path]]:
     from specfact_cli.registry.module_packages import get_modules_root, get_workspace_modules_root
 
-    effective_builtin_root = builtin_root or get_modules_root()
-    effective_project_root = get_workspace_modules_root()
-    effective_user_root = user_root or USER_MODULES_ROOT
-    effective_marketplace_root = marketplace_root or MARKETPLACE_MODULES_ROOT
-    effective_custom_root = custom_root or CUSTOM_MODULES_ROOT
+    effective_builtin_root = options.builtin_root or get_modules_root()
+    effective_project_root = get_workspace_modules_root(options.project_base_path)
+    effective_user_root = options.user_root or USER_MODULES_ROOT
+    effective_marketplace_root = options.marketplace_root or MARKETPLACE_MODULES_ROOT
+    effective_custom_root = options.custom_root or CUSTOM_MODULES_ROOT
 
     roots: list[tuple[str, Path]] = [("builtin", effective_builtin_root)]
     project_matches_user_root = False
@@ -86,7 +97,13 @@ def _discovery_root_list(
         ]
     )
 
-    legacy = _resolve_include_legacy_roots(include_legacy_roots, builtin_root, user_root, marketplace_root, custom_root)
+    legacy = _resolve_include_legacy_roots(
+        options.include_legacy_roots,
+        options.builtin_root,
+        options.user_root,
+        options.marketplace_root,
+        options.custom_root,
+    )
     if legacy:
         _append_legacy_module_roots(roots)
     return roots
@@ -121,16 +138,14 @@ def _merge_discovered_entry(
     source: str,
     package_dir: Path,
     metadata: ModulePackageMetadata,
-    seen_by_name: dict[str, DiscoveredModule],
-    discovered: list[DiscoveredModule],
-    logger: Any,
+    state: _DiscoveryMergeState,
 ) -> None:
     module_name = metadata.name
-    if module_name in seen_by_name:
-        existing = seen_by_name[module_name]
+    if module_name in state.seen_by_name:
+        existing = state.seen_by_name[module_name]
         _maybe_warn_user_shadowed_by_project(module_name, source, package_dir, existing)
         if source in {"user", "marketplace", "custom"}:
-            logger.debug(
+            state.logger.debug(
                 "Module '%s' from %s at '%s' is shadowed by higher-priority source %s at '%s'.",
                 module_name,
                 source,
@@ -144,8 +159,31 @@ def _merge_discovered_entry(
         metadata=metadata,
         source=source,
     )
-    seen_by_name[module_name] = entry
-    discovered.append(entry)
+    state.seen_by_name[module_name] = entry
+    state.discovered.append(entry)
+
+
+def _discover_modules(options: _DiscoveryRootOptions) -> list[DiscoveredModule]:
+    """Discover modules from all configured locations with deterministic priority."""
+    from specfact_cli.registry.module_packages import discover_package_metadata
+
+    logger = get_bridge_logger(__name__)
+    discovered: list[DiscoveredModule] = []
+    merge_state = _DiscoveryMergeState(
+        seen_by_name={},
+        discovered=discovered,
+        logger=logger,
+    )
+    roots = _discovery_root_list(options)
+
+    for source, root in roots:
+        if not root.exists() or not root.is_dir():
+            continue
+        entries = discover_package_metadata(root, source=source)
+        for package_dir, metadata in entries:
+            _merge_discovered_entry(source, package_dir, metadata, merge_state)
+
+    return discovered
 
 
 @beartype
@@ -158,18 +196,19 @@ def discover_all_modules(
     include_legacy_roots: bool | None = None,
 ) -> list[DiscoveredModule]:
     """Discover modules from all configured locations with deterministic priority."""
-    from specfact_cli.registry.module_packages import discover_package_metadata
+    return _discover_modules(
+        _DiscoveryRootOptions(
+            builtin_root=builtin_root,
+            user_root=user_root,
+            marketplace_root=marketplace_root,
+            custom_root=custom_root,
+            include_legacy_roots=include_legacy_roots,
+        )
+    )
 
-    logger = get_bridge_logger(__name__)
-    discovered: list[DiscoveredModule] = []
-    seen_by_name: dict[str, DiscoveredModule] = {}
-    roots = _discovery_root_list(builtin_root, user_root, marketplace_root, custom_root, include_legacy_roots)
 
-    for source, root in roots:
-        if not root.exists() or not root.is_dir():
-            continue
-        entries = discover_package_metadata(root, source=source)
-        for package_dir, metadata in entries:
-            _merge_discovered_entry(source, package_dir, metadata, seen_by_name, discovered, logger)
-
-    return discovered
+@beartype
+@ensure(lambda result: isinstance(result, list), "Discovery result must be a list")
+def discover_all_modules_for_project(base_path: Path | None = None) -> list[DiscoveredModule]:
+    """Discover modules using a specific project path for workspace-local roots."""
+    return _discover_modules(_DiscoveryRootOptions(project_base_path=base_path))

--- a/src/specfact_cli/registry/module_discovery.py
+++ b/src/specfact_cli/registry/module_discovery.py
@@ -37,6 +37,7 @@ class _DiscoveryRootOptions:
     custom_root: Path | None = None
     include_legacy_roots: bool | None = None
     project_base_path: Path | None = None
+    include_shadowed_duplicates: bool = False
 
 
 @dataclass
@@ -139,11 +140,20 @@ def _merge_discovered_entry(
     package_dir: Path,
     metadata: ModulePackageMetadata,
     state: _DiscoveryMergeState,
+    include_shadowed_duplicates: bool,
 ) -> None:
     module_name = metadata.name
     if module_name in state.seen_by_name:
         existing = state.seen_by_name[module_name]
         _maybe_warn_user_shadowed_by_project(module_name, source, package_dir, existing)
+        if include_shadowed_duplicates:
+            state.discovered.append(
+                DiscoveredModule(
+                    package_dir=package_dir,
+                    metadata=metadata,
+                    source=source,
+                )
+            )
         if source in {"user", "marketplace", "custom"}:
             state.logger.debug(
                 "Module '%s' from %s at '%s' is shadowed by higher-priority source %s at '%s'.",
@@ -181,7 +191,13 @@ def _discover_modules(options: _DiscoveryRootOptions) -> list[DiscoveredModule]:
             continue
         entries = discover_package_metadata(root, source=source)
         for package_dir, metadata in entries:
-            _merge_discovered_entry(source, package_dir, metadata, merge_state)
+            _merge_discovered_entry(
+                source,
+                package_dir,
+                metadata,
+                merge_state,
+                options.include_shadowed_duplicates,
+            )
 
     return discovered
 
@@ -212,3 +228,15 @@ def discover_all_modules(
 def discover_all_modules_for_project(base_path: Path | None = None) -> list[DiscoveredModule]:
     """Discover modules using a specific project path for workspace-local roots."""
     return _discover_modules(_DiscoveryRootOptions(project_base_path=base_path))
+
+
+@beartype
+@ensure(lambda result: isinstance(result, list), "Discovery result must be a list")
+def discover_all_modules_for_project_with_shadowed(base_path: Path | None = None) -> list[DiscoveredModule]:
+    """Discover modules for a project path and retain lower-priority shadowed duplicates."""
+    return _discover_modules(
+        _DiscoveryRootOptions(
+            project_base_path=base_path,
+            include_shadowed_duplicates=True,
+        )
+    )

--- a/src/specfact_cli/registry/module_packages.py
+++ b/src/specfact_cli/registry/module_packages.py
@@ -195,11 +195,11 @@ def get_workspace_modules_root(base_path: Path | None = None) -> Path | None:
 
 @beartype
 @ensure(lambda result: isinstance(result, list), "Must return a list of (Path, metadata) tuples")
-def discover_all_package_metadata() -> list[tuple[Path, ModulePackageMetadata]]:
+def discover_all_package_metadata(base_path: Path | None = None) -> list[tuple[Path, ModulePackageMetadata]]:
     """Discover module package metadata across built-in/marketplace/custom roots."""
-    from specfact_cli.registry.module_discovery import discover_all_modules
+    from specfact_cli.registry.module_discovery import discover_all_modules, discover_all_modules_for_project
 
-    discovered = discover_all_modules()
+    discovered = discover_all_modules() if base_path is None else discover_all_modules_for_project(base_path)
     return [(entry.package_dir, entry.metadata) for entry in discovered]
 
 
@@ -1424,6 +1424,8 @@ def register_module_package_commands(
 def get_discovered_modules_for_state(
     enable_ids: list[str] | None = None,
     disable_ids: list[str] | None = None,
+    base_path: Path | None = None,
+    preserve_existing: bool = False,
 ) -> list[dict[str, Any]]:
     """
     Discover packages, merge with state, apply overrides; return list for modules.json.
@@ -1431,12 +1433,26 @@ def get_discovered_modules_for_state(
     """
     enable_ids = enable_ids or []
     disable_ids = disable_ids or []
-    packages = discover_all_package_metadata()
+    packages = discover_all_package_metadata(base_path=base_path)
     packages = sorted(packages, key=_package_sort_key)
     discovered_list = [(meta.name, meta.version) for _dir, meta in packages]
     state = read_modules_state()
     enabled_map = merge_module_state(discovered_list, state, enable_ids, disable_ids)
-    return [
+    modules: list[dict[str, Any]] = [
         {"id": meta.name, "version": meta.version, "enabled": enabled_map.get(meta.name, True)}
         for _dir, meta in packages
     ]
+    if preserve_existing:
+        discovered_ids = {str(module["id"]) for module in modules}
+        for module_id, row in sorted(state.items()):
+            if module_id in discovered_ids:
+                continue
+            state_row = cast(dict[str, Any], row)
+            modules.append(
+                {
+                    "id": module_id,
+                    "version": str(state_row.get("version", "")),
+                    "enabled": bool(state_row.get("enabled", True)),
+                }
+            )
+    return modules

--- a/tests/integration/scripts/test_check_local_version_ahead_of_pypi_integration.py
+++ b/tests/integration/scripts/test_check_local_version_ahead_of_pypi_integration.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 
 import pytest
+
+
+def _project_version_from_pyproject_bytes(content: bytes) -> str:
+    return tomllib.loads(content.decode("utf-8"))["project"]["version"].strip()
 
 
 @pytest.mark.integration
@@ -33,6 +38,20 @@ def test_script_exits_zero_skip_when_version_matches_head_without_skip_env() -> 
     """Clean trees match HEAD; skip path avoids PyPI (no lenient network needed)."""
     repo_root = Path(__file__).resolve().parents[3]
     script = repo_root / "scripts" / "check_local_version_ahead_of_pypi.py"
+    local_version = tomllib.loads((repo_root / "pyproject.toml").read_text(encoding="utf-8"))["project"]["version"].strip()
+    head_pyproject = subprocess.run(
+        ["git", "show", "HEAD:pyproject.toml"],
+        check=False,
+        capture_output=True,
+        cwd=str(repo_root),
+        timeout=30,
+    )
+    if head_pyproject.returncode != 0:
+        pytest.skip("HEAD:pyproject.toml unavailable in this checkout")
+    head_version = _project_version_from_pyproject_bytes(head_pyproject.stdout)
+    if local_version != head_version:
+        pytest.skip(f"working tree version {local_version!r} differs from HEAD {head_version!r}")
+
     completed = subprocess.run(
         [
             sys.executable,

--- a/tests/integration/scripts/test_check_local_version_ahead_of_pypi_integration.py
+++ b/tests/integration/scripts/test_check_local_version_ahead_of_pypi_integration.py
@@ -38,7 +38,9 @@ def test_script_exits_zero_skip_when_version_matches_head_without_skip_env() -> 
     """Clean trees match HEAD; skip path avoids PyPI (no lenient network needed)."""
     repo_root = Path(__file__).resolve().parents[3]
     script = repo_root / "scripts" / "check_local_version_ahead_of_pypi.py"
-    local_version = tomllib.loads((repo_root / "pyproject.toml").read_text(encoding="utf-8"))["project"]["version"].strip()
+    local_version = tomllib.loads((repo_root / "pyproject.toml").read_text(encoding="utf-8"))["project"][
+        "version"
+    ].strip()
     head_pyproject = subprocess.run(
         ["git", "show", "HEAD:pyproject.toml"],
         check=False,

--- a/tests/unit/analyzers/test_code_analyzer.py
+++ b/tests/unit/analyzers/test_code_analyzer.py
@@ -5,13 +5,15 @@ Focus: Business logic and edge cases only (@beartype handles type validation).
 
 import ast
 import os
+import subprocess
 import tempfile
 from pathlib import Path
 from textwrap import dedent
+from unittest.mock import patch
 
 import pytest
 
-from specfact_cli.analyzers.code_analyzer import CodeAnalyzer
+from specfact_cli.analyzers.code_analyzer import CodeAnalyzer, _build_semgrep_env
 
 
 class TestCodeAnalyzer:
@@ -42,6 +44,39 @@ class TestCodeAnalyzer:
         analyzer = CodeAnalyzer(Path("."))
         names = analyzer._detect_async_patterns_parallel(tree, Path("mod.py"))
         assert set(names) == {"outer", "inner"}
+
+    def test_build_semgrep_env_uses_repo_local_runtime_dirs(self, tmp_path: Path) -> None:
+        """Semgrep env should use stable repo-local config, cache, and log paths."""
+        env = _build_semgrep_env(tmp_path)
+
+        assert env["XDG_CONFIG_HOME"] == str((tmp_path / ".specfact" / "config").resolve())
+        assert env["XDG_CACHE_HOME"] == str((tmp_path / ".specfact" / "cache").resolve())
+        assert env["SEMGREP_VERSION_CACHE_PATH"] == str((tmp_path / ".specfact" / "cache" / "semgrep").resolve())
+        assert env["SEMGREP_LOG_FILE"] == str((tmp_path / ".specfact" / "logs" / "semgrep.log").resolve())
+        assert Path(env["XDG_CONFIG_HOME"]).is_dir()
+        assert Path(env["XDG_CACHE_HOME"]).is_dir()
+        assert Path(env["SEMGREP_VERSION_CACHE_PATH"]).is_dir()
+        assert (tmp_path / ".specfact" / "logs").is_dir()
+
+    def test_run_semgrep_patterns_passes_repo_local_env(self, tmp_path: Path) -> None:
+        """Semgrep subprocess should inherit repo-local runtime paths."""
+        source_file = tmp_path / "sample.py"
+        source_file.write_text("print('hello')\n", encoding="utf-8")
+        semgrep_dir = tmp_path / "tools" / "semgrep"
+        semgrep_dir.mkdir(parents=True)
+        (semgrep_dir / "feature-detection.yml").write_text("rules: []\n", encoding="utf-8")
+        (semgrep_dir / "code-quality.yml").write_text("rules: []\n", encoding="utf-8")
+        analyzer = CodeAnalyzer(tmp_path)
+
+        def _fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            env = kwargs.get("env")
+            assert isinstance(env, dict)
+            assert env["XDG_CONFIG_HOME"] == str((tmp_path / ".specfact" / "config").resolve())
+            assert env["XDG_CACHE_HOME"] == str((tmp_path / ".specfact" / "cache").resolve())
+            return subprocess.CompletedProcess(cmd, 0, stdout='{"results":[]}', stderr="")
+
+        with patch("shutil.which", return_value="/usr/bin/semgrep"), patch("subprocess.run", side_effect=_fake_run):
+            assert analyzer._run_semgrep_patterns(source_file) == []
 
     def test_should_skip_test_files(self):
         """Test that test files are skipped."""

--- a/tests/unit/commands/test_backlog_config.py
+++ b/tests/unit/commands/test_backlog_config.py
@@ -16,6 +16,7 @@ import pytest
 
 pytest.importorskip("specfact_backlog.backlog.commands")
 from specfact_backlog.backlog.commands import (
+    _AdapterContext,
     _build_adapter_kwargs,
     _infer_ado_context_from_cwd,
     _load_backlog_config,
@@ -76,9 +77,11 @@ class TestBuildAdapterKwargsWithConfig:
             return_value={"github": {"repo_owner": "fromfile", "repo_name": "fromfile"}},
         ):
             kwargs = _build_adapter_kwargs(
-                "github",
-                repo_owner="fromcli",
-                repo_name="fromcli",
+                _AdapterContext(
+                    adapter="github",
+                    repo_owner="fromcli",
+                    repo_name="fromcli",
+                )
             )
         assert kwargs["repo_owner"] == "fromcli"
         assert kwargs["repo_name"] == "fromcli"
@@ -89,7 +92,7 @@ class TestBuildAdapterKwargsWithConfig:
             "specfact_backlog.backlog.commands._load_backlog_config",
             return_value={"github": {"repo_owner": "myorg", "repo_name": "myrepo"}},
         ):
-            kwargs = _build_adapter_kwargs("github", repo_owner=None, repo_name=None)
+            kwargs = _build_adapter_kwargs(_AdapterContext(adapter="github"))
         assert kwargs.get("repo_owner") == "myorg"
         assert kwargs.get("repo_name") == "myrepo"
 
@@ -101,7 +104,7 @@ class TestBuildAdapterKwargsWithConfig:
             "specfact_backlog.backlog.commands._load_backlog_config",
             return_value={"github": {"repo_owner": "fromfile", "repo_name": "fromfile"}},
         ):
-            kwargs = _build_adapter_kwargs("github", repo_owner=None, repo_name=None)
+            kwargs = _build_adapter_kwargs(_AdapterContext(adapter="github"))
         assert kwargs.get("repo_owner") == "fromenv"
         assert kwargs.get("repo_name") == "fromenv"
 
@@ -113,12 +116,7 @@ class TestBuildAdapterKwargsWithConfig:
                 "ado": {"org": "myorg", "project": "MyProject", "team": "My Team"},
             },
         ):
-            kwargs = _build_adapter_kwargs(
-                "ado",
-                ado_org=None,
-                ado_project=None,
-                ado_team=None,
-            )
+            kwargs = _build_adapter_kwargs(_AdapterContext(adapter="ado"))
         assert kwargs.get("org") == "myorg"
         assert kwargs.get("project") == "MyProject"
         assert kwargs.get("team") == "My Team"
@@ -132,10 +130,10 @@ class TestBuildAdapterKwargsWithConfig:
             },
         ):
             kwargs = _build_adapter_kwargs(
-                "github",
-                repo_owner=None,
-                repo_name=None,
-                github_token="fromcli",
+                _AdapterContext(
+                    adapter="github",
+                    github_token="fromcli",
+                )
             )
         assert kwargs.get("api_token") == "fromcli"
         assert "never" not in str(kwargs)
@@ -221,11 +219,6 @@ class TestInferAdoContextFromCwd:
                 return_value=("inferred-org", "inferred-project"),
             ),
         ):
-            kwargs = _build_adapter_kwargs(
-                "ado",
-                ado_org=None,
-                ado_project=None,
-                ado_team=None,
-            )
+            kwargs = _build_adapter_kwargs(_AdapterContext(adapter="ado"))
         assert kwargs.get("org") == "inferred-org"
         assert kwargs.get("project") == "inferred-project"

--- a/tests/unit/modules/init/test_first_run_selection.py
+++ b/tests/unit/modules/init/test_first_run_selection.py
@@ -163,6 +163,42 @@ def test_init_profile_solo_developer_calls_installer_with_codebase_and_code_revi
     assert install_calls[0] == ["specfact-codebase", "specfact-code-review"]
 
 
+def test_init_profile_enables_profile_modules_and_uses_repo_for_discovery(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_get_discovered_modules_for_state(**kwargs: object) -> list[dict[str, object]]:
+        captured.update(kwargs)
+        return [{"id": "nold-ai/specfact-codebase", "enabled": True}]
+
+    monkeypatch.setattr("specfact_cli.modules.init.src.commands.install_bundles_for_init", lambda *_a, **_k: None)
+    monkeypatch.setattr("specfact_cli.modules.init.src.commands.is_first_run", lambda **_: True)
+    monkeypatch.setattr(
+        "specfact_cli.modules.init.src.commands.get_discovered_modules_for_state",
+        _fake_get_discovered_modules_for_state,
+    )
+    monkeypatch.setattr("specfact_cli.modules.init.src.commands.write_modules_state", lambda _: None)
+    monkeypatch.setattr("specfact_cli.modules.init.src.commands.run_discovery_and_write_cache", lambda _: None)
+    monkeypatch.setattr(
+        "specfact_cli.modules.init.src.commands.detect_env_manager", lambda _: MagicMock(manager=MagicMock())
+    )
+
+    with _telemetry_track_context():
+        result = runner.invoke(
+            app,
+            ["--repo", str(tmp_path), "--profile", "solo-developer"],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, result.output
+    assert captured["base_path"] == tmp_path.resolve()
+    enable_ids = captured["enable_ids"]
+    assert isinstance(enable_ids, list)
+    assert set(enable_ids) == {"nold-ai/specfact-codebase", "nold-ai/specfact-code-review"}
+    assert captured["preserve_existing"] is True
+
+
 def test_init_profile_enterprise_full_stack_calls_installer_with_all_five(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/unit/modules/module_registry/test_commands.py
+++ b/tests/unit/modules/module_registry/test_commands.py
@@ -221,6 +221,37 @@ def test_install_command_project_scope_installs_to_project_modules_root(monkeypa
     assert captured["install_root"] == repo_path / ".specfact" / "modules"
 
 
+def test_install_command_project_scope_normalizes_nested_repo_path(monkeypatch, tmp_path: Path) -> None:
+    captured: dict[str, object] = {"install_root": None, "discovery_repo": None}
+    repo_root = tmp_path / "repo"
+    nested_dir = repo_root / "services" / "api"
+    nested_dir.mkdir(parents=True)
+    (repo_root / ".git").mkdir()
+
+    def _install(module_id: str, options: InstallModuleOptions | None = None, **_kwargs):
+        o = options or InstallModuleOptions()
+        captured["install_root"] = o.install_root
+        return tmp_path / module_id.split("/")[-1]
+
+    def _discover(repo: Path | None):
+        captured["discovery_repo"] = repo
+        return []
+
+    monkeypatch.setattr("specfact_cli.modules.module_registry.src.commands.discover_all_modules_for_project", _discover)
+    monkeypatch.setattr("specfact_cli.modules.module_registry.src.commands.install_module", _install)
+    monkeypatch.setattr(
+        "specfact_cli.modules.module_registry.src.commands.install_bundled_module",
+        lambda module_name, target_root, **_kwargs: False,
+        raising=False,
+    )
+
+    result = runner.invoke(app, ["install", "backlog", "--scope", "project", "--repo", str(nested_dir)])
+
+    assert result.exit_code == 0
+    assert captured["discovery_repo"] == repo_root
+    assert captured["install_root"] == repo_root / ".specfact" / "modules"
+
+
 def test_install_command_prefers_bundled_source_when_available(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("specfact_cli.modules.module_registry.src.commands.discover_all_modules", list)
     monkeypatch.setattr(
@@ -430,7 +461,7 @@ def test_uninstall_command_requires_scope_when_module_exists_in_user_and_project
     assert "project" in result.stdout
 
 
-def test_uninstall_command_custom_module_has_clear_guidance(monkeypatch) -> None:
+def test_uninstall_command_custom_module_has_clear_guidance(monkeypatch, tmp_path: Path) -> None:
     class _Meta:
         name = "bundle-mapper"
 
@@ -438,6 +469,7 @@ def test_uninstall_command_custom_module_has_clear_guidance(monkeypatch) -> None
         metadata = _Meta()
         source = "custom"
 
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setattr("specfact_cli.modules.module_registry.src.commands.discover_all_modules", lambda: [_Entry()])
 
     result = runner.invoke(app, ["uninstall", "bundle-mapper"])

--- a/tests/unit/modules/module_registry/test_commands.py
+++ b/tests/unit/modules/module_registry/test_commands.py
@@ -94,6 +94,57 @@ def test_install_command_skips_when_module_already_available_locally(monkeypatch
     assert "already installed" in result.stdout or "already available" in result.stdout
 
 
+def test_install_command_existing_disabled_module_enables_state(monkeypatch, tmp_path: Path) -> None:
+    install_root = tmp_path / "user-modules"
+    installed_module = install_root / "specfact-codebase"
+    installed_module.mkdir(parents=True)
+    (installed_module / "module-package.yaml").write_text(
+        "name: nold-ai/specfact-codebase\nversion: '0.1.0'\ncommands: [analyze]\n",
+        encoding="utf-8",
+    )
+    enabled: list[list[str]] = []
+    captured_state: list[list[dict[str, object]]] = []
+
+    monkeypatch.setattr("specfact_cli.modules.module_registry.src.commands.USER_MODULES_ROOT", install_root)
+    monkeypatch.setattr("specfact_cli.modules.module_registry.src.commands.discover_all_modules", list)
+    monkeypatch.setattr(
+        "specfact_cli.modules.module_registry.src.commands.install_module", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        "specfact_cli.modules.module_registry.src.commands.read_modules_state",
+        lambda: {"nold-ai/specfact-codebase": {"version": "0.1.0", "enabled": False}},
+    )
+    monkeypatch.setattr(
+        "specfact_cli.modules.module_registry.src.commands.get_discovered_modules_for_state",
+        lambda *, enable_ids, disable_ids, preserve_existing: (
+            enabled.append(list(enable_ids))
+            or [
+                {"id": "nold-ai/specfact-codebase", "version": "0.1.0", "enabled": True},
+                {"id": "unrelated-module", "version": "9.9.9", "enabled": False},
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        "specfact_cli.modules.module_registry.src.commands.write_modules_state",
+        lambda modules: captured_state.append(modules),
+    )
+    monkeypatch.setattr(
+        "specfact_cli.modules.module_registry.src.commands.run_discovery_and_write_cache", lambda _: None
+    )
+
+    result = runner.invoke(app, ["install", "nold-ai/specfact-codebase"])
+
+    assert result.exit_code == 0
+    assert enabled == [["nold-ai/specfact-codebase"]]
+    assert captured_state == [
+        [
+            {"id": "nold-ai/specfact-codebase", "version": "0.1.0", "enabled": True},
+            {"id": "unrelated-module", "version": "9.9.9", "enabled": False},
+        ]
+    ]
+    assert "enabled" in result.stdout.lower()
+
+
 def test_install_command_project_scope_installs_to_project_modules_root(monkeypatch, tmp_path: Path) -> None:
     captured: dict[str, object] = {"install_root": None, "module_id": None}
 

--- a/tests/unit/modules/module_registry/test_commands.py
+++ b/tests/unit/modules/module_registry/test_commands.py
@@ -116,7 +116,7 @@ def test_install_command_existing_disabled_module_enables_state(monkeypatch, tmp
     )
     monkeypatch.setattr(
         "specfact_cli.modules.module_registry.src.commands.get_discovered_modules_for_state",
-        lambda *, enable_ids, disable_ids, preserve_existing: (
+        lambda *, enable_ids, disable_ids, base_path=None, preserve_existing: (
             enabled.append(list(enable_ids))
             or [
                 {"id": "nold-ai/specfact-codebase", "version": "0.1.0", "enabled": True},
@@ -142,6 +142,56 @@ def test_install_command_existing_disabled_module_enables_state(monkeypatch, tmp
             {"id": "unrelated-module", "version": "9.9.9", "enabled": False},
         ]
     ]
+    assert "enabled" in result.stdout.lower()
+
+
+def test_install_command_project_scope_reenable_uses_selected_repo(monkeypatch, tmp_path: Path) -> None:
+    repo_path = tmp_path / "repo"
+    install_root = repo_path / ".specfact" / "modules"
+    installed_module = install_root / "specfact-codebase"
+    installed_module.mkdir(parents=True)
+    (installed_module / "module-package.yaml").write_text(
+        "name: nold-ai/specfact-codebase\nversion: '0.1.0'\ncommands: [analyze]\n",
+        encoding="utf-8",
+    )
+    base_paths: list[Path | None] = []
+    state_by_id = {"nold-ai/specfact-codebase": {"version": "0.1.0", "enabled": False}}
+
+    monkeypatch.setattr(
+        "specfact_cli.modules.module_registry.src.commands.discover_all_modules_for_project", lambda path: []
+    )
+    monkeypatch.setattr(
+        "specfact_cli.modules.module_registry.src.commands.install_module", lambda *_args, **_kwargs: None
+    )
+
+    def _read_state():
+        return dict(state_by_id)
+
+    def _discover_state(*, enable_ids, disable_ids, base_path=None, preserve_existing):
+        base_paths.append(base_path)
+        return [{"id": "nold-ai/specfact-codebase", "version": "0.1.0", "enabled": True}]
+
+    def _write_state(modules):
+        for row in modules:
+            state_by_id[str(row["id"])] = {"version": str(row["version"]), "enabled": bool(row["enabled"])}
+
+    monkeypatch.setattr("specfact_cli.modules.module_registry.src.commands.read_modules_state", _read_state)
+    monkeypatch.setattr(
+        "specfact_cli.modules.module_registry.src.commands.get_discovered_modules_for_state",
+        _discover_state,
+    )
+    monkeypatch.setattr("specfact_cli.modules.module_registry.src.commands.write_modules_state", _write_state)
+    monkeypatch.setattr(
+        "specfact_cli.modules.module_registry.src.commands.run_discovery_and_write_cache", lambda _: None
+    )
+
+    result = runner.invoke(
+        app, ["install", "nold-ai/specfact-codebase", "--scope", "project", "--repo", str(repo_path)]
+    )
+
+    assert result.exit_code == 0
+    assert base_paths == [repo_path]
+    assert state_by_id["nold-ai/specfact-codebase"]["enabled"] is True
     assert "enabled" in result.stdout.lower()
 
 

--- a/tests/unit/scripts/test_pre_commit_code_review.py
+++ b/tests/unit/scripts/test_pre_commit_code_review.py
@@ -320,6 +320,13 @@ def test_build_review_subprocess_env_injects_discovered_repo_without_mutating_os
     assert before is False
     assert after is False
     assert env["SPECFACT_MODULES_REPO"] == str(modules_root.resolve())
+    assert env["XDG_CONFIG_HOME"] == str((fake_repo / ".specfact" / "config").resolve())
+    assert env["XDG_CACHE_HOME"] == str((fake_repo / ".specfact" / "cache").resolve())
+    assert env["SEMGREP_VERSION_CACHE_PATH"] == str((fake_repo / ".specfact" / "cache" / "semgrep").resolve())
+    assert env["SEMGREP_LOG_FILE"] == str((fake_repo / ".specfact" / "logs" / "semgrep.log").resolve())
+    assert Path(env["XDG_CONFIG_HOME"]).is_dir()
+    assert Path(env["XDG_CACHE_HOME"]).is_dir()
+    assert Path(env["SEMGREP_VERSION_CACHE_PATH"]).is_dir()
 
 
 def test_build_review_subprocess_env_preserves_explicit_value(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -329,3 +336,22 @@ def test_build_review_subprocess_env_preserves_explicit_value(monkeypatch: pytes
     monkeypatch.setenv("SPECFACT_MODULES_REPO", explicit)
     env = module.build_review_subprocess_env()
     assert env["SPECFACT_MODULES_REPO"] == explicit
+
+
+def test_build_review_subprocess_env_overrides_explicit_xdg_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Nested review tooling must ignore ambient XDG paths and use repo-local dirs."""
+    module = _load_script_module()
+    explicit_config = str(tmp_path / "xdg-config")
+    explicit_cache = str(tmp_path / "xdg-cache")
+    fake_repo = tmp_path / "repo"
+    (fake_repo / "scripts").mkdir(parents=True)
+    monkeypatch.setattr(module, "_repo_root", lambda: fake_repo)
+    monkeypatch.setenv("XDG_CONFIG_HOME", explicit_config)
+    monkeypatch.setenv("XDG_CACHE_HOME", explicit_cache)
+
+    env = module.build_review_subprocess_env()
+
+    assert env["XDG_CONFIG_HOME"] == str((fake_repo / ".specfact" / "config").resolve())
+    assert env["XDG_CACHE_HOME"] == str((fake_repo / ".specfact" / "cache").resolve())

--- a/tests/unit/specfact_cli/modules/test_multi_module_install_uninstall.py
+++ b/tests/unit/specfact_cli/modules/test_multi_module_install_uninstall.py
@@ -22,7 +22,7 @@ from specfact_cli.registry.bootstrap import register_builtin_commands
 
 
 @pytest.fixture(autouse=True)
-def _reset_registry_and_root_app() -> Generator[None, None, None]:
+def reset_registry_and_root_app() -> Generator[None, None, None]:
     """Other tests clear ``CommandRegistry`` without re-registering; rebuild root ``app`` for Typer."""
     CommandRegistry._clear_for_testing()
     register_builtin_commands()
@@ -181,8 +181,8 @@ def test_module_install_multi_skips_already_installed_and_continues() -> None:
     """Multi-install: if A is already installed, skip A but still install B; exit 0."""
     installed: list[str] = []
 
-    def _fake_skip(scope: str, name: str, root: Path, reinstall: bool, discovered: Any) -> bool:
-        return "codebase" in name  # A is already installed
+    def _fake_skip(*args: Any, **_kwargs: Any) -> bool:
+        return "codebase" in str(args[1])  # A is already installed
 
     def _fake_install(module_id: str, options: object | None = None, **_kwargs: object) -> Path:
         installed.append(module_id)

--- a/tests/unit/specfact_cli/registry/test_init_module_lifecycle_ux.py
+++ b/tests/unit/specfact_cli/registry/test_init_module_lifecycle_ux.py
@@ -59,7 +59,7 @@ def test_init_bootstrap_only_does_not_run_ide_setup(tmp_path: Path, monkeypatch)
     monkeypatch.setattr("specfact_cli.modules.init.src.commands.is_first_run", lambda **_kwargs: False)
     monkeypatch.setattr(
         "specfact_cli.modules.init.src.commands.get_discovered_modules_for_state",
-        lambda enable_ids=None, disable_ids=None: [
+        lambda enable_ids=None, disable_ids=None, base_path=None, preserve_existing=False: [
             {"id": "sync", "version": "0.1.0", "enabled": True},
         ],
     )
@@ -83,7 +83,7 @@ def test_init_install_deps_runs_without_ide_template_copy(tmp_path: Path, monkey
     monkeypatch.setattr("specfact_cli.modules.init.src.commands.is_first_run", lambda **_kwargs: False)
     monkeypatch.setattr(
         "specfact_cli.modules.init.src.commands.get_discovered_modules_for_state",
-        lambda enable_ids=None, disable_ids=None: [
+        lambda enable_ids=None, disable_ids=None, base_path=None, preserve_existing=False: [
             {"id": "sync", "version": "0.1.0", "enabled": True},
         ],
     )

--- a/tests/unit/specfact_cli/registry/test_init_module_state.py
+++ b/tests/unit/specfact_cli/registry/test_init_module_state.py
@@ -67,3 +67,19 @@ def test_new_module_gets_enabled_true(registry_dir: Path):
     modules_list = get_discovered_modules_for_state()
     for m in modules_list:
         assert m.get("enabled", True) is True
+
+
+def test_refresh_preserves_unseen_module_state_when_requested(monkeypatch, registry_dir: Path, tmp_path: Path):
+    """Repo-scoped init refresh must not erase state for modules outside the selected repo."""
+    from specfact_cli.models.module_package import ModulePackageMetadata
+
+    write_modules_state([{"id": "unseen-module", "version": "9.9.9", "enabled": False}])
+    monkeypatch.setattr(
+        "specfact_cli.registry.module_packages.discover_all_package_metadata",
+        lambda **_: [(tmp_path / "seen", ModulePackageMetadata(name="seen-module", version="1.0.0"))],
+    )
+
+    modules_list = get_discovered_modules_for_state(base_path=tmp_path, preserve_existing=True)
+
+    assert {"id": "seen-module", "version": "1.0.0", "enabled": True} in modules_list
+    assert {"id": "unseen-module", "version": "9.9.9", "enabled": False} in modules_list

--- a/tests/unit/specfact_cli/registry/test_module_availability.py
+++ b/tests/unit/specfact_cli/registry/test_module_availability.py
@@ -22,7 +22,10 @@ def test_classify_installed_disabled_module_reports_disabled(monkeypatch) -> Non
         "user",
     )
 
-    monkeypatch.setattr("specfact_cli.registry.module_availability.discover_all_modules_for_project", lambda _: [entry])
+    monkeypatch.setattr(
+        "specfact_cli.registry.module_availability.discover_all_modules_for_project_with_shadowed",
+        lambda _: [entry],
+    )
     monkeypatch.setattr(
         "specfact_cli.registry.module_availability.read_modules_state",
         lambda: {"nold-ai/specfact-codebase": {"version": "0.1.0", "enabled": False}},
@@ -60,7 +63,7 @@ def test_classify_prioritizes_requested_module_id_over_shared_command_group(monk
     )
 
     monkeypatch.setattr(
-        "specfact_cli.registry.module_availability.discover_all_modules_for_project",
+        "specfact_cli.registry.module_availability.discover_all_modules_for_project_with_shadowed",
         lambda _: [code_review, codebase],
     )
     monkeypatch.setattr(
@@ -91,7 +94,10 @@ def test_classify_skipped_module_reports_compatibility_reason(monkeypatch) -> No
         "user",
     )
 
-    monkeypatch.setattr("specfact_cli.registry.module_availability.discover_all_modules_for_project", lambda _: [entry])
+    monkeypatch.setattr(
+        "specfact_cli.registry.module_availability.discover_all_modules_for_project_with_shadowed",
+        lambda _: [entry],
+    )
     monkeypatch.setattr("specfact_cli.registry.module_availability.read_modules_state", dict)
 
     availability = classify_module_availability(module_id="nold-ai/specfact-codebase", command_name="code")
@@ -125,7 +131,7 @@ def test_project_scope_shadow_reports_shadowing_and_available_project_copy(monke
     )
 
     monkeypatch.setattr(
-        "specfact_cli.registry.module_availability.discover_all_modules_for_project",
+        "specfact_cli.registry.module_availability.discover_all_modules_for_project_with_shadowed",
         lambda _: [project_entry, user_entry],
     )
     monkeypatch.setattr("specfact_cli.registry.module_availability.read_modules_state", dict)

--- a/tests/unit/specfact_cli/registry/test_module_availability.py
+++ b/tests/unit/specfact_cli/registry/test_module_availability.py
@@ -1,0 +1,137 @@
+"""Regression tests for metadata-only module availability classification."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from specfact_cli.models.module_package import ModulePackageMetadata
+from specfact_cli.registry.module_availability import ModuleAvailabilityStatus, classify_module_availability
+from specfact_cli.registry.module_discovery import DiscoveredModule
+
+
+def test_classify_installed_disabled_module_reports_disabled(monkeypatch) -> None:
+    entry = DiscoveredModule(
+        Path("/tmp/specfact-codebase"),
+        ModulePackageMetadata(
+            name="nold-ai/specfact-codebase",
+            version="0.1.0",
+            commands=["analyze"],
+            category="codebase",
+            bundle_group_command="code",
+        ),
+        "user",
+    )
+
+    monkeypatch.setattr("specfact_cli.registry.module_availability.discover_all_modules_for_project", lambda _: [entry])
+    monkeypatch.setattr(
+        "specfact_cli.registry.module_availability.read_modules_state",
+        lambda: {"nold-ai/specfact-codebase": {"version": "0.1.0", "enabled": False}},
+    )
+
+    availability = classify_module_availability(module_id="nold-ai/specfact-codebase", command_name="code")
+
+    assert availability.status is ModuleAvailabilityStatus.DISABLED
+    assert availability.module_id == "nold-ai/specfact-codebase"
+    assert "module enable nold-ai/specfact-codebase" in availability.recovery_command
+
+
+def test_classify_prioritizes_requested_module_id_over_shared_command_group(monkeypatch) -> None:
+    code_review = DiscoveredModule(
+        Path("/tmp/specfact-code-review"),
+        ModulePackageMetadata(
+            name="nold-ai/specfact-code-review",
+            version="0.1.0",
+            commands=["review"],
+            category="codebase",
+            bundle_group_command="code",
+        ),
+        "user",
+    )
+    codebase = DiscoveredModule(
+        Path("/tmp/specfact-codebase"),
+        ModulePackageMetadata(
+            name="nold-ai/specfact-codebase",
+            version="0.1.0",
+            commands=["analyze"],
+            category="codebase",
+            bundle_group_command="code",
+        ),
+        "user",
+    )
+
+    monkeypatch.setattr(
+        "specfact_cli.registry.module_availability.discover_all_modules_for_project",
+        lambda _: [code_review, codebase],
+    )
+    monkeypatch.setattr(
+        "specfact_cli.registry.module_availability.read_modules_state",
+        lambda: {
+            "nold-ai/specfact-code-review": {"version": "0.1.0", "enabled": False},
+            "nold-ai/specfact-codebase": {"version": "0.1.0", "enabled": False},
+        },
+    )
+
+    availability = classify_module_availability(module_id="nold-ai/specfact-codebase", command_name="code")
+
+    assert availability.status is ModuleAvailabilityStatus.DISABLED
+    assert availability.module_id == "nold-ai/specfact-codebase"
+
+
+def test_classify_skipped_module_reports_compatibility_reason(monkeypatch) -> None:
+    entry = DiscoveredModule(
+        Path("/tmp/specfact-codebase"),
+        ModulePackageMetadata(
+            name="nold-ai/specfact-codebase",
+            version="0.1.0",
+            commands=["analyze"],
+            category="codebase",
+            bundle_group_command="code",
+            core_compatibility=">=99.0.0",
+        ),
+        "user",
+    )
+
+    monkeypatch.setattr("specfact_cli.registry.module_availability.discover_all_modules_for_project", lambda _: [entry])
+    monkeypatch.setattr("specfact_cli.registry.module_availability.read_modules_state", dict)
+
+    availability = classify_module_availability(module_id="nold-ai/specfact-codebase", command_name="code")
+
+    assert availability.status is ModuleAvailabilityStatus.SKIPPED
+    assert "requires >=99.0.0" in availability.reason
+
+
+def test_project_scope_shadow_reports_shadowing_and_available_project_copy(monkeypatch) -> None:
+    project_entry = DiscoveredModule(
+        Path("/repo/.specfact/modules/specfact-codebase"),
+        ModulePackageMetadata(
+            name="nold-ai/specfact-codebase",
+            version="0.2.0",
+            commands=["analyze"],
+            category="codebase",
+            bundle_group_command="code",
+        ),
+        "project",
+    )
+    user_entry = DiscoveredModule(
+        Path("/home/user/.specfact/modules/specfact-codebase"),
+        ModulePackageMetadata(
+            name="nold-ai/specfact-codebase",
+            version="0.1.0",
+            commands=["analyze"],
+            category="codebase",
+            bundle_group_command="code",
+        ),
+        "user",
+    )
+
+    monkeypatch.setattr(
+        "specfact_cli.registry.module_availability.discover_all_modules_for_project",
+        lambda _: [project_entry, user_entry],
+    )
+    monkeypatch.setattr("specfact_cli.registry.module_availability.read_modules_state", dict)
+
+    availability = classify_module_availability(module_id="nold-ai/specfact-codebase", command_name="code")
+
+    assert availability.status is ModuleAvailabilityStatus.SHADOWED
+    assert availability.shadowed_by == project_entry.package_dir
+    assert availability.package_dir == user_entry.package_dir

--- a/tests/unit/specfact_cli/registry/test_module_availability.py
+++ b/tests/unit/specfact_cli/registry/test_module_availability.py
@@ -80,6 +80,30 @@ def test_classify_prioritizes_requested_module_id_over_shared_command_group(monk
     assert availability.module_id == "nold-ai/specfact-codebase"
 
 
+def test_classify_fully_qualified_id_does_not_tail_match_other_namespace(monkeypatch) -> None:
+    other_namespace = DiscoveredModule(
+        Path("/tmp/specfact-codebase"),
+        ModulePackageMetadata(
+            name="other-org/specfact-codebase",
+            version="0.1.0",
+            commands=["analyze"],
+            category="codebase",
+            bundle_group_command="code",
+        ),
+        "user",
+    )
+
+    monkeypatch.setattr(
+        "specfact_cli.registry.module_availability.discover_all_modules_for_project_with_shadowed",
+        lambda _: [other_namespace],
+    )
+    monkeypatch.setattr("specfact_cli.registry.module_availability.read_modules_state", dict)
+
+    availability = classify_module_availability(module_id="nold-ai/specfact-codebase", command_name="code")
+
+    assert availability.status is ModuleAvailabilityStatus.ABSENT
+
+
 def test_classify_skipped_module_reports_compatibility_reason(monkeypatch) -> None:
     entry = DiscoveredModule(
         Path("/tmp/specfact-codebase"),

--- a/tests/unit/specfact_cli/test_module_not_found_error.py
+++ b/tests/unit/specfact_cli/test_module_not_found_error.py
@@ -7,9 +7,10 @@ Tasks: 6.1 - 6.3
 from __future__ import annotations
 
 import click
+import pytest
 from typer.testing import CliRunner
 
-from specfact_cli.cli import app
+from specfact_cli.registry.module_availability import ModuleAvailability, ModuleAvailabilityStatus
 
 
 runner = CliRunner()
@@ -19,27 +20,39 @@ def _unstyled(text: str) -> str:
     return click.unstyle(text)
 
 
-def test_module_not_found_error_includes_init_command() -> None:
+@pytest.fixture
+def absent_module(monkeypatch):
+    monkeypatch.setattr(
+        "specfact_cli.cli.classify_module_availability",
+        lambda **kwargs: ModuleAvailability(
+            status=ModuleAvailabilityStatus.ABSENT,
+            module_id=kwargs.get("module_id"),
+            reason="not installed",
+            recovery_command=f"specfact module install {kwargs.get('module_id')}",
+        ),
+        raising=False,
+    )
+
+
+def test_module_not_found_error_includes_init_command(absent_module, capsys) -> None:
     """When a known command group is not installed, error must include the init command."""
-    result = runner.invoke(app, ["code", "review", "run"])
+    from specfact_cli.cli import _print_missing_bundle_command_help
 
-    output = _unstyled(result.output)
-
-    # Must fail
-    assert result.exit_code != 0
+    _print_missing_bundle_command_help("code")
+    output = _unstyled(capsys.readouterr().out)
 
     # Must include the corrective init command
     assert "init" in output, f"Error must mention 'init' command: {output!r}"
     assert "--profile" in output or "profile" in output, f"Error must suggest --profile option: {output!r}"
 
 
-def test_module_not_found_error_includes_uvx_command() -> None:
+def test_module_not_found_error_includes_uvx_command(absent_module, capsys) -> None:
     """Module-not-found error must include uvx-compatible init command for uvx users."""
-    result = runner.invoke(app, ["code", "review", "run"])
+    from specfact_cli.cli import _print_missing_bundle_command_help
 
-    output = _unstyled(result.output)
+    _print_missing_bundle_command_help("code")
+    output = _unstyled(capsys.readouterr().out)
 
-    assert result.exit_code != 0
     assert "specfact init" in output or "uvx" in output or "--profile" in output, (
         f"Error must include actionable init/profile guidance: {output!r}"
     )
@@ -53,12 +66,37 @@ def test_no_flat_import_in_missing_bundle_map() -> None:
     assert _INVOKED_TO_MARKETPLACE_MODULE["project"] == "nold-ai/specfact-project"
 
 
-def test_module_not_found_error_includes_init_profile_placeholder() -> None:
+def test_module_not_found_error_includes_init_profile_placeholder(absent_module, capsys) -> None:
     """Module-not-found error for 'code' command must include init --profile guidance."""
-    result = runner.invoke(app, ["code"])
+    from specfact_cli.cli import _print_missing_bundle_command_help
 
-    output = _unstyled(result.output)
+    _print_missing_bundle_command_help("code")
+    output = _unstyled(capsys.readouterr().out)
 
-    assert result.exit_code != 0
     assert "specfact init" in output, f"Error must mention specfact init: {output!r}"
     assert "--profile" in output or "<profile>" in output, f"Error must suggest a profile: {output!r}"
+
+
+def test_module_not_found_error_reports_disabled_installed_module(monkeypatch, capsys) -> None:
+    """Missing command UX must not call disabled installed modules uninstalled."""
+    from specfact_cli.cli import _print_missing_bundle_command_help
+
+    monkeypatch.setattr(
+        "specfact_cli.cli.classify_module_availability",
+        lambda **_: ModuleAvailability(
+            status=ModuleAvailabilityStatus.DISABLED,
+            module_id="nold-ai/specfact-codebase",
+            source="user",
+            reason="disabled in modules.json",
+            recovery_command="specfact module enable nold-ai/specfact-codebase",
+        ),
+        raising=False,
+    )
+
+    _print_missing_bundle_command_help("code")
+    output = _unstyled(capsys.readouterr().out)
+    normalized_output = " ".join(output.split())
+
+    assert "is installed but disabled" in output
+    assert "specfact module enable nold-ai/specfact-codebase" in normalized_output
+    assert "is not installed" not in output


### PR DESCRIPTION
## What changed

This PR fixes the inconsistent module state behavior around install, upgrade, uninstall, and `init --profile`.

## Root cause

Module availability checks were mixing discovery results with state writes, and the install repair path could overwrite unrelated `modules.json` rows. That made repeated runs across different repos or environments behave unreliably.

## Impact

- `specfact module install` now repairs disabled installed modules without dropping unrelated state.
- Missing-command detection now distinguishes absent, disabled, skipped, shadowed, and ambiguous cases more precisely.
- `specfact init --repo ... --profile/--install ...` refreshes module state using repo-aware discovery while preserving unrelated rows.
- Reality-test coverage now exercises module install, upgrade, uninstall, and profile-init flows against a real project fixture.
- Version sources were bumped together and documented in `CHANGELOG.md`.

## Validation

- `hatch run lint`
- `hatch run pytest` on the touched-scope suite
- `hatch run specfact code review run --json --out .specfact/code-review.changed.json --scope changed`
- `hatch run specfact code review run --bug-hunt --json --out .specfact/code-review.bug-hunt.json --scope changed`
- `openspec validate marketplace-07-module-install-state-consistency --strict`
- real CLI reality test with `hatch run specfact`