### PR TITLE
fix(cli): forward bare lazy subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.46.18] - 2026-05-04
+
+### Fixed
+
+- **CLI lazy delegation**: forward bare lazy subcommands such as
+  `specfact module list` and `specfact module alias` instead of dropping the
+  subcommand token and reporting `Missing command`.
+
+---
+
 ## [0.46.17] - 2026-05-03
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "specfact-cli"
-version = "0.46.17"
+version = "0.46.18"
 description = "The swiss knife CLI for agile DevOps teams. Keep backlog, specs, tests, and code in sync with validation and contract enforcement for new projects and long-lived codebases."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 if __name__ == "__main__":
     _setup = setup(
         name="specfact-cli",
-        version="0.46.17",
+        version="0.46.18",
         description=(
             "The swiss knife CLI for agile DevOps teams. Keep backlog, specs, tests, and code in sync with "
             "validation and contract enforcement for new projects and long-lived codebases."

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,4 +3,4 @@ SpecFact CLI - Spec→Contract→Sentinel tool for contract-driven development.
 """
 
 # Package version: keep in sync with pyproject.toml, setup.py, src/specfact_cli/__init__.py
-__version__ = "0.46.17"
+__version__ = "0.46.18"

--- a/src/specfact_cli/__init__.py
+++ b/src/specfact_cli/__init__.py
@@ -45,6 +45,6 @@ def _bootstrap_bundle_paths() -> None:
 
 _bootstrap_bundle_paths()
 
-__version__ = "0.46.17"
+__version__ = "0.46.18"
 
 __all__ = ["__version__"]

--- a/src/specfact_cli/cli.py
+++ b/src/specfact_cli/cli.py
@@ -610,6 +610,12 @@ def _strip_redundant_single_command_arg(click_cmd: click.Command, args: tuple[st
     return args_list
 
 
+def _lazy_delegate_remaining_args(ctx: click.Context) -> list[str]:
+    ctx_state = vars(ctx)
+    protected_args = ctx_state.get("_protected_args") or ctx_state.get("protected_args") or ()
+    return [str(arg) for arg in (*protected_args, *ctx.args)]
+
+
 class _LazyDelegateGroup(click.Group):
     """Click Group that delegates all args to the real command (lazy-loaded)."""
 
@@ -657,9 +663,10 @@ class _LazyDelegateGroup(click.Group):
     @require(lambda ctx: ctx is not None, "ctx must not be None")
     @ensure(lambda result: result is None or isinstance(result, int), "result must be None or an exit code")
     def invoke(self, ctx: click.Context) -> Any:
-        if ctx.invoked_subcommand is None and not ctx.args:
+        if ctx.invoked_subcommand is None:
+            args = _lazy_delegate_remaining_args(ctx)
             ctx.meta["original_prog_name"] = ctx.command_path
-            return self._delegate_cmd.main(args=[], prog_name=ctx.command_path, standalone_mode=False)
+            return self._delegate_cmd.main(args=args, prog_name=ctx.command_path, standalone_mode=False)
         return super().invoke(ctx)
 
     @require(_lazy_delegate_cmd_name_ready, "lazy command name must be set")

--- a/tests/unit/cli/test_lean_help_output.py
+++ b/tests/unit/cli/test_lean_help_output.py
@@ -117,6 +117,35 @@ def test_stale_lazy_flat_shim_prints_install_guidance() -> None:
     assert result.output.strip()
 
 
+def test_lazy_delegate_forwards_bare_subcommand_without_options() -> None:
+    """A lazy group must not drop a single subcommand that has no trailing args."""
+    CommandRegistry._clear_for_testing()
+    delegated = typer.Typer(help="Module commands.")
+
+    @delegated.command(name="list")
+    def list_command() -> None:
+        click.echo("listed")
+
+    @delegated.command(name="alias")
+    def alias_command() -> None:
+        click.echo("aliased")
+
+    CommandRegistry.register(
+        "module",
+        lambda: delegated,
+        CommandMetadata(name="module", help="Module commands.", tier="official", addon_id=None),
+    )
+    result = ClickCliRunner().invoke(
+        _LazyDelegateGroup("module", "Module commands."),
+        ["list"],
+        catch_exceptions=False,
+    )
+    CommandRegistry._clear_for_testing()
+
+    assert result.exit_code == 0
+    assert "listed" in result.output
+
+
 def test_lazy_delegate_help_falls_back_when_typer_command_build_fails(monkeypatch: pytest.MonkeyPatch) -> None:
     """Help-only delegation should not fail when Typer cannot materialize a loaded app."""
     CommandRegistry._clear_for_testing()


### PR DESCRIPTION
## Summary

Fixes a lazy CLI delegation regression where bare lazy subcommands with no trailing options, such as `specfact module list`, were dropped before reaching the real Typer app and failed with `Missing command`.

The branch was rebased onto current `dev` by skipping the old PR #539 commits that are already present in `dev` through the squashed merge, then adding one focused fix commit.

## Changes

- Preserve Click protected subcommand tokens when `_LazyDelegateGroup` delegates to the real command app.
- Add a regression test for a bare lazy subcommand without options.
- Bump package version to `0.46.18` and add the changelog entry.

## Validation

- Failing-before evidence: `hatch run pytest tests/unit/cli/test_lean_help_output.py::test_lazy_delegate_forwards_bare_subcommand_without_options -q` failed before the production fix with exit code 2.
- `hatch run pytest tests/unit/cli/test_lean_help_output.py::test_lazy_delegate_forwards_bare_subcommand_without_options -q`
- `hatch run pytest tests/unit/cli/test_lean_help_output.py -q`
- `hatch run python -m specfact_cli.cli module list`
- `hatch run python -m specfact_cli.cli module alias` now reaches nested `module alias` usage, confirming the outer delegate forwards the bare subcommand.
- `hatch run check-version-sources`
- `hatch run check-pypi-ahead`
- `hatch run format`
- `git diff --check`
- Pre-commit on commit: version sync, PyPI-ahead, format, markdown lint/fix, staged Python lint, code review with 0 findings, and contract-test-status.