### PR TITLE
docs: refine telemetry change to active opt-in

### DIFF
--- a/openspec/changes/telemetry-01-opentelemetry-default-on/design.md
+++ b/openspec/changes/telemetry-01-opentelemetry-default-on/design.md
@@ -6,7 +6,7 @@
 CLI invocation
       │
       ▼
-[TelemetryEmitter]  ◄── resolution: env → CLI → project config → profile → builtin; then enterprise overlay (signed policy)
+[TelemetryEmitter]  ◄── resolution: env → CLI → project config → init/first-run consent → profile → builtin; then enterprise overlay (signed policy)
       │
       ├── build payload (allowlist validator)
       ├── write .specfact/telemetry/sent.log (append-only, redacted)
@@ -30,13 +30,30 @@ only after the deprecation window ends.
 1. `SPECFACT_TELEMETRY` environment variable (explicit per-invocation override).
 2. `specfact telemetry disable|enable` CLI persisted preference.
 3. `.specfact/config.yaml` `telemetry.enabled`.
-4. Active profile telemetry defaults.
-5. Built-in community default: `true` when no enterprise governance applies.
+4. Recorded `specfact init` or first-interactive-run consent.
+5. Active profile telemetry defaults.
+6. Built-in community default: `false` until explicit consent exists.
 
-**Enterprise governance overlay (runs after steps 1–5 produce a candidate state):** when `.specfact/enterprise.yaml` is
+**Enterprise governance overlay (runs after steps 1–6 produce a candidate state):** when `.specfact/enterprise.yaml` is
 present **or** `SPECFACT_ENTERPRISE=true`, telemetry **MUST NOT** finalize as **enabled** unless a **signed org-admin
 policy** approves it per `enterprise-01-policy-resolution-extension`. Without that approval, **effective telemetry is
-disabled** even if steps 2–5 would enable it; step **1** remains the hard per-process escape hatch.
+disabled** even if steps 2–6 would enable it; step **1** remains the hard per-process escape hatch.
+
+## Active opt-in flow
+
+`specfact init` and the first interactive `specfact` run SHALL present a consent prompt before any telemetry is emitted.
+The prompt SHALL be short, neutral, and explicit:
+
+- What is tracked: command/subcommand name, module composition, duration, exit code, outcome enum, schema version, run ID,
+  timestamp, major/minor Python version, and coarse platform.
+- What is not tracked: file paths, repository names, branch names, remotes, prompts, chat transcripts, OpenSpec/spec
+  content, usernames, emails, hostnames, free-form logs, and raw error messages.
+- How to change it: `specfact telemetry enable`, `specfact telemetry disable`, `specfact telemetry status`, and
+  `SPECFACT_TELEMETRY=true|false`.
+
+Non-interactive and CI sessions SHALL NOT prompt. They SHALL remain disabled unless an explicit env/config/persisted
+enable source is present. First-run consent SHALL be stored as a normal user/project preference so `status` can report the
+source.
 
 ## Payload contract (allowlist)
 
@@ -71,16 +88,29 @@ here).
 ## Non-goals
 
 - Server-side collection stack (owned by ops).
-- Per-user consent UI beyond the enable/disable CLI surface.
+- Default-on collection in this release.
+- Consent UI beyond `specfact init`, first interactive run, and the telemetry command surface.
 - Rich telemetry (spans, traces) — only counter/histogram-equivalent summary events in v1.
 
 ## Alternatives considered
 
-1. **Opt-in default**: rejected. Historical adoption was ~0; no signal for platform improvement.
+1. **Default-on community telemetry**: rejected for this release. Even PII-safe payloads need explicit trust-building
+   before collection starts.
 2. **Telemetry inside every module independently**: rejected. Each module would re-invent the allowlist; easy to leak PII.
 3. **Full OpenTelemetry spans for every CLI run**: deferred. Excessive payload; v1 emits a single summary event per invocation.
+
+## Default-on revisit criteria
+
+SpecFact MAY revisit a default-on posture only after the opt-in release proves the trust contract:
+
+- Published telemetry transparency documentation matches the shipped payload schema.
+- Allowlist validator and regression tests block every rejected category listed above.
+- Local `.specfact/telemetry/sent.log` lets users inspect transmitted payloads before filing privacy concerns.
+- Enterprise signed-policy controls are implemented and documented.
+- Community feedback shows no material privacy complaints against the opt-in payload contract for at least one release cycle.
 
 ## Risks
 
 - Over-redaction may hide useful debugging signal. Mitigated by local `sent.log` that users can inspect and attach to bug reports voluntarily.
 - Accidental payload schema drift. Mitigated by pydantic model + allowlist validator enforced in unit tests.
+- Consent fatigue may reduce signal volume. Accepted for the first public telemetry release because developer trust is the gating adoption constraint.

--- a/openspec/changes/telemetry-01-opentelemetry-default-on/design.md
+++ b/openspec/changes/telemetry-01-opentelemetry-default-on/design.md
@@ -54,8 +54,8 @@ If the user accepts, the current command MAY emit exactly one summary event afte
 validation passes. If the user declines, the current command remains silent. The prompt SHALL be short, neutral, and
 explicit:
 
-- What is tracked: command/subcommand name, module composition, duration, exit code, outcome enum, schema version, run ID,
-  timestamp, major/minor Python version, and coarse platform.
+- What is tracked: `command`, `subcommand`, `modules_composed`, `duration_ms`, `exit_code`, `outcome`,
+  `schema_version`, `run_id`, `timestamp`, major/minor Python version, and coarse platform.
 - What is not tracked: file paths, repository names, branch names, remotes, prompts, chat transcripts, OpenSpec/spec
   content, usernames, emails, hostnames, free-form logs, and raw error messages.
 - How to change it: `specfact telemetry enable`, `specfact telemetry disable`, `specfact telemetry status`, and

--- a/openspec/changes/telemetry-01-opentelemetry-default-on/design.md
+++ b/openspec/changes/telemetry-01-opentelemetry-default-on/design.md
@@ -54,8 +54,8 @@ If the user accepts, the current command MAY emit exactly one summary event afte
 validation passes. If the user declines, the current command remains silent. The prompt SHALL be short, neutral, and
 explicit:
 
-- What is tracked: `command`, `subcommand`, `modules_composed`, `duration_ms`, `exit_code`, `outcome`,
-  `schema_version`, `run_id`, `timestamp`, major/minor Python version, and coarse platform.
+- What is tracked: five required semantic fields (`command`, `modules_composed`, `duration_ms`, `exit_code`, `outcome`),
+  optional bounded `subcommand`, `schema_version`, `run_id`, `timestamp`, major/minor Python version, and coarse platform.
 - What is not tracked: file paths, repository names, branch names, remotes, prompts, chat transcripts, OpenSpec/spec
   content, usernames, emails, hostnames, free-form logs, and raw error messages.
 - How to change it: `specfact telemetry enable`, `specfact telemetry disable`, `specfact telemetry status`, and
@@ -67,17 +67,23 @@ source.
 
 ## Payload contract (allowlist)
 
-Permitted fields only:
+Permitted fields only. Required semantic fields:
 
-- `schema_version` (str, literal "1.0")
-- `run_id` (uuid)
-- `timestamp` (ISO-8601 UTC)
 - `command` (enum: validated against registered command names)
-- `subcommand` (enum, optional)
 - `modules_composed` (list[str], bundle names)
 - `duration_ms` (int)
 - `exit_code` (int)
 - `outcome` (enum: `ok | error | cancelled`)
+
+Optional bounded semantic field:
+
+- `subcommand` (enum, optional)
+
+Required bounded metadata:
+
+- `schema_version` (str, literal "1.0")
+- `run_id` (uuid)
+- `timestamp` (ISO-8601 UTC)
 - `python_version` (str, major.minor only)
 - `platform` (enum: `linux | darwin | windows`)
 

--- a/openspec/changes/telemetry-01-opentelemetry-default-on/design.md
+++ b/openspec/changes/telemetry-01-opentelemetry-default-on/design.md
@@ -36,13 +36,23 @@ only after the deprecation window ends.
 
 **Enterprise governance overlay (runs after steps 1–6 produce a candidate state):** when `.specfact/enterprise.yaml` is
 present **or** `SPECFACT_ENTERPRISE=true`, telemetry **MUST NOT** finalize as **enabled** unless a **signed org-admin
-policy** approves it per `enterprise-01-policy-resolution-extension`. Without that approval, **effective telemetry is
-disabled** even if steps 2–6 would enable it; step **1** remains the hard per-process escape hatch.
+policy** approves it per `enterprise-01-policy-resolution-extension`. `SPECFACT_TELEMETRY=false` is always a hard
+per-process disable. `SPECFACT_TELEMETRY=true` is a transient per-process enable only outside enterprise governance, or
+inside enterprise governance when the signed policy allows telemetry; it never bypasses a missing or disabling enterprise
+policy.
+
+**Legacy override compatibility:** `SPECFACT_TELEMETRY_OPT_IN` is treated as a deprecated alias for
+`SPECFACT_TELEMETRY` only when `SPECFACT_TELEMETRY` is unset. `.specfact/config.yaml` `telemetry.opt-in` is treated as a
+deprecated alias for `telemetry.enabled` only when `telemetry.enabled` is unset. New keys take precedence over legacy
+keys, legacy usage emits a runtime deprecation warning, and conflicting legacy/new values emit a conflict warning while
+using the new value.
 
 ## Active opt-in flow
 
 `specfact init` and the first interactive `specfact` run SHALL present a consent prompt before any telemetry is emitted.
-The prompt SHALL be short, neutral, and explicit:
+If the user accepts, the current command MAY emit exactly one summary event after consent is recorded and payload
+validation passes. If the user declines, the current command remains silent. The prompt SHALL be short, neutral, and
+explicit:
 
 - What is tracked: command/subcommand name, module composition, duration, exit code, outcome enum, schema version, run ID,
   timestamp, major/minor Python version, and coarse platform.

--- a/openspec/changes/telemetry-01-opentelemetry-default-on/proposal.md
+++ b/openspec/changes/telemetry-01-opentelemetry-default-on/proposal.md
@@ -1,28 +1,31 @@
-# Change: OpenTelemetry Default-On with PII-Safe Payload
+# Change: OpenTelemetry Active Opt-In with PII-Safe Payload
 
 ## Why
 
-SpecFact needs honest usage signal to improve the platform, but current telemetry is opt-in and under-utilised. Without default-on telemetry we cannot detect command failures, module-composition regressions, or adoption trends. At the same time, any default-on collection must be PII-safe, single-command opt-out, and automatically disabled in enterprise deployments where central governance owns its own observability. This change establishes the primitives consumed by FinOps outcome evidence, distillation loop health, and enterprise audit.
+SpecFact needs honest usage signal to improve the platform, but the first public telemetry release must earn developer trust before collecting anything. Default-on telemetry would create avoidable community backlash even with a PII-safe payload because developers reasonably expect explicit consent for CLI usage reporting. This change therefore reverts the default-on posture and ships an active opt-in flow during `specfact init` or the first interactive run, with a concise disclosure of what is tracked, what is never tracked, and how to change the setting later.
 
 ## What Changes
 
-- **NEW**: OpenTelemetry emitter enabled by default for CLI invocations, emitting a PII-safe payload (command shape, module composition, duration, exit code, outcome enum).
+- **NEW**: OpenTelemetry emitter available for CLI invocations only after explicit user consent, emitting a PII-safe payload (command shape, module composition, duration, exit code, outcome enum).
+- **NEW**: Active opt-in consent prompt during `specfact init` or the first interactive `specfact` run. Non-interactive, CI, and unattended first runs default to disabled until `specfact telemetry enable` or `SPECFACT_TELEMETRY=true` is provided.
+- **NEW**: Telemetry disclosure copy shown before consent and available from `specfact telemetry status`, clearly stating the tracked fields and rejected categories.
 - **NEW**: Allowlisted payload contract — the five permitted **semantic** telemetry fields are **`command`**, **`duration`**, **`exit_code`**, **`outcome`** (enum), and **`module_composition`** (bundle/module names), mapped onto the versioned schema in `specs/telemetry-otel/spec.md` (additional bounded metadata such as `schema_version`, `run_id`, and coarse platform facts remain allowlisted there). Rejections are **per disallowed category** at the emitter boundary:
   - **File paths** — any filesystem path or repo-relative path is rejected.
   - **Repo names / branches** — repository identifiers, default-branch names, or remote URLs are rejected.
   - **Prompt content** — user prompts, system prompts, or chat transcripts are rejected.
   - **Spec content** — OpenSpec bodies, markdown specs, or large free-text blobs are rejected.
   - **Free-form strings** — unconstrained error text, log lines, or narrative strings are rejected (bounded error **class** only).
-- **NEW**: `specfact telemetry [enable|disable|status]` command surface plus `SPECFACT_TELEMETRY=false` environment variable for CI-friendly opt-out.
+- **NEW**: `specfact telemetry [enable|disable|status]` command surface plus `SPECFACT_TELEMETRY=true|false` environment variable for CI-friendly per-process overrides.
 - **NEW**: Enterprise-mode default: when `.specfact/enterprise.yaml` (or equivalent marker) is detected, telemetry defaults to `off` unless an `org-admin` signed policy opts in.
 - **NEW**: Local audit log at `.specfact/telemetry/sent.log` (append-only) recording the exact redacted payload transmitted for each invocation, so users can verify contents.
 - **EXTEND**: `specfact --version` surface prints current telemetry status.
+- **DOCUMENT**: Criteria for revisiting default-on later: published telemetry transparency docs, stable allowlist tests, local audit log adoption, explicit enterprise policy controls, and evidence that the community accepts the opt-in payload contract without privacy complaints.
 
 ## Capabilities
 
 ### New Capability: `telemetry-otel`
 
-Emitter, payload contract, opt-out commands, enterprise default, local audit log.
+Emitter, payload contract, active opt-in commands, enterprise default, local audit log.
 
 ## Migration Notes
 
@@ -35,7 +38,7 @@ Emitter, payload contract, opt-out commands, enterprise default, local audit log
 
 ## Impact
 
-- Downstream (finops-01, knowledge-01, distillation) can rely on a single telemetry surface.
+- Downstream (finops-01, knowledge-01, distillation) can rely on a single telemetry surface when users opt in.
 - Enterprise tier (enterprise-02 audit) reuses the same emitter path but routes to its own exporter.
 - No runtime cost impact for air-gapped users: emitter is a no-op when no exporter is configured.
 

--- a/openspec/changes/telemetry-01-opentelemetry-default-on/proposal.md
+++ b/openspec/changes/telemetry-01-opentelemetry-default-on/proposal.md
@@ -16,7 +16,7 @@ SpecFact needs honest usage signal to improve the platform, but the first public
   - **Spec content** — OpenSpec bodies, markdown specs, or large free-text blobs are rejected.
   - **Free-form strings** — unconstrained error text, log lines, or narrative strings are rejected (bounded error **class** only).
 - **NEW**: `specfact telemetry [enable|disable|status]` command surface plus `SPECFACT_TELEMETRY=true|false` environment variable for CI-friendly per-process overrides.
-- **NEW**: Enterprise-mode default: when `.specfact/enterprise.yaml` (or equivalent marker) is detected, telemetry defaults to `off` unless an `org-admin` signed policy opts in.
+- **NEW**: Enterprise-mode default: when `.specfact/enterprise.yaml` (or equivalent marker) is detected, telemetry defaults to `off` unless a signed `org-admin` policy opts in.
 - **NEW**: Local audit log at `.specfact/telemetry/sent.log` (append-only) recording the exact redacted payload transmitted for each invocation, so users can verify contents.
 - **EXTEND**: `specfact --version` surface prints current telemetry status.
 - **DOCUMENT**: Criteria for revisiting default-on later: published telemetry transparency docs, stable allowlist tests, local audit log adoption, explicit enterprise policy controls, and evidence that the community accepts the opt-in payload contract without privacy complaints.
@@ -35,6 +35,11 @@ Emitter, payload contract, active opt-in commands, enterprise default, local aud
   **deprecation warning**, and (per `design.md`) follows the **dual-write** window so historical consumers keep working
   while new consumers prefer the project-local path. Optional one-time **copy/merge** tooling MAY ship as a follow-up
   command, but the contract only requires dual-append plus warning until the legacy file is removed.
+- **Legacy overrides:** existing `SPECFACT_TELEMETRY_OPT_IN` and `.specfact/config.yaml` `telemetry.opt-in` settings are
+  honored during one deprecation series when `SPECFACT_TELEMETRY` and `telemetry.enabled` are unset. The CLI emits a
+  runtime deprecation warning when a legacy key is used, and emits a conflict warning when legacy and new keys disagree.
+  New keys take precedence over legacy keys. Release notes SHALL publish the cutoff before legacy override support is
+  removed.
 
 ## Impact
 

--- a/openspec/changes/telemetry-01-opentelemetry-default-on/proposal.md
+++ b/openspec/changes/telemetry-01-opentelemetry-default-on/proposal.md
@@ -6,10 +6,10 @@ SpecFact needs honest usage signal to improve the platform, but the first public
 
 ## What Changes
 
-- **NEW**: OpenTelemetry emitter available for CLI invocations only after explicit user consent, emitting a PII-safe payload (`command`, `modules_composed`, `duration_ms`, `exit_code`, `outcome`).
+- **NEW**: OpenTelemetry emitter available for CLI invocations only after explicit user consent, emitting a PII-safe payload with five required semantic fields (`command`, `modules_composed`, `duration_ms`, `exit_code`, `outcome`) plus optional bounded `subcommand`.
 - **NEW**: Active opt-in consent prompt during `specfact init` or the first interactive `specfact` run. Non-interactive, CI, and unattended first runs default to disabled until `specfact telemetry enable` or `SPECFACT_TELEMETRY=true` is provided.
 - **NEW**: Telemetry disclosure copy shown before consent and available from `specfact telemetry status`, clearly stating the tracked fields and rejected categories.
-- **NEW**: Allowlisted payload contract — the five permitted **semantic** telemetry fields are **`command`**, **`modules_composed`** (bundle/module names), **`duration_ms`**, **`exit_code`**, and **`outcome`** (enum), mapped onto the versioned schema in `specs/telemetry-otel/spec.md` (additional bounded metadata such as `schema_version`, `run_id`, and coarse platform facts remain allowlisted there). Rejections are **per disallowed category** at the emitter boundary:
+- **NEW**: Allowlisted payload contract — the five required **semantic** telemetry fields are **`command`**, **`modules_composed`** (bundle/module names), **`duration_ms`**, **`exit_code`**, and **`outcome`** (enum), plus optional bounded **`subcommand`**, mapped onto the versioned schema in `specs/telemetry-otel/spec.md` (additional bounded metadata such as `schema_version`, `run_id`, and coarse platform facts remain allowlisted there). Rejections are **per disallowed category** at the emitter boundary:
   - **File paths** — any filesystem path or repo-relative path is rejected.
   - **Repo names / branches** — repository identifiers, default-branch names, or remote URLs are rejected.
   - **Prompt content** — user prompts, system prompts, or chat transcripts are rejected.

--- a/openspec/changes/telemetry-01-opentelemetry-default-on/proposal.md
+++ b/openspec/changes/telemetry-01-opentelemetry-default-on/proposal.md
@@ -6,10 +6,10 @@ SpecFact needs honest usage signal to improve the platform, but the first public
 
 ## What Changes
 
-- **NEW**: OpenTelemetry emitter available for CLI invocations only after explicit user consent, emitting a PII-safe payload (command shape, module composition, duration, exit code, outcome enum).
+- **NEW**: OpenTelemetry emitter available for CLI invocations only after explicit user consent, emitting a PII-safe payload (`command`, `modules_composed`, `duration_ms`, `exit_code`, `outcome`).
 - **NEW**: Active opt-in consent prompt during `specfact init` or the first interactive `specfact` run. Non-interactive, CI, and unattended first runs default to disabled until `specfact telemetry enable` or `SPECFACT_TELEMETRY=true` is provided.
 - **NEW**: Telemetry disclosure copy shown before consent and available from `specfact telemetry status`, clearly stating the tracked fields and rejected categories.
-- **NEW**: Allowlisted payload contract — the five permitted **semantic** telemetry fields are **`command`**, **`duration`**, **`exit_code`**, **`outcome`** (enum), and **`module_composition`** (bundle/module names), mapped onto the versioned schema in `specs/telemetry-otel/spec.md` (additional bounded metadata such as `schema_version`, `run_id`, and coarse platform facts remain allowlisted there). Rejections are **per disallowed category** at the emitter boundary:
+- **NEW**: Allowlisted payload contract — the five permitted **semantic** telemetry fields are **`command`**, **`modules_composed`** (bundle/module names), **`duration_ms`**, **`exit_code`**, and **`outcome`** (enum), mapped onto the versioned schema in `specs/telemetry-otel/spec.md` (additional bounded metadata such as `schema_version`, `run_id`, and coarse platform facts remain allowlisted there). Rejections are **per disallowed category** at the emitter boundary:
   - **File paths** — any filesystem path or repo-relative path is rejected.
   - **Repo names / branches** — repository identifiers, default-branch names, or remote URLs are rejected.
   - **Prompt content** — user prompts, system prompts, or chat transcripts are rejected.

--- a/openspec/changes/telemetry-01-opentelemetry-default-on/specs/telemetry-otel/spec.md
+++ b/openspec/changes/telemetry-01-opentelemetry-default-on/specs/telemetry-otel/spec.md
@@ -16,7 +16,7 @@ The system SHALL emit a summary telemetry event for every CLI invocation when te
 - **GIVEN** a community-tier installation with telemetry enabled by `specfact init`, first-run consent, `specfact telemetry enable`, project config, or `SPECFACT_TELEMETRY=true`
 - **WHEN** any `specfact` command runs to completion
 - **THEN** a single summary event is emitted containing only allowlisted fields
-- **AND** the event records command, duration, exit code, and outcome enum.
+- **AND** the event records the five semantic fields specified in the disclosure requirement.
 
 #### Scenario: First interactive run asks for consent before emission
 
@@ -67,7 +67,7 @@ The system SHALL provide single-command enable/disable/status controls and envir
 
 #### Scenario: `SPECFACT_TELEMETRY=true` enables one invocation without persisted consent
 
-- **GIVEN** no persisted telemetry consent exists
+- **GIVEN** a community-tier installation with no enterprise marker and no persisted telemetry consent
 - **WHEN** a command runs with `SPECFACT_TELEMETRY=true`
 - **THEN** one telemetry event is emitted if payload validation passes
 - **AND** persisted configuration is not modified.
@@ -94,7 +94,7 @@ The system SHALL disclose what telemetry tracks and rejects before consent and f
 
 - **GIVEN** the user sees the `specfact init`, first-run consent, or `specfact telemetry status` disclosure
 - **WHEN** telemetry disclosure is rendered
-- **THEN** it lists the tracked command/subcommand, module composition, duration, exit code, outcome enum, schema version, run ID, timestamp, Python major/minor version, and coarse platform fields
+- **THEN** it lists the tracked `command`, `subcommand`, `modules_composed`, `duration_ms`, `exit_code`, `outcome`, `schema_version`, `run_id`, `timestamp`, Python major/minor version, and coarse platform fields
 - **AND** it states that file paths, repo names, branch names, remotes, prompt content, chat transcripts, spec content, usernames, emails, hostnames, free-form logs, and raw error messages are not collected.
 
 ### Requirement: Enterprise Default-Off

--- a/openspec/changes/telemetry-01-opentelemetry-default-on/specs/telemetry-otel/spec.md
+++ b/openspec/changes/telemetry-01-opentelemetry-default-on/specs/telemetry-otel/spec.md
@@ -1,15 +1,36 @@
 ## ADDED Requirements
 
-### Requirement: OpenTelemetry Default-On Emitter
+### Requirement: OpenTelemetry Active Opt-In Emitter
 
 The system SHALL emit a summary telemetry event for every CLI invocation when telemetry is enabled, using an allowlisted PII-safe payload.
 
-#### Scenario: Default community-tier invocation emits a summary event
+#### Scenario: Community-tier invocation stays silent before consent
 
-- **GIVEN** a community-tier installation with no explicit telemetry configuration
+- **GIVEN** a community-tier installation with no explicit telemetry configuration or recorded consent
+- **WHEN** any `specfact` command runs to completion
+- **THEN** no telemetry event is emitted
+- **AND** `specfact telemetry status` reports `disabled (source: unconfigured)`.
+
+#### Scenario: Explicitly opted-in invocation emits a summary event
+
+- **GIVEN** a community-tier installation with telemetry enabled by `specfact init`, first-run consent, `specfact telemetry enable`, project config, or `SPECFACT_TELEMETRY=true`
 - **WHEN** any `specfact` command runs to completion
 - **THEN** a single summary event is emitted containing only allowlisted fields
 - **AND** the event records command, duration, exit code, and outcome enum.
+
+#### Scenario: First interactive run asks for consent before emission
+
+- **GIVEN** an interactive terminal with no explicit telemetry configuration or recorded consent
+- **WHEN** the first `specfact` command reaches telemetry resolution
+- **THEN** the CLI shows a concise telemetry disclosure before asking for consent
+- **AND** no telemetry event is emitted unless the user accepts.
+
+#### Scenario: Non-interactive first run does not prompt and remains disabled
+
+- **GIVEN** a non-interactive terminal or CI environment with no explicit telemetry configuration or recorded consent
+- **WHEN** the first `specfact` command reaches telemetry resolution
+- **THEN** the CLI does not prompt
+- **AND** no telemetry event is emitted.
 
 #### Scenario: Disallowed fields are rejected before transmission
 
@@ -18,9 +39,16 @@ The system SHALL emit a summary telemetry event for every CLI invocation when te
 - **THEN** validation raises and no event is transmitted
 - **AND** the rejection is logged to stderr at debug level without the offending value.
 
-### Requirement: Telemetry Opt-Out Surface
+### Requirement: Telemetry Consent Surface
 
-The system SHALL provide a single-command opt-out and an environment-variable opt-out honouring a deterministic resolution chain.
+The system SHALL provide single-command enable/disable/status controls and environment-variable overrides honouring a deterministic resolution chain.
+
+#### Scenario: `specfact init` records active opt-in
+
+- **GIVEN** a user runs `specfact init` in an interactive terminal
+- **WHEN** the user accepts the telemetry prompt after reading the disclosure
+- **THEN** telemetry is persisted as enabled for the configured scope
+- **AND** `specfact telemetry status` reports `enabled` with the consent source.
 
 #### Scenario: `specfact telemetry disable` persists across invocations
 
@@ -35,6 +63,24 @@ The system SHALL provide a single-command opt-out and an environment-variable op
 - **WHEN** a command runs with `SPECFACT_TELEMETRY=false`
 - **THEN** no event is emitted for that invocation
 - **AND** persisted configuration is not modified.
+
+#### Scenario: `SPECFACT_TELEMETRY=true` enables one invocation without persisted consent
+
+- **GIVEN** no persisted telemetry consent exists
+- **WHEN** a command runs with `SPECFACT_TELEMETRY=true`
+- **THEN** one telemetry event is emitted if payload validation passes
+- **AND** persisted configuration is not modified.
+
+### Requirement: Telemetry Disclosure
+
+The system SHALL disclose what telemetry tracks and rejects before consent and from the status command.
+
+#### Scenario: Disclosure lists tracked fields and rejected categories
+
+- **GIVEN** the user sees the `specfact init`, first-run consent, or `specfact telemetry status` disclosure
+- **WHEN** telemetry disclosure is rendered
+- **THEN** it lists the tracked command/subcommand, module composition, duration, exit code, outcome enum, schema version, run ID, timestamp, Python major/minor version, and coarse platform fields
+- **AND** it states that file paths, repo names, branch names, remotes, prompt content, chat transcripts, spec content, usernames, emails, hostnames, free-form logs, and raw error messages are not collected.
 
 ### Requirement: Enterprise Default-Off
 

--- a/openspec/changes/telemetry-01-opentelemetry-default-on/specs/telemetry-otel/spec.md
+++ b/openspec/changes/telemetry-01-opentelemetry-default-on/specs/telemetry-otel/spec.md
@@ -33,10 +33,18 @@ The system SHALL emit a summary telemetry event for every CLI invocation when te
 - **THEN** the CLI does not prompt
 - **AND** no telemetry event is emitted.
 
-#### Scenario: Disallowed fields are rejected before transmission
+#### Scenario: Current emitter drops non-allowlisted fields before transmission
 
-- **GIVEN** an emitter attempts to include a file path or free-form string
-- **WHEN** the payload is validated
+- **GIVEN** the current `TelemetryManager._sanitize` implementation receives non-allowlisted metadata
+- **WHEN** a telemetry event is built before transmission
+- **THEN** non-allowlisted keys are silently dropped
+- **AND** the transmitted or locally recorded event contains only allowlisted keys.
+
+#### Scenario: Target-state validator rejects disallowed categories before transmission
+
+- **GIVEN** the target-state emitter attempts to include a file path, repo identifier, prompt content, spec content, or
+  free-form string outside the allowlist
+- **WHEN** the payload is validated after the hard-fail rollout gate is enabled
 - **THEN** validation raises and no event is transmitted
 - **AND** the rejection is logged to stderr at debug level without the offending value.
 

--- a/openspec/changes/telemetry-01-opentelemetry-default-on/specs/telemetry-otel/spec.md
+++ b/openspec/changes/telemetry-01-opentelemetry-default-on/specs/telemetry-otel/spec.md
@@ -4,10 +4,10 @@
 
 The system SHALL emit a summary telemetry event for every CLI invocation when telemetry is enabled, using an allowlisted PII-safe payload.
 
-#### Scenario: Community-tier invocation stays silent before consent
+#### Scenario: Community-tier unprompted invocation stays silent before consent
 
 - **GIVEN** a community-tier installation with no explicit telemetry configuration or recorded consent
-- **WHEN** any `specfact` command runs to completion
+- **WHEN** a `specfact` command runs without an interactive consent prompt
 - **THEN** no telemetry event is emitted
 - **AND** `specfact telemetry status` reports `disabled (source: unconfigured)`.
 
@@ -23,7 +23,8 @@ The system SHALL emit a summary telemetry event for every CLI invocation when te
 - **GIVEN** an interactive terminal with no explicit telemetry configuration or recorded consent
 - **WHEN** the first `specfact` command reaches telemetry resolution
 - **THEN** the CLI shows a concise telemetry disclosure before asking for consent
-- **AND** no telemetry event is emitted unless the user accepts.
+- **AND** the current command emits no telemetry if the user declines
+- **AND** the current command MAY emit exactly one summary event after consent is recorded if the user accepts.
 
 #### Scenario: Non-interactive first run does not prompt and remains disabled
 
@@ -71,6 +72,20 @@ The system SHALL provide single-command enable/disable/status controls and envir
 - **THEN** one telemetry event is emitted if payload validation passes
 - **AND** persisted configuration is not modified.
 
+#### Scenario: Legacy telemetry opt-in overrides are honored during deprecation
+
+- **GIVEN** `SPECFACT_TELEMETRY` is unset and `SPECFACT_TELEMETRY_OPT_IN=true`
+- **WHEN** telemetry state is resolved
+- **THEN** telemetry is treated as enabled for that invocation outside enterprise governance
+- **AND** a runtime deprecation warning tells the user to migrate to `SPECFACT_TELEMETRY=true`.
+
+#### Scenario: New telemetry overrides take precedence over legacy overrides
+
+- **GIVEN** `SPECFACT_TELEMETRY=false` and `SPECFACT_TELEMETRY_OPT_IN=true`
+- **WHEN** telemetry state is resolved
+- **THEN** telemetry is disabled for that invocation
+- **AND** a runtime conflict warning states that `SPECFACT_TELEMETRY` took precedence.
+
 ### Requirement: Telemetry Disclosure
 
 The system SHALL disclose what telemetry tracks and rejects before consent and from the status command.
@@ -92,6 +107,27 @@ The system SHALL default telemetry to disabled when an enterprise marker is pres
 - **WHEN** a command runs
 - **THEN** no telemetry is emitted
 - **AND** `specfact telemetry status` reports `disabled (source: enterprise-default)`.
+
+#### Scenario: Enterprise marker blocks transient environment enable without signed policy
+
+- **GIVEN** `.specfact/enterprise.yaml` is present without an enabling org policy
+- **WHEN** a command runs with `SPECFACT_TELEMETRY=true`
+- **THEN** no telemetry is emitted
+- **AND** `specfact telemetry status` reports `disabled (source: enterprise-default)`.
+
+#### Scenario: Enterprise signed policy permits transient environment enable
+
+- **GIVEN** `.specfact/enterprise.yaml` is present with a signed org policy that permits telemetry
+- **WHEN** a command runs with `SPECFACT_TELEMETRY=true`
+- **THEN** one telemetry event is emitted if payload validation passes
+- **AND** persisted configuration is not modified.
+
+#### Scenario: Enterprise signed policy does not override explicit transient disable
+
+- **GIVEN** `.specfact/enterprise.yaml` is present with a signed org policy that permits telemetry
+- **WHEN** a command runs with `SPECFACT_TELEMETRY=false`
+- **THEN** no telemetry is emitted
+- **AND** persisted configuration is not modified.
 
 ### Requirement: Local Redacted Audit Log
 

--- a/openspec/changes/telemetry-01-opentelemetry-default-on/specs/telemetry-otel/spec.md
+++ b/openspec/changes/telemetry-01-opentelemetry-default-on/specs/telemetry-otel/spec.md
@@ -16,7 +16,7 @@ The system SHALL emit a summary telemetry event for every CLI invocation when te
 - **GIVEN** a community-tier installation with telemetry enabled by `specfact init`, first-run consent, `specfact telemetry enable`, project config, or `SPECFACT_TELEMETRY=true`
 - **WHEN** any `specfact` command runs to completion
 - **THEN** a single summary event is emitted containing only allowlisted fields
-- **AND** the event records the five semantic fields specified in the disclosure requirement.
+- **AND** the event records the five required semantic fields specified in the disclosure requirement.
 
 #### Scenario: First interactive run asks for consent before emission
 
@@ -94,7 +94,8 @@ The system SHALL disclose what telemetry tracks and rejects before consent and f
 
 - **GIVEN** the user sees the `specfact init`, first-run consent, or `specfact telemetry status` disclosure
 - **WHEN** telemetry disclosure is rendered
-- **THEN** it lists the tracked `command`, `subcommand`, `modules_composed`, `duration_ms`, `exit_code`, `outcome`, `schema_version`, `run_id`, `timestamp`, Python major/minor version, and coarse platform fields
+- **THEN** it lists the five required semantic fields `command`, `modules_composed`, `duration_ms`, `exit_code`, and `outcome`
+- **AND** it lists optional bounded `subcommand`, `schema_version`, `run_id`, `timestamp`, Python major/minor version, and coarse platform fields
 - **AND** it states that file paths, repo names, branch names, remotes, prompt content, chat transcripts, spec content, usernames, emails, hostnames, free-form logs, and raw error messages are not collected.
 
 ### Requirement: Enterprise Default-Off

--- a/openspec/changes/telemetry-01-opentelemetry-default-on/tasks.md
+++ b/openspec/changes/telemetry-01-opentelemetry-default-on/tasks.md
@@ -2,35 +2,40 @@
 
 ## 1. Branch and dependency guardrails
 
-- [ ] 1.1 Create dedicated worktree branch `feature/telemetry-01-opentelemetry-default-on` from `origin/dev` (per
+- [ ] 1.1 Create dedicated worktree branch `feature/telemetry-01-opt-in-scope` from `origin/dev` for the scope rewrite, then use a fresh implementation branch from `origin/dev` after validation (per
   `AGENTS.md`; use `git worktree add` … `origin/dev`, not a stale local `dev` tip).
 - [ ] 1.2 Run `hatch env create` in the worktree (Hatch bootstrap) before implementation.
 - [ ] 1.3 Pre-flight checks: `hatch run format`/`lint` smoke as applicable, `hatch run smart-test` parity or CI-green base,
   and clean `git status` before merge-related pushes.
 - [ ] 1.4 `AGENTS.md` policy self-check (worktree-only; no commits from protected checkouts).
-- [ ] 1.5 Confirm no prerequisite changes are required (this change is foundational).
+- [ ] 1.5 Revert or supersede any pending implementation branch that shipped community default-on telemetry before continuing implementation.
 - [ ] 1.6 Reconfirm scope against plan and proposal.
 
 ## 2. Spec-first and test-first preparation
 
-- [ ] 2.1 Finalize `specs/telemetry-otel/spec.md` with all listed scenarios.
+- [ ] 2.1 Finalize `specs/telemetry-otel/spec.md` with active opt-in, first-run consent, disclosure, and enterprise-default-off scenarios.
 - [ ] 2.2 Write pydantic allowlist model tests that fail first (disallowed field, missing field, wrong enum).
-- [ ] 2.3 Write resolution-chain tests (env > CLI > config > profile > enterprise default > builtin) that fail first.
-- [ ] 2.4 Capture failing-first output in `TDD_EVIDENCE.md`.
+- [ ] 2.3 Write resolution-chain tests (env > CLI > config > init/first-run consent > profile > enterprise default > builtin disabled) that fail first.
+- [ ] 2.4 Write first-run consent tests: interactive prompt accepts, interactive prompt declines, non-interactive no-prompt disabled.
+- [ ] 2.5 Write telemetry disclosure tests proving tracked fields and rejected categories are rendered before consent and in status output.
+- [ ] 2.6 Capture failing-first output in `TDD_EVIDENCE.md`.
 
 ## 3. Implementation
 
 - [ ] 3.1 Implement `TelemetryEmitter` with pydantic allowlist model in `src/specfact_cli/telemetry/emitter.py`.
 - [ ] 3.2 Implement resolution chain in `src/specfact_cli/telemetry/resolution.py` with `@icontract`/`@beartype`.
 - [ ] 3.3 Implement `specfact telemetry [enable|disable|status]` command surface.
-- [ ] 3.4 Implement `.specfact/telemetry/sent.log` append-only writer.
-- [ ] 3.5 Wire enterprise-default detection (`.specfact/enterprise.yaml` + `SPECFACT_ENTERPRISE` env).
-- [ ] 3.6 Wire emitter into CLI entry point so every invocation flows through it.
+- [ ] 3.4 Implement `specfact init` and first-interactive-run active opt-in consent recording.
+- [ ] 3.5 Implement non-interactive/CI disabled-by-default handling with no prompt.
+- [ ] 3.6 Implement telemetry disclosure rendering for consent and status surfaces.
+- [ ] 3.7 Implement `.specfact/telemetry/sent.log` append-only writer for transmitted payloads.
+- [ ] 3.8 Wire enterprise-default detection (`.specfact/enterprise.yaml` + `SPECFACT_ENTERPRISE` env).
+- [ ] 3.9 Wire emitter into CLI entry point so opted-in invocations flow through it.
 
 ## 4. Validation and documentation
 
 - [ ] 4.1 Re-run tests until all scenarios pass; update `TDD_EVIDENCE.md`.
-- [ ] 4.2 Update `docs/` with telemetry policy, opt-out instructions, payload schema.
+- [ ] 4.2 Update `docs/` with telemetry policy, active opt-in instructions, payload schema, and "what is never tracked" disclosure.
 - [ ] 4.3 Add payload schema to `docs/agent-rules/` for downstream consumers (finops, enterprise).
 - [ ] 4.4 Run `openspec validate telemetry-01-opentelemetry-default-on --strict`.
 - [ ] 4.5 Run `hatch run format && hatch run type-check && hatch run contract-test && hatch test --cover -v`.
@@ -39,9 +44,9 @@
 
 - [ ] 5.1 Mirror change to `specfact-cli-internal/wiki/sources/telemetry-01-opentelemetry-default-on.md`; run `scripts/wiki_rebuild_graph.py`.
 - [ ] 5.2 Update `openspec/CHANGE_ORDER.md` with this change and its downstream dependents (finops-01, enterprise-02).
-- [ ] 5.3 Open PR from `feature/telemetry-01-opentelemetry-default-on` to `dev`.
+- [ ] 5.3 Open PR from the validated telemetry implementation branch to `dev`.
 - [ ] 5.4 After merge to `dev`, from repository root run `openspec archive telemetry-01-opentelemetry-default-on` when the
   change is complete (do not manually move change folders).
-- [ ] 5.5 Post-merge cleanup: `git worktree remove <path>`, `git branch -d feature/telemetry-01-opentelemetry-default-on`,
+- [ ] 5.5 Post-merge cleanup: `git worktree remove <path>`, delete the telemetry implementation branch,
   `git worktree prune`, and delete the remote feature branch if your release flow requires (`git push origin --delete
-  feature/telemetry-01-opentelemetry-default-on`).
+  <branch>`).

--- a/openspec/changes/telemetry-01-opentelemetry-default-on/tasks.md
+++ b/openspec/changes/telemetry-01-opentelemetry-default-on/tasks.md
@@ -33,16 +33,17 @@
 - [ ] 3.5 Implement non-interactive/CI disabled-by-default handling with no prompt.
 - [ ] 3.6 Implement legacy override compatibility and deprecation/conflict warnings.
 - [ ] 3.7 Implement telemetry disclosure rendering for consent and status surfaces.
-- [ ] 3.8 Implement `.specfact/telemetry/sent.log` append-only writer for transmitted payloads.
-- [ ] 3.9 Wire enterprise-default detection (`.specfact/enterprise.yaml` + `SPECFACT_ENTERPRISE` env).
+- [ ] 3.8 Implement `.specfact/telemetry/sent.log` append-only writer for transmitted payloads, including dual-write to
+  the legacy telemetry log for the full deprecation-window migration.
+- [ ] 3.9 Wire enterprise-default detection (`.specfact/enterprise.yaml` + `SPECFACT_ENTERPRISE` env) through signed-policy
+  verification before enterprise telemetry behavior can enable emission.
 - [ ] 3.10 Wire emitter into CLI entry point so opted-in invocations flow through it.
 
 ## 4. Validation and documentation
 
 - [ ] 4.1 Re-run tests until all scenarios pass; update `TDD_EVIDENCE.md`.
-- [ ] 4.2 Update `docs/` and adjacent modules documentation (`specfact-cli-modules/docs/reference/telemetry.md` when present)
-  with telemetry policy, active opt-in instructions, payload schema, precedence/deprecation behavior, and "what is never
-  tracked" disclosure.
+- [ ] 4.2 Update `docs/` and `specfact-cli-modules/docs/reference/telemetry.md` with telemetry policy, active opt-in
+  instructions, payload schema, precedence/deprecation behavior, and "what is never tracked" disclosure.
 - [ ] 4.3 Add payload schema to `docs/agent-rules/` for downstream consumers (finops, enterprise).
 - [ ] 4.4 Run `openspec validate telemetry-01-opentelemetry-default-on --strict`.
 - [ ] 4.5 Run `hatch run format && hatch run type-check && hatch run contract-test && hatch test --cover -v`.

--- a/openspec/changes/telemetry-01-opentelemetry-default-on/tasks.md
+++ b/openspec/changes/telemetry-01-opentelemetry-default-on/tasks.md
@@ -40,7 +40,9 @@
 ## 4. Validation and documentation
 
 - [ ] 4.1 Re-run tests until all scenarios pass; update `TDD_EVIDENCE.md`.
-- [ ] 4.2 Update `docs/` with telemetry policy, active opt-in instructions, payload schema, and "what is never tracked" disclosure.
+- [ ] 4.2 Update `docs/` and adjacent modules documentation (`specfact-cli-modules/docs/reference/telemetry.md` when present)
+  with telemetry policy, active opt-in instructions, payload schema, precedence/deprecation behavior, and "what is never
+  tracked" disclosure.
 - [ ] 4.3 Add payload schema to `docs/agent-rules/` for downstream consumers (finops, enterprise).
 - [ ] 4.4 Run `openspec validate telemetry-01-opentelemetry-default-on --strict`.
 - [ ] 4.5 Run `hatch run format && hatch run type-check && hatch run contract-test && hatch test --cover -v`.

--- a/openspec/changes/telemetry-01-opentelemetry-default-on/tasks.md
+++ b/openspec/changes/telemetry-01-opentelemetry-default-on/tasks.md
@@ -15,10 +15,14 @@
 
 - [ ] 2.1 Finalize `specs/telemetry-otel/spec.md` with active opt-in, first-run consent, disclosure, and enterprise-default-off scenarios.
 - [ ] 2.2 Write pydantic allowlist model tests that fail first (disallowed field, missing field, wrong enum).
-- [ ] 2.3 Write resolution-chain tests (env > CLI > config > init/first-run consent > profile > enterprise default > builtin disabled) that fail first.
-- [ ] 2.4 Write first-run consent tests: interactive prompt accepts, interactive prompt declines, non-interactive no-prompt disabled.
-- [ ] 2.5 Write telemetry disclosure tests proving tracked fields and rejected categories are rendered before consent and in status output.
-- [ ] 2.6 Capture failing-first output in `TDD_EVIDENCE.md`.
+- [ ] 2.3 Write resolution-chain tests (env > CLI > config > init/first-run consent > profile > builtin disabled) that fail first.
+- [ ] 2.4 Write enterprise-overlay tests proving signed-policy gating is applied after resolution and fails first when
+  the overlay is missing or signature verification fails.
+- [ ] 2.5 Write legacy override migration tests for `SPECFACT_TELEMETRY_OPT_IN` and `telemetry.opt-in`, including
+  deprecation warnings and new-key precedence on conflicts.
+- [ ] 2.6 Write first-run consent tests: interactive prompt accepts, interactive prompt declines, non-interactive no-prompt disabled.
+- [ ] 2.7 Write telemetry disclosure tests proving tracked fields and rejected categories are rendered before consent and in status output.
+- [ ] 2.8 Capture failing-first output in `TDD_EVIDENCE.md`.
 
 ## 3. Implementation
 
@@ -27,10 +31,11 @@
 - [ ] 3.3 Implement `specfact telemetry [enable|disable|status]` command surface.
 - [ ] 3.4 Implement `specfact init` and first-interactive-run active opt-in consent recording.
 - [ ] 3.5 Implement non-interactive/CI disabled-by-default handling with no prompt.
-- [ ] 3.6 Implement telemetry disclosure rendering for consent and status surfaces.
-- [ ] 3.7 Implement `.specfact/telemetry/sent.log` append-only writer for transmitted payloads.
-- [ ] 3.8 Wire enterprise-default detection (`.specfact/enterprise.yaml` + `SPECFACT_ENTERPRISE` env).
-- [ ] 3.9 Wire emitter into CLI entry point so opted-in invocations flow through it.
+- [ ] 3.6 Implement legacy override compatibility and deprecation/conflict warnings.
+- [ ] 3.7 Implement telemetry disclosure rendering for consent and status surfaces.
+- [ ] 3.8 Implement `.specfact/telemetry/sent.log` append-only writer for transmitted payloads.
+- [ ] 3.9 Wire enterprise-default detection (`.specfact/enterprise.yaml` + `SPECFACT_ENTERPRISE` env).
+- [ ] 3.10 Wire emitter into CLI entry point so opted-in invocations flow through it.
 
 ## 4. Validation and documentation
 


### PR DESCRIPTION
## Summary

- revise `telemetry-01-opentelemetry-default-on` from community default-on to active opt-in
- add explicit consent timing, legacy override compatibility, and enterprise overlay precedence
- update GitHub #518 and parent feature #515 to match the active opt-in scope

## Type of Change

- [ ] Bug fix
- [ ] New feature implementation
- [x] OpenSpec scope refinement
- [x] Documentation/specification update
- [ ] Release/change finalization

## Contract-First Testing Evidence

- `openspec validate telemetry-01-opentelemetry-default-on --strict`
- `git diff --check`
- pre-commit hooks during commit:
  - markdown auto-fix
  - markdown lint
  - Block 2 code review gate
  - contract-test-status gate

## How Has This Been Tested?

This PR only changes OpenSpec artifacts. I validated the updated proposal, design, tasks, and delta spec with strict
OpenSpec validation and committed through the repository pre-commit gates.

## Quality Gates Status

- [x] Strict OpenSpec validation passed
- [x] Markdown lint passed
- [x] Contract-test-status gate passed
- [x] No production code changed
- [x] No module signing changes required

## Notes

- PR review annotations were addressed by clarifying first-run emission behavior, legacy `SPECFACT_TELEMETRY_OPT_IN` /
  `telemetry.opt-in` migration, and enterprise signed-policy precedence.
- Internal wiki mirror was updated separately in `specfact-cli-internal` and `wiki_rebuild_graph.py` was run there.
