### PR TITLE
Isolate module auto-signing into dedicated job, tighten verify permissions, and require signatures for PR checks

### DIFF
--- a/.github/workflows/sign-modules.yml
+++ b/.github/workflows/sign-modules.yml
@@ -57,16 +57,14 @@ jobs:
   verify:
     name: Verify Module Signatures
     runs-on: ubuntu-latest
-    outputs:
-      signing_pr_created: ${{ steps.open_auto_sign_pr.outputs.created == 'true' && 'true' || 'false' }}
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Fetch workflow_dispatch comparison base
         if: github.event_name == 'workflow_dispatch'
@@ -81,46 +79,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pyyaml beartype icontract cryptography cffi
-
-      - name: Auto-sign changed bundled modules (push to dev/main)
-        if: >-
-          github.event_name == 'push' &&
-          (github.ref_name == 'dev' || github.ref_name == 'main')
-        env:
-          SPECFACT_MODULE_PRIVATE_SIGN_KEY: ${{ secrets.SPECFACT_MODULE_PRIVATE_SIGN_KEY }}
-          SPECFACT_MODULE_PRIVATE_SIGN_KEY_PASSPHRASE: ${{ secrets.SPECFACT_MODULE_PRIVATE_SIGN_KEY_PASSPHRASE }}
-        run: |
-          set -euo pipefail
-          if [ -z "${SPECFACT_MODULE_PRIVATE_SIGN_KEY}" ]; then
-            echo "::error::Missing SPECFACT_MODULE_PRIVATE_SIGN_KEY. Configure the secret so pushes to ${GITHUB_REF_NAME} can auto-sign bundled modules."
-            exit 1
-          fi
-          BEFORE="${{ github.event.before }}"
-          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
-            BEFORE="$(git rev-parse HEAD~1 2>/dev/null || true)"
-          fi
-          if [ -z "$BEFORE" ]; then
-            echo "::error::Unable to resolve parent commit for --changed-only signing."
-            exit 1
-          fi
-          python scripts/sign-modules.py \
-            --changed-only \
-            --repair-stale-integrity \
-            --base-ref "$BEFORE" \
-            --bump-version patch \
-            --payload-from-filesystem
-
-      - name: Strict verify bundled modules (push to dev/main)
-        if: github.event_name == 'push' && (github.ref_name == 'dev' || github.ref_name == 'main')
-        run: |
-          set -euo pipefail
-          # shellcheck disable=SC1091
-          source scripts/module-verify-policy.sh
-          BEFORE="${{ github.event.before }}"
-          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
-            BEFORE="HEAD~1"
-          fi
-          python scripts/verify-modules-signature.py "${VERIFY_MODULES_STRICT[@]}" --version-check-base "$BEFORE"
 
       - name: PR or dispatch verify (relaxed checksum; version bump vs base)
         if: github.event_name != 'push'
@@ -158,16 +116,87 @@ jobs:
             done
             python scripts/verify-modules-signature.py "${RESIGN_ARGS[@]}"
           else
-            python scripts/verify-modules-signature.py "${VERIFY_ARGS[@]}" --version-check-base "$BASE_REF"
+            python scripts/verify-modules-signature.py "${VERIFY_ARGS[@]}" --version-check-base "$BASE_REF" --require-signature
           fi
+
+  sign_and_pr:
+    name: Auto-sign manifests and open PR (push to dev/main)
+    if: github.event_name == 'push' && (github.ref_name == 'dev' || github.ref_name == 'main')
+    runs-on: ubuntu-latest
+    needs: [verify]
+    outputs:
+      signing_pr_created: ${{ steps.open_auto_sign_pr.outputs.created }}
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout trusted scripts (protected branch tip)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ref: ${{ github.ref_name }}
+          path: _trusted_scripts
+
+      - name: Checkout push workspace
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+          path: _workspace
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install signer dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pyyaml beartype icontract cryptography cffi
+
+      - name: Auto-sign changed bundled modules
+        working-directory: _workspace
+        env:
+          SPECFACT_MODULE_PRIVATE_SIGN_KEY: ${{ secrets.SPECFACT_MODULE_PRIVATE_SIGN_KEY }}
+          SPECFACT_MODULE_PRIVATE_SIGN_KEY_PASSPHRASE: ${{ secrets.SPECFACT_MODULE_PRIVATE_SIGN_KEY_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SPECFACT_MODULE_PRIVATE_SIGN_KEY}" ]; then
+            echo "::error::Missing SPECFACT_MODULE_PRIVATE_SIGN_KEY. Configure the secret so pushes to ${GITHUB_REF_NAME} can auto-sign bundled modules."
+            exit 1
+          fi
+          BEFORE="${{ github.event.before }}"
+          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            BEFORE="$(git rev-parse HEAD~1 2>/dev/null || true)"
+          fi
+          if [ -z "$BEFORE" ]; then
+            echo "::error::Unable to resolve parent commit for --changed-only signing."
+            exit 1
+          fi
+          python "${GITHUB_WORKSPACE}/_trusted_scripts/scripts/sign-modules.py" \
+            --changed-only \
+            --repair-stale-integrity \
+            --base-ref "$BEFORE" \
+            --bump-version patch \
+            --payload-from-filesystem
+
+      - name: Strict verify bundled modules after signing
+        working-directory: _workspace
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC1091
+          source "${GITHUB_WORKSPACE}/_trusted_scripts/scripts/module-verify-policy.sh"
+          BEFORE="${{ github.event.before }}"
+          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            BEFORE="HEAD~1"
+          fi
+          python "${GITHUB_WORKSPACE}/_trusted_scripts/scripts/verify-modules-signature.py" "${VERIFY_MODULES_STRICT[@]}" --version-check-base "$BEFORE"
 
       - id: open_auto_sign_pr
         name: Open PR with auto-signed manifests (dev/main; no direct push)
-        if: >-
-          github.event_name == 'push' &&
-          (github.ref_name == 'dev' || github.ref_name == 'main')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: _workspace
         run: |
           set -euo pipefail
           SIGNING_PR_CREATED=false
@@ -191,15 +220,14 @@ jobs:
             --body "Automated integrity refresh after push to \`${GITHUB_REF_NAME}\`. Merge so strict verify and reproducibility run against the signed tip (protected branch — no direct push)."
           SIGNING_PR_CREATED=true
           echo "created=${SIGNING_PR_CREATED}" >> "${GITHUB_OUTPUT}"
-
   reproducibility:
     name: Assert signing reproducibility
     if: >-
       github.event_name == 'push' &&
       github.ref_name == 'main' &&
-      needs.verify.outputs.signing_pr_created != 'true'
+      needs.sign_and_pr.outputs.signing_pr_created != 'true'
     runs-on: ubuntu-latest
-    needs: [verify]
+    needs: [verify, sign_and_pr]
     permissions:
       contents: read
     steps:
@@ -207,6 +235,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Sync to remote branch tip (after verify; skip when a signing PR was opened instead)
         run: |
@@ -253,6 +282,8 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs: [verify]
+    outputs:
+      signing_pr_created: ${{ steps.open_auto_sign_pr.outputs.created }}
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
### Motivation
- Prevent untrusted workspace code from performing signing and avoid direct pushes to protected branches by running signing from the protected branch tip.
- Reduce write permissions during verification and only grant write permissions to the job that needs them.
- Make PR/dispatch verification stricter by requiring an existing signature and gate reproducibility checks when an auto-signing PR is opened.

### Description
- Reworked `.github/workflows/sign-modules.yml` to move auto-signing steps out of the `verify` job into a new `sign_and_pr` job that checks out trusted scripts at the protected branch tip into `_trusted_scripts` and the push workspace into `_workspace` before signing.
- `verify` job now runs with `contents: read` and `persist-credentials: false` on checkout, and the PR/dispatch path calls the verifier with `--require-signature`.
- `sign_and_pr` job runs on `push` to `dev/main`, has `contents: write` and `pull-requests: write` permissions, performs signing via the protected `_trusted_scripts/scripts/sign-modules.py`, runs strict verification afterward, and opens an auto-sign PR if manifests changed; it exposes `signing_pr_created` as an output.
- `reproducibility` job now depends on `sign_and_pr` and skips its assert when a signing PR was created by checking `needs.sign_and_pr.outputs.signing_pr_created`, and checkouts use `persist-credentials: false`.
- The manual `sign-and-push` (`workflow_dispatch`) job now also exposes `signing_pr_created` from its `open_auto_sign_pr` step.

### Testing
- No automated tests were run as part of this change; modifications are limited to the GitHub Actions workflow file (`.github/workflows/sign-modules.yml`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe5cc226108321a5746fdc616e59da)