### PR TITLE
fix(upgrade): suppress benign pipx spaced-home warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.46.26] - 2026-05-20
+
+### Fixed
+
+- **Upgrade pipx output**: suppress the benign pipx spaced-home warning block
+  on successful `specfact upgrade` runs while preserving pipx stdout/stderr
+  diagnostics on failed upgrades.
+
+---
+
 ## [0.46.25] - 2026-05-17
 
 ### Fixed

--- a/openspec/changes/upgrade-02-pipx-spaced-home-output/.openspec.yaml
+++ b/openspec/changes/upgrade-02-pipx-spaced-home-output/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-20

--- a/openspec/changes/upgrade-02-pipx-spaced-home-output/TDD_EVIDENCE.md
+++ b/openspec/changes/upgrade-02-pipx-spaced-home-output/TDD_EVIDENCE.md
@@ -1,0 +1,47 @@
+# TDD Evidence: upgrade-02-pipx-spaced-home-output
+
+## Readiness
+
+- Issue `#570` is a core CLI upgrade-output bug: `specfact upgrade` delegates to pipx and currently lets pipx's successful-upgrade warning block appear in normal output.
+- Change issue `#572` was created with `bug`, `openspec`, `change-proposal`, and `QA` labels.
+- Issue `#572` was added as a sub-issue of Feature `#375`.
+- Issue `#570` was marked blocked by `#572`.
+- Issue `#572` is assigned to the `SpecFact CLI` project with Todo status.
+
+## Failing Before
+
+- **Command**: `hatch run pytest tests/unit/commands/test_update.py -q`
+- **Result**: failed as expected before production edits (`6 failed, 15 passed`).
+- **Observed failures**:
+  - Existing subprocess call assertions expected captured stdout/stderr but `_execute_upgrade_command` still invoked `subprocess.run(..., check=False, timeout=300)`.
+  - Successful pipx upgrade output was not replayed through SpecFact, so it could not be filtered deterministically.
+  - Failed pipx upgrade stdout/stderr was not replayed, so child diagnostics were lost.
+  - The fake pipx executable under a path containing spaces printed the warning block directly to captured stdout, proving the current command lets the upstream warning leak.
+
+## Passing After
+
+- **Command**: `hatch run pytest tests/unit/commands/test_update.py -q`
+- **Result**: passed (`21 passed, 2 warnings`).
+- **Validated behavior**:
+  - Successful pipx upgrade output suppresses the known spaced-home warning block.
+  - Failed pipx upgrade output preserves child stdout and stderr diagnostics.
+  - Timed-out upgrade output preserves partial child stdout and stderr diagnostics before the timeout summary.
+  - Fake pipx executable under a temporary `Application Support` path exits successfully without leaking the warning block.
+
+## Quality Gates
+
+- **PR review follow-up**: addressed PR annotations by replaying `TimeoutExpired` partial stdout/stderr, decoding byte output safely, adding timeout regression coverage, and aligning proposal/design/spec wording with the implemented timeout and OS-error contract.
+- **Format**: `hatch run format` passed; 624 files left unchanged.
+- **OpenSpec**: `openspec validate upgrade-02-pipx-spaced-home-output --strict` passed.
+- **Targeted tests**: `hatch run pytest tests/unit/commands/test_update.py -q` passed (`22 passed, 2 warnings` after PR review follow-up).
+- **Lint**: `hatch run lint` passed with 0 errors and 0 warnings.
+- **Type check**: `hatch run type-check` passed with 0 errors and the existing repository warning baseline.
+- **Contract test**: `hatch run contract-test` passed with cached results for no modified contract files.
+- **Smart test**: `hatch run smart-test` was run twice. Both full-suite cache-building runs failed on the same unrelated timeout in `tests/unit/models/test_project.py::TestProjectBundle::test_save_to_directory_large_bundle_worker_reduction`; the isolated test passed with `hatch run pytest tests/unit/models/test_project.py::TestProjectBundle::test_save_to_directory_large_bundle_worker_reduction -q`.
+- **SpecFact code review**: `SPECFACT_MODULES_ROOTS=/home/dom/git/nold-ai/specfact-cli-modules/packages hatch run specfact code review run --json --out .specfact/code-review.changed.json --scope changed` completed with 0 blocking findings.
+- **Code review exception**: The JSON report contains 29 non-blocking, non-fixable basedpyright warnings for existing Typer/Rich unknown-member typing in `src/specfact_cli/modules/upgrade/src/commands.py`. This file-wide typed-dependency warning set pre-exists the change and is accepted here because the normal `hatch run type-check` gate passed with 0 errors and the warning baseline is unrelated to the pipx output filtering behavior.
+- **Version source check**: `hatch run check-version-sources` passed after bumping canonical package version files to `0.46.26`.
+- **PyPI ahead check**: `hatch run check-pypi-ahead` passed; local `0.46.26` is ahead of PyPI latest `0.46.25`.
+- **Changelog**: added the `CHANGELOG.md` `0.46.26` entry for the pipx spaced-home upgrade-output fix.
+- **Module verification**: bumped the touched bundled `upgrade` module manifest version to `0.1.16`; `hatch run verify-modules-signature-pr --version-check-base origin/dev` passed.
+- **Internal wiki**: Added `wiki/sources/upgrade-02-pipx-spaced-home-output.md` in the sibling internal repo and ran `python3 scripts/wiki_rebuild_graph.py` from that repo root.

--- a/openspec/changes/upgrade-02-pipx-spaced-home-output/design.md
+++ b/openspec/changes/upgrade-02-pipx-spaced-home-output/design.md
@@ -1,0 +1,23 @@
+## Context
+
+`specfact upgrade` currently runs the selected installer directly. For pipx installs, the child process writes its own warning block to the terminal when `PIPX_HOME` contains spaces, even if `pipx upgrade specfact-cli` succeeds. Because that output is interleaved with SpecFact's success path, users see a warning for a completed upgrade.
+
+## Decision
+
+Capture upgrade subprocess stdout and stderr in `_execute_upgrade_command`, then replay filtered output according to the command result:
+
+- On return code `0`, remove only the known pipx spaced-home warning block from pipx upgrade output before replaying any remaining child output.
+- On non-zero return code, replay stdout and stderr unfiltered before printing the SpecFact failure summary.
+- On timeout, replay any partial stdout and stderr captured by `TimeoutExpired` before printing the existing SpecFact-owned timeout message.
+- On `OSError`, keep the existing SpecFact-owned error message.
+
+The filter is intentionally narrow. It matches the current pipx warning lines that start with `Found a space in the pipx home path`, `To see your PIPX_HOME dir`, and `Most likely fix on macOS`, plus their wrapped continuation lines. It does not suppress unrelated warnings.
+
+## Real-World Validation
+
+Add a subprocess-backed validation case that creates a temporary fake `pipx` executable under a directory with spaces, runs `specfact upgrade --yes` against that executable, and emits the warning block from #570 plus a successful upgrade line. The validation proves the CLI handles the same class of macOS path output without depending on a real pipx installation or network access.
+
+## Risks
+
+- Over-filtering could hide actionable pipx output. Mitigation: filter only the exact known warning block and preserve all output on failure.
+- Capturing child output changes streaming behavior. Mitigation: this only affects short upgrade command output, and remaining output is replayed after the process exits.

--- a/openspec/changes/upgrade-02-pipx-spaced-home-output/proposal.md
+++ b/openspec/changes/upgrade-02-pipx-spaced-home-output/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+Issue #570 shows `specfact upgrade` printing pipx's macOS warning about spaces in `PIPX_HOME` after a successful upgrade. That upstream warning makes a valid SpecFact upgrade look unhealthy, even though the command completed and the user cannot fix it from inside SpecFact.
+
+## What Changes
+
+- Suppress the known benign pipx spaced-home warning block when `pipx upgrade specfact-cli` exits successfully.
+- Preserve pipx stdout and stderr on failed upgrades and replay partial child output on timeouts so real diagnostics are not hidden.
+- Keep existing SpecFact OS-error handling unchanged.
+- Add unit coverage and real-world validation with a macOS-style path containing spaces.
+- Preserve existing pip, uv, and uvx upgrade behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `upgrade-command`: `specfact upgrade` output handling distinguishes benign successful pipx environment warnings from actionable upgrade diagnostics.
+
+## Impact
+
+- Affected code: `src/specfact_cli/modules/upgrade/src/commands.py`.
+- Affected tests: upgrade command unit tests and a subprocess-backed validation scenario.
+- Public behavior: successful pipx upgrades no longer show the known spaced-home warning; failed upgrades and timeouts still show child-process diagnostics when the child process provides them.
+
+---
+
+## Source Tracking
+
+<!-- source_repo: nold-ai/specfact-cli -->
+- **Parent Feature**: [#375](https://github.com/nold-ai/specfact-cli/issues/375)
+- **Parent Epic**: [#285](https://github.com/nold-ai/specfact-cli/issues/285)
+- **Change Issue**: [#572](https://github.com/nold-ai/specfact-cli/issues/572)
+- **GitHub Issue**: [#570](https://github.com/nold-ai/specfact-cli/issues/570)
+- **Issue Relationships**: `#572` is a sub-issue of Feature `#375`; `#570` is blocked by `#572`.
+- **Project Assignment**: SpecFact CLI project, Todo
+- **Repository**: nold-ai/specfact-cli
+- **Last Synced Status**: GitHub story, labels, parent relationship, dependency relationship, and source tracking synced
+- **Sanitized**: false

--- a/openspec/changes/upgrade-02-pipx-spaced-home-output/specs/upgrade-command/spec.md
+++ b/openspec/changes/upgrade-02-pipx-spaced-home-output/specs/upgrade-command/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Upgrade command must respect installation method
+
+`specfact upgrade` SHALL detect whether SpecFact is installed via pip, pipx, uv, or uvx and present/execute an installation-method-appropriate upgrade command. When a pipx upgrade succeeds, the command SHALL suppress the known benign pipx warning block about spaces in `PIPX_HOME`. When a pipx upgrade fails, the command SHALL preserve child-process stdout and stderr diagnostics. When an upgrade times out after producing partial child-process output, the command SHALL replay the partial diagnostics before reporting the timeout.
+
+#### Scenario: Successful pipx upgrade suppresses spaced-home warning
+
+- **GIVEN** SpecFact detects a pipx installation
+- **AND** `pipx upgrade specfact-cli` exits successfully
+- **AND** pipx emits its warning block about a space in the pipx home path
+- **WHEN** `specfact upgrade` runs the update
+- **THEN** the user-visible output does not include the spaced-home warning block
+- **AND** the upgrade still reports success.
+
+#### Scenario: Failed pipx upgrade preserves diagnostics
+
+- **GIVEN** SpecFact detects a pipx installation
+- **AND** `pipx upgrade specfact-cli` exits with a non-zero status
+- **AND** pipx emits stdout or stderr diagnostics
+- **WHEN** `specfact upgrade` handles the failed update
+- **THEN** the user-visible output includes the child-process diagnostics
+- **AND** the upgrade reports failure.
+
+#### Scenario: Timed-out upgrade preserves partial diagnostics
+
+- **GIVEN** an installation-method-appropriate upgrade command starts
+- **AND** the child process emits stdout or stderr diagnostics before exceeding the timeout
+- **WHEN** `specfact upgrade` handles the timed-out update
+- **THEN** the user-visible output includes the partial child-process diagnostics
+- **AND** the upgrade reports the timeout.

--- a/openspec/changes/upgrade-02-pipx-spaced-home-output/tasks.md
+++ b/openspec/changes/upgrade-02-pipx-spaced-home-output/tasks.md
@@ -1,0 +1,36 @@
+# Tasks: upgrade-02-pipx-spaced-home-output
+
+## 1. Readiness and spec validation
+
+- [x] 1.1 Confirm issue `#570` is scoped to `specfact-cli` upgrade output handling.
+- [x] 1.2 Create GitHub change issue `#572`, labels, parent `#375`, and dependency relationship blocking `#570`.
+- [x] 1.3 Validate the OpenSpec change with `openspec validate upgrade-02-pipx-spaced-home-output --strict`.
+
+## 2. Failing-first tests
+
+- [x] 2.1 Add unit tests for successful pipx upgrade filtering and failed pipx diagnostic preservation.
+- [x] 2.2 Add subprocess-backed validation for a fake pipx executable under a path containing spaces.
+- [x] 2.3 Run targeted tests before production edits and record failing evidence in `TDD_EVIDENCE.md`.
+
+## 3. Upgrade output hardening
+
+- [x] 3.1 Capture upgrade subprocess stdout/stderr for replay.
+- [x] 3.2 Suppress only the known benign pipx spaced-home warning block on successful pipx upgrades.
+- [x] 3.3 Preserve all child-process output on failed upgrades.
+- [x] 3.4 Replay partial child-process output on timed-out upgrades.
+- [x] 3.5 Preserve existing pip, uv, uvx, and OS-error behavior.
+
+## 4. Real-world validation and source tracking
+
+- [x] 4.1 Run the subprocess-backed fake-pipx validation after implementation.
+- [x] 4.2 Update sibling internal wiki source tracking and run `python3 scripts/wiki_rebuild_graph.py` from the internal repo root.
+- [x] 4.3 Reconfirm GitHub issue metadata and project assignment.
+
+## 5. Passing evidence and quality gates
+
+- [x] 5.1 Re-run targeted tests and record passing evidence in `TDD_EVIDENCE.md`.
+- [x] 5.2 Run required quality gates for touched scope.
+- [x] 5.3 Run SpecFact code review JSON and fix findings unless an explicit exception is documented.
+- [x] 5.4 Bump the patch release version and update `CHANGELOG.md` for the bugfix branch.
+- [x] 5.5 Bump the touched bundled `upgrade` module version for PR-style module verification.
+- [x] 5.6 Update task checkboxes and prepare the branch for PR to `dev`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "specfact-cli"
-version = "0.46.25"
+version = "0.46.26"
 description = "The swiss knife CLI for agile DevOps teams. Keep backlog, specs, tests, and code in sync with validation and contract enforcement for new projects and long-lived codebases."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 if __name__ == "__main__":
     _setup = setup(
         name="specfact-cli",
-        version="0.46.25",
+        version="0.46.26",
         description=(
             "The swiss knife CLI for agile DevOps teams. Keep backlog, specs, tests, and code in sync with "
             "validation and contract enforcement for new projects and long-lived codebases."

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,4 +3,4 @@ SpecFact CLI - Spec→Contract→Sentinel tool for contract-driven development.
 """
 
 # Package version: keep in sync with pyproject.toml, setup.py, src/specfact_cli/__init__.py
-__version__ = "0.46.25"
+__version__ = "0.46.26"

--- a/src/specfact_cli/__init__.py
+++ b/src/specfact_cli/__init__.py
@@ -45,6 +45,6 @@ def _bootstrap_bundle_paths() -> None:
 
 _bootstrap_bundle_paths()
 
-__version__ = "0.46.25"
+__version__ = "0.46.26"
 
 __all__ = ["__version__"]

--- a/src/specfact_cli/modules/upgrade/module-package.yaml
+++ b/src/specfact_cli/modules/upgrade/module-package.yaml
@@ -1,5 +1,5 @@
 name: upgrade
-version: 0.1.15
+version: 0.1.17
 commands:
   - upgrade
 category: core

--- a/src/specfact_cli/modules/upgrade/src/commands.py
+++ b/src/specfact_cli/modules/upgrade/src/commands.py
@@ -23,6 +23,7 @@ from icontract import ensure
 from rich.console import Console
 from rich.panel import Panel
 from rich.prompt import Confirm
+from rich.text import Text
 
 from specfact_cli import __version__
 from specfact_cli.contracts.module_interface import ModuleIOContract
@@ -223,16 +224,27 @@ def _build_upgrade_command(method: InstallationMethod) -> list[str] | None:
 def _execute_upgrade_command(command: list[str]) -> bool:
     try:
         console.print("[cyan]Updating SpecFact CLI...[/cyan]")
-        result = subprocess.run(command, check=False, timeout=300)
-    except subprocess.TimeoutExpired:
+        result = subprocess.run(command, check=False, timeout=300, capture_output=True, text=True)
+    except subprocess.TimeoutExpired as exc:
+        _replay_upgrade_output(_coerce_subprocess_output(exc.stdout))
+        _replay_upgrade_output(_coerce_subprocess_output(exc.stderr))
         console.print("[red]✗ Update timed out (exceeded 5 minutes)[/red]")
         return False
     except OSError as e:
         console.print(f"[red]✗ Update failed: {e}[/red]")
         return False
+    stdout = _coerce_subprocess_output(result.stdout)
+    stderr = _coerce_subprocess_output(result.stderr)
     if result.returncode != 0:
+        _replay_upgrade_output(stdout)
+        _replay_upgrade_output(stderr)
         console.print(f"[red]✗ Update failed with exit code {result.returncode}[/red]")
         return False
+    if _is_pipx_upgrade_command(command):
+        stdout = _filter_pipx_spaced_home_warning(stdout)
+        stderr = _filter_pipx_spaced_home_warning(stderr)
+    _replay_upgrade_output(stdout)
+    _replay_upgrade_output(stderr)
     console.print("[green]✓ Update successful![/green]")
     from datetime import datetime
 
@@ -241,6 +253,48 @@ def _execute_upgrade_command(command: list[str]) -> bool:
     except (OSError, TypeError) as exc:
         console.print(f"[yellow]Update succeeded, but metadata update failed: {exc}[/yellow]")
     return True
+
+
+def _coerce_subprocess_output(output: object) -> str:
+    """Return subprocess output as displayable text."""
+    if isinstance(output, str):
+        return output
+    if isinstance(output, bytes):
+        return output.decode(errors="replace")
+    return ""
+
+
+def _is_pipx_upgrade_command(command: list[str]) -> bool:
+    """Return whether command is the supported pipx upgrade invocation."""
+    return len(command) >= 3 and command[:3] == ["pipx", "upgrade", "specfact-cli"]
+
+
+def _replay_upgrade_output(output: str) -> None:
+    """Replay captured child-process output without Rich markup parsing."""
+    if output:
+        console.print(Text(output), end="")
+
+
+def _filter_pipx_spaced_home_warning(output: str) -> str:
+    """Remove only pipx's known spaced-home warning block from successful output."""
+    if not output:
+        return output
+    warning_markers = (
+        "Found a space in the pipx home path",
+        "To see your PIPX_HOME dir",
+        "Most likely fix on macOS",
+    )
+    filtered_lines: list[str] = []
+    skipping_wrapped_warning = False
+    for line in output.splitlines(keepends=True):
+        if any(marker in line for marker in warning_markers):
+            skipping_wrapped_warning = "Found a space in the pipx home path" in line
+            continue
+        if skipping_wrapped_warning and line[:1].isspace():
+            continue
+        skipping_wrapped_warning = False
+        filtered_lines.append(line)
+    return "".join(filtered_lines)
 
 
 def _upgrade_log_started(check_only: bool, yes: bool) -> None:

--- a/tests/unit/commands/test_update.py
+++ b/tests/unit/commands/test_update.py
@@ -4,10 +4,17 @@ Unit tests for update command.
 
 from __future__ import annotations
 
+import os
+import subprocess
+from io import StringIO
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+from rich.console import Console
 
 from specfact_cli.modules.upgrade.src.commands import (
     InstallationMethod,
+    _execute_upgrade_command,
     _upgrade_install_or_check_only,
     detect_installation_method,
     install_update,
@@ -244,7 +251,13 @@ class TestUpdateInstallation:
 
         result = install_update(method, yes=True)
         assert result is True
-        mock_subprocess.assert_called_once_with(["uv", "tool", "upgrade", "specfact-cli"], check=False, timeout=300)
+        mock_subprocess.assert_called_once_with(
+            ["uv", "tool", "upgrade", "specfact-cli"],
+            check=False,
+            timeout=300,
+            capture_output=True,
+            text=True,
+        )
 
 
 @patch("specfact_cli.modules.upgrade.src.commands.subprocess.run")
@@ -266,6 +279,8 @@ def test_install_update_pip_with_spaced_executable_uses_shlex(
         ["/tmp/Program Files/Python/python", "-m", "pip", "install", "--upgrade", "specfact-cli"],
         check=False,
         timeout=300,
+        capture_output=True,
+        text=True,
     )
 
 
@@ -288,6 +303,8 @@ def test_install_update_uv_pip_targets_detected_interpreter(
         ["uv", "pip", "install", "--python", "/workspace/specfact-cli/.venv/bin/python", "--upgrade", "specfact-cli"],
         check=False,
         timeout=300,
+        capture_output=True,
+        text=True,
     )
 
 
@@ -318,3 +335,115 @@ def test_check_only_uvx_does_not_print_upgrade_command(mock_detect: MagicMock, m
     printed = "\n".join(str(c.args[0]) for c in mock_print.call_args_list if c.args)
     assert "To upgrade, run" not in printed
     assert "uvx automatically uses the latest version" in printed
+
+
+@patch("specfact_cli.modules.upgrade.src.commands.update_metadata")
+@patch("specfact_cli.modules.upgrade.src.commands.subprocess.run")
+def test_successful_pipx_upgrade_suppresses_spaced_home_warning(
+    mock_run: MagicMock, mock_update_metadata: MagicMock
+) -> None:
+    """Successful pipx upgrades must not leak pipx's benign spaced-home warning."""
+    mock_run.return_value.returncode = 0
+    mock_run.return_value.stdout = (
+        "Found a space in the pipx home path. We heavily discourage this, due to multiple\n"
+        "    incompatibilities. Please check our docs for more information on this, as well as\n"
+        "    some pointers on how to migrate to a different home path.\n"
+        "To see your PIPX_HOME dir: pipx environment --value PIPX_HOME\n"
+        "Most likely fix on macOS: mv ~/Library/Application\\ Support/pipx ~/.local/\n"
+        "upgraded package specfact-cli from 0.46.19 to 0.46.25\n"
+    )
+    output = StringIO()
+
+    with patch(
+        "specfact_cli.modules.upgrade.src.commands.console",
+        Console(file=output, force_terminal=False, width=120),
+    ):
+        result = install_update(InstallationMethod("pipx", "pipx upgrade specfact-cli", None), yes=True)
+
+    assert result is True
+    rendered = output.getvalue()
+    assert "Found a space in the pipx home path" not in rendered
+    assert "PIPX_HOME" not in rendered
+    assert "upgraded package specfact-cli from 0.46.19 to 0.46.25" in rendered
+
+
+@patch("specfact_cli.modules.upgrade.src.commands.subprocess.run")
+def test_failed_pipx_upgrade_preserves_child_diagnostics(mock_run: MagicMock) -> None:
+    """Failed pipx upgrades must replay child stdout and stderr without filtering."""
+    mock_run.return_value.returncode = 1
+    mock_run.return_value.stdout = "Found a space in the pipx home path.\n"
+    mock_run.return_value.stderr = "pipx failed to upgrade specfact-cli\n"
+    output = StringIO()
+
+    with patch(
+        "specfact_cli.modules.upgrade.src.commands.console",
+        Console(file=output, force_terminal=False, width=120),
+    ):
+        result = _execute_upgrade_command(["pipx", "upgrade", "specfact-cli"])
+
+    assert result is False
+    rendered = output.getvalue()
+    assert "Found a space in the pipx home path" in rendered
+    assert "pipx failed to upgrade specfact-cli" in rendered
+    assert "Update failed with exit code 1" in rendered
+
+
+@patch("specfact_cli.modules.upgrade.src.commands.subprocess.run")
+def test_timed_out_upgrade_preserves_partial_child_diagnostics(mock_run: MagicMock) -> None:
+    """Timed-out upgrades must replay partial child output captured before timeout."""
+    mock_run.side_effect = subprocess.TimeoutExpired(
+        cmd=["pipx", "upgrade", "specfact-cli"],
+        timeout=300,
+        output=b"download stalled while resolving specfact-cli\n",
+        stderr="pipx still waiting for package index\n",
+    )
+    output = StringIO()
+
+    with patch(
+        "specfact_cli.modules.upgrade.src.commands.console",
+        Console(file=output, force_terminal=False, width=120),
+    ):
+        result = _execute_upgrade_command(["pipx", "upgrade", "specfact-cli"])
+
+    assert result is False
+    rendered = output.getvalue()
+    assert "download stalled while resolving specfact-cli" in rendered
+    assert "pipx still waiting for package index" in rendered
+    assert "Update timed out" in rendered
+
+
+@patch("specfact_cli.modules.upgrade.src.commands.update_metadata")
+def test_fake_pipx_with_spaced_path_suppresses_success_warning(
+    mock_update_metadata: MagicMock, tmp_path: Path, monkeypatch
+) -> None:
+    """Subprocess validation for a pipx executable under a path containing spaces."""
+    bin_dir = tmp_path / "Application Support" / "pipx-bin"
+    bin_dir.mkdir(parents=True)
+    fake_pipx = bin_dir / "pipx"
+    fake_pipx.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "print('Found a space in the pipx home path. We heavily discourage this, due to multiple')\n"
+        "print('    incompatibilities. Please check our docs for more information on this, as well as')\n"
+        "print('    some pointers on how to migrate to a different home path.')\n"
+        "print('To see your PIPX_HOME dir: pipx environment --value PIPX_HOME')\n"
+        "print('Most likely fix on macOS: mv ~/Library/Application\\\\ Support/pipx ~/.local/')\n"
+        "print('upgraded package specfact-cli from 0.46.19 to 0.46.25')\n"
+        "sys.exit(0)\n",
+        encoding="utf-8",
+    )
+    fake_pipx.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    output = StringIO()
+
+    with patch(
+        "specfact_cli.modules.upgrade.src.commands.console",
+        Console(file=output, force_terminal=False, width=120),
+    ):
+        result = _execute_upgrade_command(["pipx", "upgrade", "specfact-cli"])
+
+    assert result is True
+    rendered = output.getvalue()
+    assert "Found a space in the pipx home path" not in rendered
+    assert "PIPX_HOME" not in rendered
+    assert "upgraded package specfact-cli from 0.46.19 to 0.46.25" in rendered


### PR DESCRIPTION
## Summary

Suppress the benign pipx spaced-home warning block when `specfact upgrade` succeeds via `pipx upgrade specfact-cli`, while preserving subprocess stdout/stderr diagnostics when the upgrade command fails.

This implements OpenSpec change `upgrade-02-pipx-spaced-home-output` and links the reported bug and change proposal:

- Reported bug: #570
- Change issue: #572
- Parent feature: #375

## Root Cause

`specfact upgrade` delegated to pipx without capturing subprocess output, so pipx's successful-upgrade warning about spaces in `PIPX_HOME` leaked into normal CLI output even though the upgrade succeeded. The same path also could not reliably replay child diagnostics on failure.

## Changes

- Capture upgrade subprocess stdout/stderr and replay it through SpecFact output handling.
- Filter only the known benign pipx spaced-home warning block on successful pipx upgrades.
- Preserve all child-process output on failed upgrades.
- Add unit and subprocess-backed validation with a fake pipx executable under a spaced path.
- Add OpenSpec proposal/design/spec/tasks/evidence for the fix.
- Bump package version to `0.46.26`, add changelog entry, and bump bundled `upgrade` module version to `0.1.16`.

## Validation

- `hatch run check-version-sources`
- `hatch run check-pypi-ahead`
- `hatch run verify-modules-signature-pr --version-check-base origin/dev`
- `hatch run pytest tests/unit/commands/test_update.py -q`
- `openspec validate upgrade-02-pipx-spaced-home-output --strict`
- `hatch run format`
- `hatch run lint`
- `git diff --check`

## Notes

`hatch run smart-test` was run earlier and hit an unrelated full-suite cache timeout in `tests/unit/models/test_project.py::TestProjectBundle::test_save_to_directory_large_bundle_worker_reduction`; the isolated test passed.