### PR TITLE
fix(ci): isolate module signing privileges from PR verification

### DIFF
--- a/.github/workflows/sign-modules.yml
+++ b/.github/workflows/sign-modules.yml
@@ -57,16 +57,14 @@ jobs:
   verify:
     name: Verify Module Signatures
     runs-on: ubuntu-latest
-    outputs:
-      signing_pr_created: ${{ steps.open_auto_sign_pr.outputs.created == 'true' && 'true' || 'false' }}
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Fetch workflow_dispatch comparison base
         if: github.event_name == 'workflow_dispatch'
@@ -81,34 +79,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pyyaml beartype icontract cryptography cffi
-
-      - name: Auto-sign changed bundled modules (push to dev/main)
-        if: >-
-          github.event_name == 'push' &&
-          (github.ref_name == 'dev' || github.ref_name == 'main')
-        env:
-          SPECFACT_MODULE_PRIVATE_SIGN_KEY: ${{ secrets.SPECFACT_MODULE_PRIVATE_SIGN_KEY }}
-          SPECFACT_MODULE_PRIVATE_SIGN_KEY_PASSPHRASE: ${{ secrets.SPECFACT_MODULE_PRIVATE_SIGN_KEY_PASSPHRASE }}
-        run: |
-          set -euo pipefail
-          if [ -z "${SPECFACT_MODULE_PRIVATE_SIGN_KEY}" ]; then
-            echo "::error::Missing SPECFACT_MODULE_PRIVATE_SIGN_KEY. Configure the secret so pushes to ${GITHUB_REF_NAME} can auto-sign bundled modules."
-            exit 1
-          fi
-          BEFORE="${{ github.event.before }}"
-          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
-            BEFORE="$(git rev-parse HEAD~1 2>/dev/null || true)"
-          fi
-          if [ -z "$BEFORE" ]; then
-            echo "::error::Unable to resolve parent commit for --changed-only signing."
-            exit 1
-          fi
-          python scripts/sign-modules.py \
-            --changed-only \
-            --repair-stale-integrity \
-            --base-ref "$BEFORE" \
-            --bump-version patch \
-            --payload-from-filesystem
 
       - name: Strict verify bundled modules (push to dev/main)
         if: github.event_name == 'push' && (github.ref_name == 'dev' || github.ref_name == 'main')
@@ -158,16 +128,73 @@ jobs:
             done
             python scripts/verify-modules-signature.py "${RESIGN_ARGS[@]}"
           else
-            python scripts/verify-modules-signature.py "${VERIFY_ARGS[@]}" --version-check-base "$BASE_REF"
+            python scripts/verify-modules-signature.py "${VERIFY_ARGS[@]}" --version-check-base "$BASE_REF" --require-signature
           fi
+
+  sign_and_pr:
+    name: Auto-sign manifests and open PR (push to dev/main)
+    if: github.event_name == 'push' && (github.ref_name == 'dev' || github.ref_name == 'main')
+    runs-on: ubuntu-latest
+    needs: [verify]
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout trusted scripts (protected branch tip)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ref: ${{ github.ref_name }}
+          path: _trusted_scripts
+
+      - name: Checkout push workspace
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+          path: _workspace
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install signer dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pyyaml beartype icontract cryptography cffi
+
+      - name: Auto-sign changed bundled modules
+        working-directory: _workspace
+        env:
+          SPECFACT_MODULE_PRIVATE_SIGN_KEY: ${{ secrets.SPECFACT_MODULE_PRIVATE_SIGN_KEY }}
+          SPECFACT_MODULE_PRIVATE_SIGN_KEY_PASSPHRASE: ${{ secrets.SPECFACT_MODULE_PRIVATE_SIGN_KEY_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SPECFACT_MODULE_PRIVATE_SIGN_KEY}" ]; then
+            echo "::error::Missing SPECFACT_MODULE_PRIVATE_SIGN_KEY. Configure the secret so pushes to ${GITHUB_REF_NAME} can auto-sign bundled modules."
+            exit 1
+          fi
+          BEFORE="${{ github.event.before }}"
+          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            BEFORE="$(git rev-parse HEAD~1 2>/dev/null || true)"
+          fi
+          if [ -z "$BEFORE" ]; then
+            echo "::error::Unable to resolve parent commit for --changed-only signing."
+            exit 1
+          fi
+          python "${GITHUB_WORKSPACE}/_trusted_scripts/scripts/sign-modules.py" \
+            --changed-only \
+            --repair-stale-integrity \
+            --base-ref "$BEFORE" \
+            --bump-version patch \
+            --payload-from-filesystem
 
       - id: open_auto_sign_pr
         name: Open PR with auto-signed manifests (dev/main; no direct push)
-        if: >-
-          github.event_name == 'push' &&
-          (github.ref_name == 'dev' || github.ref_name == 'main')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: _workspace
         run: |
           set -euo pipefail
           SIGNING_PR_CREATED=false
@@ -191,15 +218,14 @@ jobs:
             --body "Automated integrity refresh after push to \`${GITHUB_REF_NAME}\`. Merge so strict verify and reproducibility run against the signed tip (protected branch — no direct push)."
           SIGNING_PR_CREATED=true
           echo "created=${SIGNING_PR_CREATED}" >> "${GITHUB_OUTPUT}"
-
   reproducibility:
     name: Assert signing reproducibility
     if: >-
       github.event_name == 'push' &&
       github.ref_name == 'main' &&
-      needs.verify.outputs.signing_pr_created != 'true'
+      needs.sign_and_pr.outputs.signing_pr_created != 'true'
     runs-on: ubuntu-latest
-    needs: [verify]
+    needs: [verify, sign_and_pr]
     permissions:
       contents: read
     steps:
@@ -207,6 +233,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Sync to remote branch tip (after verify; skip when a signing PR was opened instead)
         run: |


### PR DESCRIPTION
### Motivation
- Close a CI trust-boundary regression where the PR/dispatch verification job ran branch-controlled scripts with a persisted write-capable checkout token and could execute signing logic from untrusted commits. 
- Ensure signing secrets are only exposed to trusted signer code checked out from a protected ref and that PR verification cannot be bypassed by checksum-only checks. 
- This change aligns the fix with the repository's security/CI hardening work tracked in the `dep-security-cleanup` area of active OpenSpec work.

### Description
- Make the `verify` job read-only by setting `permissions: contents: read` and use `actions/checkout` with `persist-credentials: false` so PR/dispatch verification cannot persist the workflow token into the checked-out tree. 
- Require signatures for PR/dispatch verification by invoking `verify-modules-signature.py` with `--require-signature` on the non-push path to block unsigned manifest merges. 
- Add a dedicated push-only `sign_and_pr` job with `contents: write`/`pull-requests: write` that checks out trusted signing scripts into `_trusted_scripts`, checks out the push workspace into a separate `_workspace`, injects signing secrets only for that job, and runs the signer from the trusted path. 
- Update the `reproducibility` job wiring so it depends on the new `sign_and_pr` output and use `persist-credentials: false` when only read access is required.

### Testing
- Parsed the modified workflow with Python/YAML using `yaml.safe_load(...)` which succeeded. 
- Attempted to run repository `yaml-lint` via `hatch run yaml-lint` but the environment does not have `hatch` installed so the lint step could not be executed here. 
- Verified the workflow file remains valid YAML with `python -m yaml.safe_load` as an automated sanity check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe5cc226108321a5746fdc616e59da)