### PR TITLE
fix: keep core bundled registry URLs scoped

### DIFF
--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -41,6 +41,7 @@ jobs:
       SPECFACT_MODULE_PRIVATE_SIGN_KEY: ${{ secrets.SPECFACT_MODULE_PRIVATE_SIGN_KEY }}
       SPECFACT_MODULE_PRIVATE_SIGN_KEY_PASSPHRASE: ${{ secrets.SPECFACT_MODULE_PRIVATE_SIGN_KEY_PASSPHRASE }}
       BUNDLED_REGISTRY_INDEX: resources/bundled-module-registry/index.json
+      BUNDLED_REGISTRY_DOWNLOAD_BASE_URL: https://github.com/nold-ai/specfact-cli/releases/download
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -114,7 +115,9 @@ jobs:
             MODULE_PATH="${{ steps.resolve.outputs.module_path }}"
           fi
           mkdir -p dist
-          python scripts/publish-module.py "$MODULE_PATH" -o dist --index-fragment dist/registry-entry.yaml
+          python scripts/publish-module.py "$MODULE_PATH" -o dist \
+            --download-base-url "${BUNDLED_REGISTRY_DOWNLOAD_BASE_URL}" \
+            --index-fragment dist/registry-entry.yaml
 
       - name: Read published module metadata
         id: entry
@@ -201,6 +204,7 @@ jobs:
       SPECFACT_MODULE_PRIVATE_SIGN_KEY: ${{ secrets.SPECFACT_MODULE_PRIVATE_SIGN_KEY }}
       SPECFACT_MODULE_PRIVATE_SIGN_KEY_PASSPHRASE: ${{ secrets.SPECFACT_MODULE_PRIVATE_SIGN_KEY_PASSPHRASE }}
       BUNDLED_REGISTRY_INDEX: resources/bundled-module-registry/index.json
+      BUNDLED_REGISTRY_DOWNLOAD_BASE_URL: https://github.com/nold-ai/specfact-cli/releases/download
       HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
       HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
     steps:
@@ -268,7 +272,9 @@ jobs:
               python scripts/sign-modules.py --payload-from-filesystem "${MODULE_DIR}/module-package.yaml"
             fi
 
-            python scripts/publish-module.py "${MODULE_DIR}" -o dist --index-fragment "${FRAGMENT}"
+            python scripts/publish-module.py "${MODULE_DIR}" -o dist \
+              --download-base-url "${BUNDLED_REGISTRY_DOWNLOAD_BASE_URL}" \
+              --index-fragment "${FRAGMENT}"
 
             python scripts/update-registry-index.py \
               --index-path "${BUNDLED_REGISTRY_INDEX}" \

--- a/resources/bundled-module-registry/index.json
+++ b/resources/bundled-module-registry/index.json
@@ -2,19 +2,19 @@
   "modules": [
     {
       "checksum_sha256": "ce82ea7d2a48dfa8b16ad48599ec6daa922d6aa1a61c242da1143366d5d53ec4",
-      "download_url": "https://github.com/nold-ai/specfact-cli-modules/releases/download/init-0.1.33.tar.gz",
+      "download_url": "https://github.com/nold-ai/specfact-cli/releases/download/init-0.1.33.tar.gz",
       "id": "init",
       "latest_version": "0.1.33"
     },
     {
       "checksum_sha256": "49c5bcbef6ce4aba3302b8209d3641cc34430f3fe4754423d61428557f8c641d",
-      "download_url": "https://github.com/nold-ai/specfact-cli-modules/releases/download/upgrade-0.1.19.tar.gz",
+      "download_url": "https://github.com/nold-ai/specfact-cli/releases/download/upgrade-0.1.19.tar.gz",
       "id": "upgrade",
       "latest_version": "0.1.19"
     },
     {
       "checksum_sha256": "79359da27cb1c734a928a453a786b626e7b06654f515f32ead0cf96fa8e70bc2",
-      "download_url": "https://github.com/nold-ai/specfact-cli-modules/releases/download/module-registry-0.1.26.tar.gz",
+      "download_url": "https://github.com/nold-ai/specfact-cli/releases/download/module-registry-0.1.26.tar.gz",
       "id": "module-registry",
       "latest_version": "0.1.26"
     },

--- a/scripts/update-registry-index.py
+++ b/scripts/update-registry-index.py
@@ -17,6 +17,9 @@ from icontract import ensure, require
 
 logger = logging.getLogger(__name__)
 
+CORE_BUNDLED_MODULE_IDS = frozenset({"init", "module-registry", "upgrade", "bundle-mapper"})
+CORE_REPOSITORY_DOWNLOAD_URL_PREFIX = "https://github.com/nold-ai/specfact-cli/releases/download/"
+
 
 @beartype
 @require(
@@ -52,7 +55,19 @@ def _load_entry(entry_fragment: Path) -> dict[str, Any]:
     missing = [key for key in required_keys if not entry.get(key)]
     if missing:
         raise ValueError(f"Entry fragment missing required keys: {', '.join(missing)}")
+    _validate_entry_scope(entry)
     return entry
+
+
+@beartype
+def _validate_entry_scope(entry: dict[str, Any]) -> None:
+    """Reject core bundled module entries that are not scoped to the core repository."""
+    module_id = str(entry["id"])
+    download_url = str(entry["download_url"])
+    if module_id in CORE_BUNDLED_MODULE_IDS and not download_url.startswith(CORE_REPOSITORY_DOWNLOAD_URL_PREFIX):
+        raise ValueError(
+            f"Core bundled module entry {module_id!r} must reference nold-ai/specfact-cli, got {download_url!r}"
+        )
 
 
 def _entry_sort_key(item: object) -> str:

--- a/tests/unit/scripts/test_update_registry_index.py
+++ b/tests/unit/scripts/test_update_registry_index.py
@@ -5,9 +5,20 @@ from __future__ import annotations
 import importlib.util
 import json
 from pathlib import Path
+from typing import Protocol, cast
+
+import pytest
 
 
-def _load_script_module() -> object:
+class UpdateRegistryIndexModule(Protocol):
+    """Protocol for the dynamically loaded update-registry-index script."""
+
+    def main(self, argv: list[str]) -> int:
+        """Run the script entry point."""
+        ...
+
+
+def _load_script_module() -> UpdateRegistryIndexModule:
     """Load scripts/update-registry-index.py as a Python module."""
     script_path = Path(__file__).resolve().parents[3] / "scripts" / "update-registry-index.py"
     spec = importlib.util.spec_from_file_location("update_registry_index", script_path)
@@ -15,7 +26,23 @@ def _load_script_module() -> object:
         raise AssertionError(f"Unable to load script module at {script_path}")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    return module
+    return cast(UpdateRegistryIndexModule, module)
+
+
+def _write_entry_fragment(entry_path: Path, module_id: str, version: str, download_url: str, checksum: str) -> None:
+    """Write a minimal registry entry fragment for updater tests."""
+    entry_path.write_text(
+        "\n".join(
+            [
+                f"id: {module_id}",
+                f"latest_version: {version}",
+                f"download_url: {download_url}",
+                f"checksum_sha256: {checksum}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
 
 
 def test_main_upserts_new_module_entry(tmp_path: Path) -> None:
@@ -24,17 +51,12 @@ def test_main_upserts_new_module_entry(tmp_path: Path) -> None:
     index_path = tmp_path / "index.json"
     entry_path = tmp_path / "entry.yaml"
     index_path.write_text(json.dumps({"schema_version": "1.0.0", "modules": []}), encoding="utf-8")
-    entry_path.write_text(
-        "\n".join(
-            [
-                "id: nold-ai/backlog",
-                "latest_version: 0.1.0",
-                "download_url: https://example.com/backlog-0.1.0.tar.gz",
-                "checksum_sha256: abc",
-                "",
-            ]
-        ),
-        encoding="utf-8",
+    _write_entry_fragment(
+        entry_path,
+        "nold-ai/backlog",
+        "0.1.0",
+        "https://example.com/backlog-0.1.0.tar.gz",
+        "abc",
     )
 
     exit_code = module.main(["--index-path", str(index_path), "--entry-fragment", str(entry_path)])
@@ -66,17 +88,12 @@ def test_main_updates_existing_entry_in_place(tmp_path: Path) -> None:
         ),
         encoding="utf-8",
     )
-    entry_path.write_text(
-        "\n".join(
-            [
-                "id: nold-ai/backlog",
-                "latest_version: 0.2.0",
-                "download_url: https://example.com/backlog-0.2.0.tar.gz",
-                "checksum_sha256: new",
-                "",
-            ]
-        ),
-        encoding="utf-8",
+    _write_entry_fragment(
+        entry_path,
+        "nold-ai/backlog",
+        "0.2.0",
+        "https://example.com/backlog-0.2.0.tar.gz",
+        "new",
     )
 
     exit_code = module.main(["--index-path", str(index_path), "--entry-fragment", str(entry_path)])
@@ -86,3 +103,31 @@ def test_main_updates_existing_entry_in_place(tmp_path: Path) -> None:
     assert len(payload["modules"]) == 1
     assert payload["modules"][0]["latest_version"] == "0.2.0"
     assert payload["modules"][0]["checksum_sha256"] == "new"
+
+
+@pytest.mark.parametrize(
+    "download_url",
+    [
+        "https://github.com/nold-ai/specfact-cli-modules/releases/download/upgrade-0.1.20.tar.gz",
+        "https://example.com/releases/download/upgrade-0.1.20.tar.gz",
+    ],
+)
+def test_main_rejects_core_module_entry_from_unexpected_repository(tmp_path: Path, download_url: str) -> None:
+    """Core bundled module entries must positively target the core repository."""
+    module = _load_script_module()
+    index_path = tmp_path / "index.json"
+    entry_path = tmp_path / "entry.yaml"
+    index_payload = {"schema_version": "1.0.0", "modules": []}
+    index_path.write_text(json.dumps(index_payload), encoding="utf-8")
+    _write_entry_fragment(
+        entry_path,
+        "upgrade",
+        "0.1.20",
+        download_url,
+        "abc",
+    )
+
+    exit_code = module.main(["--index-path", str(index_path), "--entry-fragment", str(entry_path)])
+
+    assert exit_code == 1
+    assert json.loads(index_path.read_text(encoding="utf-8")) == index_payload

--- a/tests/unit/workflows/test_trustworthy_green_checks.py
+++ b/tests/unit/workflows/test_trustworthy_green_checks.py
@@ -230,6 +230,26 @@ def test_publish_modules_entry_summary_avoids_escaped_fstring_expression() -> No
     assert "data['latest_version']" in raw
 
 
+def test_publish_modules_bundled_snapshot_targets_core_repository() -> None:
+    """Bundled snapshot entries for core modules must not inherit the marketplace URL base."""
+    raw = PUBLISH_MODULES.read_text(encoding="utf-8")
+    expected_base = "BUNDLED_REGISTRY_DOWNLOAD_BASE_URL: https://github.com/nold-ai/specfact-cli/releases/download"
+    assert raw.count(expected_base) == 2
+    assert (
+        "BUNDLED_REGISTRY_DOWNLOAD_BASE_URL: https://github.com/nold-ai/specfact-cli-modules/releases/download"
+        not in raw
+    )
+
+    publish_blocks = [block for block in raw.split("\n\n") if "scripts/publish-module.py" in block]
+    assert publish_blocks, "Expected publish-modules workflow to package module artifacts"
+    for block in publish_blocks:
+        assert "--download-base-url" in block, "Bundled publish calls must set the snapshot URL base"
+        assert "${BUNDLED_REGISTRY_DOWNLOAD_BASE_URL}" in block
+        if "--index-fragment" in block:
+            assert "--download-base-url" in block, "Registry fragments must set the bundled snapshot URL base"
+            assert "${BUNDLED_REGISTRY_DOWNLOAD_BASE_URL}" in block
+
+
 CANONICAL_VERSION_SOURCE_REGEX = r"^(pyproject\.toml|setup\.py|src/__init__\.py|src/specfact_cli/__init__\.py)$"
 
 


### PR DESCRIPTION
## Summary

Fixes the bundled registry publishing path so core modules from `specfact-cli` do not get snapshot entries pointing at `nold-ai/specfact-cli-modules`.

## Root Cause

`publish-modules.yml` generated bundled registry fragments through `scripts/publish-module.py` without overriding that script's marketplace-oriented default `--download-base-url`, so core module snapshots inherited the modules-repo URL base.

## Changes

- Set an explicit bundled registry download base for both single-module and batch publish paths: `https://github.com/nold-ai/specfact-cli/releases/download`.
- Add a fail-closed guard in `scripts/update-registry-index.py` that rejects known core bundled module IDs when their generated `download_url` points at `nold-ai/specfact-cli-modules`.
- Correct existing bundled snapshot URLs for `init`, `upgrade`, and `module-registry`.
- Add regression coverage for the workflow and updater guard.

## Validation

- Failing-before: new regression tests failed against the pre-fix behavior.
- `hatch run pytest tests/unit/scripts/test_update_registry_index.py tests/unit/workflows/test_trustworthy_green_checks.py -q`
- `hatch run format`
- `hatch run lint`
- `hatch run workflows-lint`
- `hatch run yaml-lint`
- `hatch run type-check` (exit 0; existing warning set only)
- `hatch run check-version-sources`
- `git diff --check`
- Pre-commit on amended commit: passed, including SpecFact code review with 0 findings.