### PR TITLE
Fix bundled module publish summary quoting

### DIFF
--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -256,7 +256,6 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist
-          PY_ENTRY_SUMMARY='import sys, yaml; from pathlib import Path; data = yaml.safe_load(Path(sys.argv[1]).read_text(encoding="utf-8")); print(f"{data[\"id\"]}@{data[\"latest_version\"]}")'
           PUBLISHED=()
           while IFS= read -r MODULE_DIR; do
             [ -n "${MODULE_DIR}" ] || continue
@@ -277,7 +276,17 @@ jobs:
               --changed-flag /tmp/index_changed.txt
             CHANGED=$(tr -d '\n' < /tmp/index_changed.txt)
             if [ "${CHANGED}" = "true" ]; then
-              ENTRY="$(python -c "${PY_ENTRY_SUMMARY}" "${FRAGMENT}")"
+              ENTRY="$(
+                python - "${FRAGMENT}" <<'PY'
+          import sys
+          from pathlib import Path
+
+          import yaml
+
+          data = yaml.safe_load(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          print(f"{data['id']}@{data['latest_version']}")
+          PY
+              )"
               PUBLISHED+=("${ENTRY}")
             fi
           done < /tmp/modules_to_publish.txt

--- a/tests/unit/workflows/test_trustworthy_green_checks.py
+++ b/tests/unit/workflows/test_trustworthy_green_checks.py
@@ -13,6 +13,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[3]
 PR_ORCHESTRATOR = REPO_ROOT / ".github" / "workflows" / "pr-orchestrator.yml"
 SIGN_MODULES = REPO_ROOT / ".github" / "workflows" / "sign-modules.yml"
+PUBLISH_MODULES = REPO_ROOT / ".github" / "workflows" / "publish-modules.yml"
 PRE_COMMIT_CONFIG = REPO_ROOT / ".pre-commit-config.yaml"
 CODERABBIT_CONFIG = REPO_ROOT / ".coderabbit.yaml"
 LEGACY_ACTIONLINT_RUNNER = REPO_ROOT / "scripts" / "run_actionlint.sh"
@@ -218,6 +219,15 @@ def test_module_signature_check_name_is_canonical_across_workflows() -> None:
     assert isinstance(sign_job, dict), "Expected verify job in sign-modules workflow"
     dedicated_name = sign_job.get("name")
     assert orchestrator_name == dedicated_name == "Verify Module Signatures"
+
+
+def test_publish_modules_entry_summary_avoids_escaped_fstring_expression() -> None:
+    """Bundled publishing must not use a python -c f-string with shell-escaped quotes."""
+    raw = PUBLISH_MODULES.read_text(encoding="utf-8")
+    assert "PY_ENTRY_SUMMARY=" not in raw
+    assert "python - \"${FRAGMENT}\" <<'PY'" in raw
+    assert "data['id']" in raw
+    assert "data['latest_version']" in raw
 
 
 CANONICAL_VERSION_SOURCE_REGEX = r"^(pyproject\.toml|setup\.py|src/__init__\.py|src/specfact_cli/__init__\.py)$"


### PR DESCRIPTION
## Summary
- Replace the fragile publish-modules Python one-liner with a here-doc snippet.
- Add a workflow regression test that rejects the escaped f-string pattern that failed in Actions.

## Root cause
The Publish Modules workflow passed a Python f-string through `python -c` with shell-escaped quotes inside the f-string expression. Python rejected those backslash escapes at runtime, causing job 76430283685 to fail with a SyntaxError.

## Validation
- `hatch run workflows-lint`
- `hatch run pytest tests/unit/workflows/test_trustworthy_green_checks.py -q`
- `hatch run lint`
- `SPECFACT_MODULES_ROOTS=/home/dom/git/nold-ai/specfact-cli-modules/packages hatch run specfact code review run --json --out .specfact/code-review.changed.json tests/unit/workflows/test_trustworthy_green_checks.py` -> PASS, 0 findings