### PR TITLE
docs: position SpecFact as AI-bloat defense CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.47.4] - 2026-06-02
+
+### Changed
+
+- **AI-bloat defense positioning**: update first-contact README, docs, package
+  metadata, and GitHub metadata guidance so SpecFact leads with deterministic
+  code review, cleanup forecasts, and spec/contract evidence for AI-assisted
+  Python delivery.
+
+---
+
 ## [0.47.3] - 2026-06-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SpecFact CLI
 
-> Review AI-assisted code against your own contracts.
-> Catch drift before it reaches PR or main.
+> Defend AI-assisted Python code from bloat before it reaches PR.
+> Run deterministic review, cleanup forecasts, and spec/contract evidence locally.
 
 [![PyPI version](https://img.shields.io/pypi/v/specfact-cli.svg?color=22c55e)](https://pypi.org/project/specfact-cli/)
 [![Python versions](https://img.shields.io/pypi/pyversions/specfact-cli.svg)](https://pypi.org/project/specfact-cli/)
@@ -64,11 +64,18 @@ specfact code review run --path . --scope full
 
 The sample output comes from a pinned capture against `nold-ai/specfact-demo-repo`. Reproduce it with `docs/_support/readme-first-contact/capture-readme-output.sh`; capture metadata lives alongside the raw logs in `docs/_support/readme-first-contact/sample-output/`.
 
-The Code Review bundle also reports `ai_bloat` advisories for code shapes that AI-assisted coding often amplifies, such as redundant wrappers, passthrough lambdas, identity `try`/`except` blocks, and avoidable intermediate lists. These findings are advisory, score-neutral, and not AI-authorship detection. Use the generated `.specfact/code-review.json` report with the Project bundle's `/specfact.08-simplify` IDE prompt to review each cleanup before accepting it. See the [AI bloat quickstart](https://modules.specfact.io/quickstart-ai-bloat/) on the modules docs site.
+## AI-bloat defense loop
+
+SpecFact is the local AI-bloat defense CLI for Python-first teams using AI IDEs. The Code Review bundle reports `ai_bloat` advisories for code shapes that AI-assisted coding often amplifies: redundant wrappers, passthrough lambdas, identity `try`/`except` blocks, avoidable intermediate lists, and long low-branch functions.
+
+For cleanup work, run a JSON review, inspect the cleanup forecast and AI-bloat index, hand remediation packets to your AI IDE, accept only safe changes, then re-run review for proof. The JSON report is the portable handoff artifact for Claude, Codex, Cursor, Copilot, or a headless agent.
+
+These findings are bloat-shape detection and cleanup guidance, not AI-authorship detection. Exact simplify flags and report fields live in the [AI bloat quickstart](https://modules.specfact.io/quickstart-ai-bloat/) and [Code Review run guide](https://modules.specfact.io/bundles/code-review/run/) on the modules docs site.
 
 ## What SpecFact does
 
-- **Reviews AI-assisted changes deterministically** — compare code against contracts, clean-code rules, and policy gates
+- **Defends against AI bloat deterministically** — forecast cleanup impact and route remediation packets to your AI IDE
+- **Reviews AI-assisted changes against evidence** — compare code against contracts, clean-code rules, and policy gates
 - **Extracts structure from existing code** — reverse-engineer brownfield repos before you change them
 - **Blocks drift before merge** — use the same checks locally, in pre-commit, and in CI
 - **Links backlog intent to code reality** — connect backlog, specs, validation, and implementation
@@ -76,11 +83,11 @@ The Code Review bundle also reports `ai_bloat` advisories for code shapes that A
 
 ## What is SpecFact?
 
-SpecFact is a local CLI for catching backlog/spec/code drift before it becomes expensive. It gives solo developers, legacy maintainers, and teams a validation layer around AI-assisted delivery, brownfield reverse engineering, and contract-first reviews.
+SpecFact is a local CLI for AI-bloat defense, deterministic code review, and backlog/spec/code drift control. It gives solo developers, legacy maintainers, and teams a validation layer around AI-assisted delivery, brownfield reverse engineering, and contract-first reviews.
 
 It exists because delivery drifts in predictable ways:
 
-- AI-assisted code lands faster than validation catches up
+- AI-assisted code lands faster than cleanup and validation catch up
 - brownfield systems rarely have trustworthy up-to-date specs
 - backlog intent gets reinterpreted before it reaches code
 - teams need the same review rules across IDEs, CI, and pull requests

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,9 +11,15 @@ This repository owns the **core CLI** documentation set for SpecFact.
 Use it as the canonical starting point when a user still needs orientation around what SpecFact is,
 why it exists, what value it provides, and how to get started.
 
-SpecFact is the validation and alignment layer for software delivery. The core docs explain the
-product story, runtime lifecycle, bootstrap path, and the handoff into deeper module-owned
-workflows.
+SpecFact is the AI-bloat defense and validation CLI for Python-first AI-assisted and brownfield
+delivery. The core docs explain the product story, runtime lifecycle, bootstrap path, and the
+handoff into deeper module-owned workflows.
+
+Start with AI-bloat defense: run review, inspect the cleanup forecast and AI-bloat index, hand
+remediation packets to your AI IDE, then re-run for proof. These signals are cleanup guidance, not
+AI-authorship detection. Exact flags and JSON fields live in the
+[AI bloat quickstart](https://modules.specfact.io/quickstart-ai-bloat/) and
+[Code Review run guide](https://modules.specfact.io/bundles/code-review/run/).
 
 For **module-specific deep functionality**, use the canonical modules docs site at
 `https://modules.specfact.io/`. The canonical modules docs site owns the detailed guides for bundle
@@ -23,6 +29,7 @@ workflows, adapters, and module authoring.
 
 Use this docs set for:
 
+- AI-bloat defense first-contact onboarding and quickstart routing
 - CLI bootstrap, lifecycle, and upgrade flows
 - module registry, trust, and ownership boundaries
 - overall workflow topology across `project`, `backlog`, `code`, `spec`, and `govern`
@@ -32,6 +39,7 @@ Use this docs set for:
 
 Use the canonical modules docs site for:
 
+- cleanup forecast, remediation packet, and Code Review JSON schema details
 - backlog refinement, ceremony, dependency-analysis, and delta workflows
 - project bundle and bridge-sync runbooks
 - spec bundle deep dives and govern bundle deep dives

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,7 +3,7 @@
 
 title: SpecFact CLI Documentation
 description: >-
-  Complete documentation for SpecFact CLI - Brownfield-first CLI: Reverse engineer legacy Python → specs → enforced contracts.
+  AI-bloat defense CLI for Python teams: deterministic review, cleanup forecasts, and spec/contract evidence for AI-assisted and brownfield delivery.
 baseurl: ""  # Custom domain at root, no baseurl needed
 url: &docs_site_url "https://docs.specfact.io"  # Custom domain
 docs_home_url: *docs_site_url

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -6,6 +6,15 @@ permalink: /getting-started/
 
 # Getting Started with SpecFact CLI
 
+SpecFact starts as AI-bloat defense for Python-first AI-assisted code: run deterministic review,
+inspect the cleanup forecast, hand remediation packets to your AI IDE, and re-run for proof. The
+same local CLI also supports contract/spec evidence, brownfield analysis, and team gates when you
+need more depth.
+
+`ai_bloat` findings are cleanup candidates, not AI-authorship detection. For exact simplify flags
+and report fields, use the [AI bloat quickstart](https://modules.specfact.io/quickstart-ai-bloat/)
+on the modules docs site.
+
 ## Start Here
 
 - **[Where to Start](where-to-start.md)** - New-user overview: what SpecFact is for, what core owns, and what to do next
@@ -18,14 +27,9 @@ permalink: /getting-started/
 ## Quick Start
 
 ```bash
-# Install
-pip install specfact-cli
-
-# Bootstrap with a profile
-specfact init --profile solo-developer
-
-# Analyze your codebase
-specfact code import --repo . my-project
+# Zero-install AI-bloat defense pass
+uvx specfact-cli init --profile solo-developer
+uvx specfact-cli code review run --path . --scope full
 ```
 
 See the **[5-Minute Quickstart](quickstart.md)** for a complete walkthrough.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -4,8 +4,8 @@ title: 5-Minute Quickstart
 permalink: /getting-started/quickstart/
 redirect_from:
   - /getting-started/first-steps/
-description: Get SpecFact CLI running in under 5 minutes — uvx first, then optional pip install for IDE workflows and deeper analysis.
-keywords: [quickstart, first-run, bootstrap, analysis, uvx]
+description: Get SpecFact CLI running in under 5 minutes for AI-bloat defense, cleanup forecasts, and deterministic code review.
+keywords: [quickstart, first-run, bootstrap, analysis, uvx, ai-bloat, cleanup forecast]
 audience: [solo, team]
 expertise_level: [beginner]
 doc_owner: specfact-cli
@@ -20,7 +20,7 @@ exempt_reason: ""
 <!-- markdownlint-disable-next-line MD025 -->
 # 5-Minute Quickstart
 
-Get from zero to a **scored code review** in a few commands. This path is aimed at developers who want one command and one clear result before reading about modules, profiles, or architecture.
+Get from zero to **AI-bloat defense** and a scored code review in a few commands. This path is aimed at developers who want one command, one clear result, and a JSON handoff for AI IDE cleanup before reading about modules, profiles, or architecture.
 
 ## Prerequisites
 
@@ -45,15 +45,26 @@ uvx specfact-cli code review run --path . --scope full
 
 You should see a **Verdict**, **Score**, and findings. That is the fastest “aha” path on a real codebase.
 
-If the Code Review bundle reports `category=ai_bloat`, treat those entries as cleanup candidates, not proof of AI authorship. They are `severity=info`, advisory-only, and score-neutral. Write the JSON report, then use `/specfact.08-simplify` from your IDE prompts to review each proposed simplification:
+If the Code Review bundle reports `category=ai_bloat`, treat those entries as cleanup candidates, not proof of AI authorship. They are `severity=info`, advisory-only, and score-neutral.
+
+## Step 3: Run the JSON-first cleanup loop
+
+Run simplify-focused review with JSON output:
 
 ```bash
-uvx specfact-cli code review run --json --out .specfact/code-review.json --path . --scope full
+uvx specfact-cli code review run --scope changed --enforcement shadow --focus simplify --preview-fixes --json --out .specfact/code-review.json
 ```
 
-For the focused walkthrough, see the [AI bloat quickstart](https://modules.specfact.io/quickstart-ai-bloat/) on the modules docs site.
+Then work the report in this order:
 
-## Step 3: Install SpecFact locally (optional)
+1. Inspect `cleanup_forecast` and the AI-bloat index.
+2. Hand remediation packets to your AI IDE.
+3. Accept only safe or approved changes.
+4. Re-run review for proof.
+
+This is AI-bloat defense, not AI-authorship detection. For exact simplify flags, invalid combinations, and report fields, see the [AI bloat quickstart](https://modules.specfact.io/quickstart-ai-bloat/) and [Code Review run guide](https://modules.specfact.io/bundles/code-review/run/) on the modules docs site.
+
+## Step 4: Install SpecFact locally (optional)
 
 When you want a stable `specfact` command and IDE integration, install with pip:
 
@@ -63,7 +74,7 @@ cd /path/to/your/project
 specfact init --profile solo-developer
 ```
 
-## Step 4: Set Up IDE (Optional)
+## Step 5: Set Up IDE (Optional)
 
 ```bash
 specfact init ide --ide cursor --install-deps
@@ -71,7 +82,7 @@ specfact init ide --ide cursor --install-deps
 
 This creates `.specfact/` directory structure and IDE-specific prompt templates.
 
-## Step 5: Analyze Your Codebase and Check Health
+## Step 6: Analyze Your Codebase and Check Health
 
 ```bash
 specfact code import --repo . my-project
@@ -80,7 +91,7 @@ specfact project health-check
 
 `code import` analyzes your code and extracts features, user stories, and dependency graphs into a project bundle at `.specfact/projects/my-project/`. `project health-check` summarizes what SpecFact discovered.
 
-## Step 6: Validate
+## Step 7: Validate
 
 ```bash
 specfact code repro --verbose

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,9 @@
 ---
 layout: default
 title: SpecFact CLI Documentation
-description: Point SpecFact at your code, get a scored review and a fix list in minutes — then go deeper into backlog, specs, and CI when you need to.
+description: Defend AI-assisted Python code from bloat with deterministic review, cleanup forecasts, and spec/contract evidence.
 permalink: /
-keywords: [specfact, core-cli, quickstart, code review, onboarding]
+keywords: [specfact, core-cli, quickstart, code review, ai-bloat, cleanup forecast, onboarding]
 audience: [solo, team, enterprise]
 expertise_level: [beginner, intermediate, advanced]
 doc_owner: specfact-cli
@@ -18,11 +18,12 @@ exempt_reason: ""
 <!-- markdownlint-disable-next-line MD025 -->
 # SpecFact CLI Documentation
 
-**Review AI-assisted code against your own contracts.**
-**Catch drift before it reaches PR or main.**
+**Defend AI-assisted Python code from bloat before it reaches PR.**
+**Run deterministic review, cleanup forecasts, and spec/contract evidence locally.**
 
-Point SpecFact at your repo, get a scored review with file-level findings, then go deeper into
-backlog, specs, and CI when you need more control.
+Point SpecFact at your repo, get a scored review with file-level findings, then use the JSON report
+as the cleanup contract for your AI IDE. Go deeper into backlog, specs, and CI when you need more
+control.
 
 ```bash
 uvx specfact-cli init --profile solo-developer
@@ -34,9 +35,9 @@ fastest way to see SpecFact on existing code. [Read the full quickstart →](/ge
 
 SpecFact does **not** include built-in AI. It pairs deterministic CLI commands with your chosen IDE and copilot so fast-moving work has a stronger validation and alignment layer around it.
 
-**New in Code Review:** `ai_bloat` advisories flag bloated shapes commonly produced during AI-assisted coding, then feed the `/specfact.08-simplify` IDE prompt for human-confirmed cleanup. They are advisory, score-neutral, and do not classify whether code was written by AI. [Try the AI bloat quickstart on modules.specfact.io](https://modules.specfact.io/quickstart-ai-bloat/).
+**AI-bloat defense:** `ai_bloat` advisories flag bloated shapes commonly produced during AI-assisted coding. Simplify-focused reviews add a cleanup forecast, AI-bloat index, preserve reasons, and remediation packets that Claude, Codex, Cursor, Copilot, or another assistant can consume. They are cleanup signals, not AI-authorship detection. [Try the AI bloat quickstart on modules.specfact.io](https://modules.specfact.io/quickstart-ai-bloat/).
 
-**SpecFact is the validation and alignment layer for software delivery.**
+**SpecFact is the AI-bloat defense and validation CLI for AI-assisted and brownfield delivery.**
 
 ---
 
@@ -46,14 +47,14 @@ SpecFact helps you keep backlog intent, specifications, implementation, and vali
 
 It is especially useful when:
 
-- AI-assisted or “vibe-coded” work needs more rigor
+- AI-assisted or “vibe-coded” work needs bloat cleanup and stronger validation
 - brownfield and legacy code need trustworthy reverse-engineered understanding of existing systems
 - teams want to avoid the “I wanted X but got Y” delivery failure
 - organizations need a path toward stronger shared policy enforcement
 
 ## Why does it exist?
 
-SpecFact exists because backlog/spec/code drift is expensive: teams ship the wrong thing, AI-assisted changes skip validation, and policy enforcement breaks down across IDEs and CI. SpecFact gives you a default starting point before you jump into module-deep workflows on the modules site.
+SpecFact exists because backlog/spec/code drift is expensive: teams ship the wrong thing, AI-assisted changes accumulate bloat before validation catches up, and policy enforcement breaks down across IDEs and CI. SpecFact gives you a default starting point before you jump into module-deep workflows on the modules site.
 
 ## Why should I use it?
 
@@ -64,6 +65,7 @@ Use SpecFact when you want faster delivery without losing validation, stronger b
 With SpecFact, you get:
 
 - deterministic local tooling instead of opaque cloud dependence
+- AI-bloat defense with cleanup forecasts and remediation packet handoff
 - a validation layer around AI-assisted delivery
 - codebase analysis and sidecar validation for brownfield work
 - stronger backlog/spec/code alignment
@@ -81,7 +83,7 @@ With SpecFact, you get:
 <div class="path-cards">
 <div class="path-card">
 <h3>See what&apos;s wrong with your code right now</h3>
-<p>Run a scored code review on an existing repo with uvx, then iterate.</p>
+<p>Run a scored code review, inspect AI-bloat cleanup candidates, then iterate.</p>
 <ul>
 <li><a href="/getting-started/quickstart/">5-Minute Quickstart</a></li>
 <li><a href="/getting-started/installation/">Installation</a></li>

--- a/docs/modules/code-review.md
+++ b/docs/modules/code-review.md
@@ -29,7 +29,10 @@ The scaffold adds these review entrypoints:
 - `specfact code review ledger`
 - `specfact code review rules`
 
-For bundle-deep command usage, keep the modules docs open alongside this core handoff page. The modules quickstart for AI-shaped bloat cleanup lives at [modules.specfact.io/quickstart-ai-bloat/](https://modules.specfact.io/quickstart-ai-bloat/).
+For bundle-deep command usage, keep the modules docs open alongside this core handoff page:
+
+- [AI bloat quickstart](https://modules.specfact.io/quickstart-ai-bloat/)
+- [Code Review run guide](https://modules.specfact.io/bundles/code-review/run/)
 
 ## AI-shaped bloat advisories
 
@@ -42,7 +45,14 @@ These findings are:
 - score-neutral even though they use `severity=info`
 - written to `.specfact/code-review.json` when the report includes all severities
 
-They are bloat-shape detection, not AI-authorship detection. Use them as cleanup candidates and confirm each rewrite in your IDE.
+They are bloat-shape detection, not AI-authorship proof. Use them as cleanup candidates and confirm each rewrite in your IDE.
+
+Simplify-focused reports also summarize cleanup impact with a cleanup forecast and AI-bloat index. Findings may include preserve reasons and remediation packets so Claude, Codex, Cursor, Copilot, or another AI IDE can decide whether a candidate is safe-mechanical, needs tests, needs design judgment, or should be preserved.
+
+Core docs intentionally keep this at workflow level. Exact flags, invalid combinations, additive JSON fields, and schema examples are owned by the modules docs site:
+
+- [Code Review run guide](https://modules.specfact.io/bundles/code-review/run/)
+- [AI bloat quickstart](https://modules.specfact.io/quickstart-ai-bloat/)
 
 Run the review with JSON output:
 

--- a/openspec/CHANGE_ORDER.md
+++ b/openspec/CHANGE_ORDER.md
@@ -92,6 +92,7 @@ README. Snapshot/CI work folds into 03 and 04 if and when needed.
 | `dep-security-cleanup` | 62/69 done | Apache-2.0 license-cleanliness pass |
 | `marketplace-07-module-install-state-consistency` | ✓ archive pending | Resolves install-state disagreement across scopes |
 | `module-scope-version-diagnostics` | active | Resolves project/user module version mismatch diagnostics and enforcement under #565 / #353 |
+| `docs-15-clean-code-bazooka-onboarding` | active | Core docs companion for modules cleanup forecast and AI IDE remediation handoff under #356 |
 | `upgrade-01-install-method-aware` | ✓ archive pending | Bug-fix for uvx/uv users |
 | `governance-02-exception-management` | active | Time-bound policy exceptions |
 | `architecture-02-well-architected-review` | **gated on architecture-01 shipping + 1 cycle of usage** | Boundary/ADR review pillar |

--- a/openspec/changes/docs-15-clean-code-bazooka-onboarding/.openspec.yaml
+++ b/openspec/changes/docs-15-clean-code-bazooka-onboarding/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-24

--- a/openspec/changes/docs-15-clean-code-bazooka-onboarding/README.md
+++ b/openspec/changes/docs-15-clean-code-bazooka-onboarding/README.md
@@ -1,0 +1,3 @@
+# docs-15-clean-code-bazooka-onboarding
+
+Core onboarding docs for cleanup forecast, AI-bloat index, and AI IDE remediation handoff.

--- a/openspec/changes/docs-15-clean-code-bazooka-onboarding/TDD_EVIDENCE.md
+++ b/openspec/changes/docs-15-clean-code-bazooka-onboarding/TDD_EVIDENCE.md
@@ -1,0 +1,181 @@
+# TDD Evidence: docs-15-clean-code-bazooka-onboarding
+
+This file records failing-before and passing-after evidence for the AI-bloat defense first-contact docs and metadata change.
+
+## Failing-before evidence
+
+### 2026-06-02 targeted docs and metadata tests
+
+Command:
+
+```bash
+hatch run pytest tests/unit/docs/test_first_contact_story.py tests/unit/docs/test_wow_entrypoint_contract.py tests/unit/docs/test_release_docs_parity.py tests/unit/test_core_docs_site_contract.py tests/unit/scripts/test_code_review_module_docs.py -q
+```
+
+Result: failed as expected before docs/metadata implementation.
+
+Summary:
+
+- 48 tests collected.
+- 37 passed.
+- 11 failed.
+- Failures showed the old README/docs hook, missing AI-bloat defense entrypoint wording, missing JSON-first cleanup loop, incomplete Code Review handoff wording, and old "swiss knife" package metadata.
+
+## Passing evidence
+
+### 2026-06-02 targeted docs and metadata tests
+
+Command:
+
+```bash
+hatch run pytest tests/unit/docs/test_first_contact_story.py tests/unit/docs/test_wow_entrypoint_contract.py tests/unit/docs/test_release_docs_parity.py tests/unit/test_core_docs_site_contract.py tests/unit/scripts/test_code_review_module_docs.py -q
+```
+
+Result: passed.
+
+Summary:
+
+- 48 tests collected.
+- 48 passed.
+
+After rebasing onto current `origin/dev` and parameterizing duplicated test shapes found by the
+code review helper, the same targeted command passed with 47 collected tests and 47 passed.
+
+### 2026-06-02 OpenSpec validation
+
+Command:
+
+```bash
+openspec validate docs-15-clean-code-bazooka-onboarding --strict
+```
+
+Result: passed. The change remained valid after expanding scope to docs entry points, package metadata, and GitHub repository metadata.
+
+### 2026-06-02 docs validation
+
+Command:
+
+```bash
+hatch run docs-validate
+```
+
+Result: passed.
+
+Summary:
+
+- `check-command-contract`: OK, 107 generated command paths validated.
+- `check-docs-commands`: OK, 380 unique command prefixes checked.
+- `check-cross-site-links`: OK, 26 unique `modules.specfact.io` URLs checked.
+- `check_doc_frontmatter`: OK, 17 enforced docs checked.
+
+### 2026-06-02 metadata/version consistency
+
+Command:
+
+```bash
+hatch run check-version-sources
+```
+
+Result: passed.
+
+### 2026-06-02 formatting
+
+Command:
+
+```bash
+hatch run format
+```
+
+Result: passed. All files were already formatted; 627 files left unchanged.
+
+### 2026-06-02 rebase onto current dev
+
+Command:
+
+```bash
+git fetch origin
+git rebase origin/dev
+```
+
+Result: passed. The feature worktree was rebased onto the current `origin/dev`.
+
+Notes:
+
+- Git stash/autostash failed silently in this worktree, so tracked changes were preserved through a temporary `/tmp` patch before the rebase and reapplied afterward with `git apply --3way`.
+- Rebase conflicts in `docs/getting-started/README.md` and `pyproject.toml` were resolved by keeping the current upstream version `0.47.3` and this change's AI-bloat defense positioning.
+
+### 2026-06-02 SpecFact code review helper
+
+Command:
+
+```bash
+hatch run python scripts/pre_commit_code_review.py setup.py src/specfact_cli/__init__.py tests/unit/docs/docs_test_constants.py tests/unit/docs/test_first_contact_story.py tests/unit/docs/test_release_docs_parity.py tests/unit/scripts/test_code_review_module_docs.py tests/unit/test_core_docs_site_contract.py
+```
+
+Result: passed.
+
+Summary:
+
+- The helper reviewed the changed Python files for this docs/test scope.
+- Initial helper output produced 11 warning findings; clean-code warnings were fixed in touched tests.
+- Final helper output: 0 findings, `overall_verdict='PASS'`.
+
+### 2026-06-02 full lint
+
+Command:
+
+```bash
+hatch run lint
+```
+
+Result: passed after rebasing onto current `origin/dev`.
+
+Summary:
+
+- 627 files already formatted.
+- Type check reported 0 errors, 0 warnings, and 0 notes.
+- Pylint rated the code at 10.00/10.
+
+## Blocked or failed external gates
+
+### Internal wiki mirror follow-up
+
+The sibling internal checkout exists, but no matching
+`/home/dom/git/nold-ai/specfact-cli-internal/wiki/sources/docs-15-clean-code-bazooka-onboarding.md`
+page is present. Because this implementation materially expanded the active change scope, follow up
+by creating or updating that wiki source page with the current summary, status, dependencies, and
+external-deps, then run `python3 scripts/wiki_rebuild_graph.py` from the `specfact-cli-internal`
+repository root.
+
+### 2026-06-02 GitHub repository metadata update
+
+Commands attempted:
+
+```bash
+gh api -X PATCH repos/nold-ai/specfact-cli -f description='AI-bloat defense CLI for Python teams: deterministic code review, cleanup forecasts, and spec/contract evidence for AI-assisted and brownfield delivery.'
+gh api -X PUT repos/nold-ai/specfact-cli/topics -f names[]=ai ...
+```
+
+Initial result: blocked by GitHub token permissions.
+
+GitHub returned HTTP 403 `Resource not accessible by personal access token` for both repository description and topics updates. A readback confirmed the live repository still uses the older "Swiss-knife CLI" description and the previous topic set.
+
+Final readback after manual metadata update:
+
+```bash
+gh api repos/nold-ai/specfact-cli --jq '{description, homepage, topics}'
+```
+
+Result: passed.
+
+- Description matches the planned AI-bloat defense wording.
+- Homepage is `https://docs.specfact.io/`.
+- Topics match the planned 20-topic set: `ai`, `ai-assisted-development`, `ai-bloat`, `brownfield`, `clean-code`, `code-quality`, `code-review`, `code2spec`, `contract-first`, `contract-testing`, `developer-tools`, `legacy-modernization`, `python`, `requirements-engineering`, `spec-driven-development`, `spec-first`, `static-analysis`, `technical-debt`, `testing`, and `vibe-coding`.
+
+## Before/after docs summary
+
+- README and docs home now lead with AI-bloat defense for AI-assisted Python code.
+- Docs README and getting-started entry points now route users through cleanup forecast, AI-bloat index, remediation packets, and rerun proof.
+- Quickstart now includes a JSON-first simplify loop.
+- Core Code Review handoff now links to modules-owned AI bloat quickstart and Code Review run guide for exact flags/schema.
+- Package/docs metadata no longer uses "Swiss-knife" as the primary product identity.

--- a/openspec/changes/docs-15-clean-code-bazooka-onboarding/design.md
+++ b/openspec/changes/docs-15-clean-code-bazooka-onboarding/design.md
@@ -1,0 +1,28 @@
+## Context
+
+The `specfact-code-review` command surface is module-owned. Core docs should not become a second command reference, but they must give users the product story and first-run path. The planned modules change adds stronger cleanup evidence: forecast metrics, AI-bloat index, preserve reasons, remediation packets, preview evidence, and opt-in mutation proof.
+
+## Decisions
+
+- Treat this as a docs-only companion. It must not change runtime code or module behavior.
+- Use stable wording in core docs: "cleanup forecast", "AI-bloat index", "remediation packets", and "AI IDE handoff".
+- Avoid documenting low-level JSON field contracts until the modules change finalizes them; link to modules docs for exact schema and flags.
+- Keep the safety framing explicit: `ai_bloat` identifies bloat-shaped cleanup candidates, not AI authorship.
+- Keep the handoff model vendor-neutral: Claude, Codex, Cursor, Copilot, and other assistants can consume the same JSON.
+
+## Docs Flow
+
+The intended user flow in core docs:
+
+1. Install/init SpecFact.
+2. Run code review with JSON output.
+3. Inspect cleanup forecast and AI-bloat index.
+4. Hand the remediation packets to the AI IDE or LLM of choice.
+5. Apply only safe or approved changes.
+6. Re-run review to prove findings cleared.
+
+## Risks
+
+- **Core docs drift from module flags.** Mitigation: keep exact flag/schema details in modules docs and link there.
+- **Users think AI-bloat means AI-authorship detection.** Mitigation: repeat that this is shape detection and cleanup guidance.
+- **Docs promise unimplemented behavior too early.** Mitigation: phrase as "after the Code Review bundle version that includes cleanup forecast" until implementation lands.

--- a/openspec/changes/docs-15-clean-code-bazooka-onboarding/design.md
+++ b/openspec/changes/docs-15-clean-code-bazooka-onboarding/design.md
@@ -1,21 +1,40 @@
 ## Context
 
-The `specfact-code-review` command surface is module-owned. Core docs should not become a second command reference, but they must give users the product story and first-run path. The planned modules change adds stronger cleanup evidence: forecast metrics, AI-bloat index, preserve reasons, remediation packets, preview evidence, and opt-in mutation proof.
+The `specfact-code-review` command surface is module-owned. Core docs should not become a second command reference, but they must give users the product story and first-run path. The modules change now adds stronger cleanup evidence: forecast metrics, AI-bloat index, preserve reasons, remediation packets, preview evidence, and opt-in mutation proof.
+
+The public positioning should shift from a broad "Swiss-knife CLI" frame to a sharper lead hook: AI-bloat defense for Python-first AI-assisted code. That hook is the entry point, not a full product rename. Below the hook, SpecFact remains the local deterministic validation/alignment CLI for contracts, specs, tests, backlog intent, and brownfield delivery.
 
 ## Decisions
 
-- Treat this as a docs-only companion. It must not change runtime code or module behavior.
+- Treat this as a docs and public-metadata companion. It must not change runtime code or module behavior.
+- Lead first-contact surfaces with AI-bloat defense, then explain the broader validation/alignment platform.
 - Use stable wording in core docs: "cleanup forecast", "AI-bloat index", "remediation packets", and "AI IDE handoff".
-- Avoid documenting low-level JSON field contracts until the modules change finalizes them; link to modules docs for exact schema and flags.
+- Avoid duplicating low-level JSON field contracts; link to modules docs for exact schema and flags.
 - Keep the safety framing explicit: `ai_bloat` identifies bloat-shaped cleanup candidates, not AI authorship.
 - Keep the handoff model vendor-neutral: Claude, Codex, Cursor, Copilot, and other assistants can consume the same JSON.
+- Replace "Swiss-knife" metadata wording with AI-bloat defense / deterministic review wording in package and repo metadata.
+- Record GitHub repository metadata values in this change so the out-of-tree metadata mutation is reviewable.
+
+## Public Metadata
+
+Target GitHub repository description:
+
+```text
+AI-bloat defense CLI for Python teams: deterministic code review, cleanup forecasts, and spec/contract evidence for AI-assisted and brownfield delivery.
+```
+
+Target GitHub topics:
+
+```text
+ai, ai-assisted-development, ai-bloat, vibe-coding, code-review, clean-code, code-quality, technical-debt, static-analysis, python, developer-tools, brownfield, legacy-modernization, code2spec, contract-testing, contract-first, spec-driven-development, spec-first, requirements-engineering, testing
+```
 
 ## Docs Flow
 
 The intended user flow in core docs:
 
 1. Install/init SpecFact.
-2. Run code review with JSON output.
+2. Run simplify-focused code review with JSON output.
 3. Inspect cleanup forecast and AI-bloat index.
 4. Hand the remediation packets to the AI IDE or LLM of choice.
 5. Apply only safe or approved changes.
@@ -25,4 +44,5 @@ The intended user flow in core docs:
 
 - **Core docs drift from module flags.** Mitigation: keep exact flag/schema details in modules docs and link there.
 - **Users think AI-bloat means AI-authorship detection.** Mitigation: repeat that this is shape detection and cleanup guidance.
-- **Docs promise unimplemented behavior too early.** Mitigation: phrase as "after the Code Review bundle version that includes cleanup forecast" until implementation lands.
+- **Docs over-narrow SpecFact to one feature.** Mitigation: make AI-bloat defense the lead hook while preserving contract/spec/brownfield validation as the underlying platform.
+- **GitHub repo metadata changes are outside normal code review.** Mitigation: record exact description/topics here and verify the live state after applying them.

--- a/openspec/changes/docs-15-clean-code-bazooka-onboarding/proposal.md
+++ b/openspec/changes/docs-15-clean-code-bazooka-onboarding/proposal.md
@@ -1,16 +1,19 @@
-# Change: Clean code cleanup onboarding docs
+# Change: AI-bloat defense first-contact docs and metadata
 
 ## Why
 
 The core README and getting-started docs already mention `ai_bloat`, but they describe the earlier advisory flow: run JSON, inspect findings, then use `/specfact.08-simplify`. The Code Review bundle is now planned to expose cleanup forecasts, an AI-bloat index, preserve signals, and remediation packets that any AI IDE can consume.
 
-Core docs should explain that value without duplicating bundle-deep command reference. The first-contact path should show developers that SpecFact can help fight AI-generated bloat with deterministic review evidence, while the modules docs remain canonical for exact flags and JSON schema details.
+Core docs should explain that value without duplicating bundle-deep command reference. The first-contact path should make **AI-bloat defense** the lead hook for Python-first AI-assisted codebases, while preserving SpecFact's broader identity as a deterministic validation and alignment CLI for contracts, specs, tests, and brownfield delivery.
+
+The paired modules-side capability change has shipped, so core docs can now describe cleanup forecasts, the AI-bloat index, preserve reasons, and remediation packets as available module capabilities. Exact flags, JSON field contracts, and deeper workflow details remain owned by the modules docs site.
 
 ## What Changes
 
+- Reposition first-contact surfaces around AI-bloat defense: deterministic review, cleanup forecast, and AI IDE remediation handoff before broader platform detail.
 - Update core onboarding docs to describe the JSON-first cleanup loop: run review, inspect forecast/index, hand remediation packets to an AI IDE, apply only safe guidance, and re-run for proof.
 - Update the Code Review module handoff page so users understand which cleanup details live on `modules.specfact.io`.
-- Keep README and quickstart examples aligned with the module capability without hardcoding unstable implementation details before the modules change ships.
+- Keep README, docs home, docs README, quickstart examples, package metadata, and GitHub repository metadata aligned with the module capability without duplicating unstable schema detail.
 - Link this docs change to the modules-side capability change [nold-ai/specfact-cli-modules#297](https://github.com/nold-ai/specfact-cli-modules/issues/297).
 
 ## Capabilities
@@ -21,12 +24,14 @@ Core docs should explain that value without duplicating bundle-deep command refe
 - `docs-aha-moment-entry`: Update the quickstart aha path to include cleanup forecast and AI IDE handoff language.
 - `code-review-module`: Keep the core module handoff accurate while delegating command details to the modules docs site.
 - `review-report-model`: Document the additive report shape at a high level when mirrored in core docs.
+- `first-contact-story`: Align README, docs home, docs README, package metadata, and GitHub repository metadata around the same AI-bloat defense hook.
 
 ## Impact
 
-- **Affected docs:** `README.md`, `docs/getting-started/quickstart.md`, and `docs/modules/code-review.md`.
+- **Affected docs:** `README.md`, `docs/index.md`, `docs/README.md`, `docs/getting-started/README.md`, `docs/getting-started/quickstart.md`, and `docs/modules/code-review.md`.
+- **Affected metadata:** `pyproject.toml`, `setup.py`, `src/specfact_cli/__init__.py`, `docs/_config.yml`, and GitHub repository description/topics.
 - **Affected ownership boundary:** Core docs summarize the value path; modules docs own exact command flags and schema field details.
-- **No runtime impact:** This is a docs-only companion to the modules implementation.
+- **No runtime impact:** This is a docs and public-metadata companion to the modules implementation.
 
 ## Source Tracking
 

--- a/openspec/changes/docs-15-clean-code-bazooka-onboarding/proposal.md
+++ b/openspec/changes/docs-15-clean-code-bazooka-onboarding/proposal.md
@@ -28,9 +28,9 @@ The paired modules-side capability change has shipped, so core docs can now desc
 
 ## Impact
 
-- **Affected docs:** `README.md`, `docs/index.md`, `docs/README.md`, `docs/getting-started/README.md`, `docs/getting-started/quickstart.md`, and `docs/modules/code-review.md`.
-- **Affected metadata:** `pyproject.toml`, `setup.py`, `src/specfact_cli/__init__.py`, `docs/_config.yml`, and GitHub repository description/topics.
-- **Affected ownership boundary:** Core docs summarize the value path; modules docs own exact command flags and schema field details.
+- **Docs touched:** `README.md`, `docs/index.md`, `docs/README.md`, `docs/getting-started/README.md`, `docs/getting-started/quickstart.md`, and `docs/modules/code-review.md`.
+- **Metadata touched:** `pyproject.toml`, `setup.py`, `src/specfact_cli/__init__.py`, `docs/_config.yml`, and GitHub repository description/topics.
+- **Ownership boundary:** Core docs summarize the value path; modules docs own exact command flags and schema field details.
 - **No runtime impact:** This is a docs and public-metadata companion to the modules implementation.
 
 ## Source Tracking

--- a/openspec/changes/docs-15-clean-code-bazooka-onboarding/proposal.md
+++ b/openspec/changes/docs-15-clean-code-bazooka-onboarding/proposal.md
@@ -1,0 +1,39 @@
+# Change: Clean code cleanup onboarding docs
+
+## Why
+
+The core README and getting-started docs already mention `ai_bloat`, but they describe the earlier advisory flow: run JSON, inspect findings, then use `/specfact.08-simplify`. The Code Review bundle is now planned to expose cleanup forecasts, an AI-bloat index, preserve signals, and remediation packets that any AI IDE can consume.
+
+Core docs should explain that value without duplicating bundle-deep command reference. The first-contact path should show developers that SpecFact can help fight AI-generated bloat with deterministic review evidence, while the modules docs remain canonical for exact flags and JSON schema details.
+
+## What Changes
+
+- Update core onboarding docs to describe the JSON-first cleanup loop: run review, inspect forecast/index, hand remediation packets to an AI IDE, apply only safe guidance, and re-run for proof.
+- Update the Code Review module handoff page so users understand which cleanup details live on `modules.specfact.io`.
+- Keep README and quickstart examples aligned with the module capability without hardcoding unstable implementation details before the modules change ships.
+- Link this docs change to the modules-side capability change [nold-ai/specfact-cli-modules#297](https://github.com/nold-ai/specfact-cli-modules/issues/297).
+
+## Capabilities
+
+### Modified Capabilities
+
+- `readme-first-contact`: Present clean-code cleanup as a first-contact value path for AI-assisted codebases.
+- `docs-aha-moment-entry`: Update the quickstart aha path to include cleanup forecast and AI IDE handoff language.
+- `code-review-module`: Keep the core module handoff accurate while delegating command details to the modules docs site.
+- `review-report-model`: Document the additive report shape at a high level when mirrored in core docs.
+
+## Impact
+
+- **Affected docs:** `README.md`, `docs/getting-started/quickstart.md`, and `docs/modules/code-review.md`.
+- **Affected ownership boundary:** Core docs summarize the value path; modules docs own exact command flags and schema field details.
+- **No runtime impact:** This is a docs-only companion to the modules implementation.
+
+## Source Tracking
+
+<!-- source_repo: nold-ai/specfact-cli -->
+- **GitHub Issue:** [#584](https://github.com/nold-ai/specfact-cli/issues/584)
+- **Parent Feature:** [#356](https://github.com/nold-ai/specfact-cli/issues/356)
+- **Repository:** nold-ai/specfact-cli
+- **Paired Modules Change:** [nold-ai/specfact-cli-modules#297](https://github.com/nold-ai/specfact-cli-modules/issues/297)
+- **Last Synced Status:** synced
+- **Sanitized:** false

--- a/openspec/changes/docs-15-clean-code-bazooka-onboarding/specs/code-review-module/spec.md
+++ b/openspec/changes/docs-15-clean-code-bazooka-onboarding/specs/code-review-module/spec.md
@@ -10,3 +10,9 @@ The core Code Review module page SHALL explain the module's purpose and route us
 - **THEN** it SHALL also describe cleanup forecasts, AI-bloat index, preserve signals, and remediation packets at a high level
 - **AND** it SHALL route users to `modules.specfact.io` for exact flags, JSON fields, and AI IDE workflow details
 - **AND** it SHALL preserve the warning that bloat-shape findings are not AI-authorship proof
+
+#### Scenario: Core handoff page avoids becoming a duplicate command reference
+
+- **WHEN** the Code Review module page mentions simplify-focused flags or JSON fields
+- **THEN** it SHALL keep those mentions at workflow level
+- **AND** it SHALL link to the modules Code Review run guide and AI bloat quickstart for exact flags, invalid combinations, and report schema details

--- a/openspec/changes/docs-15-clean-code-bazooka-onboarding/specs/code-review-module/spec.md
+++ b/openspec/changes/docs-15-clean-code-bazooka-onboarding/specs/code-review-module/spec.md
@@ -7,7 +7,7 @@ The core Code Review module page SHALL explain the module's purpose and route us
 #### Scenario: Module page summarizes cleanup forecast capability
 
 - **WHEN** the page describes AI-shaped bloat advisories
-- **THEN** it SHALL also describe cleanup forecasts, AI-bloat index, preserve signals, and remediation packets at a high level
+- **THEN** it SHALL also describe cleanup forecasts, AI-bloat index, preserve signals, and remediation packets at a high-level summary
 - **AND** it SHALL route users to `modules.specfact.io` for exact flags, JSON fields, and AI IDE workflow details
 - **AND** it SHALL preserve the warning that bloat-shape findings are not AI-authorship proof
 

--- a/openspec/changes/docs-15-clean-code-bazooka-onboarding/specs/code-review-module/spec.md
+++ b/openspec/changes/docs-15-clean-code-bazooka-onboarding/specs/code-review-module/spec.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: Code Review module page routes users to canonical bundle docs
+
+The core Code Review module page SHALL explain the module's purpose and route users to modules-owned command documentation for exact runtime behavior.
+
+#### Scenario: Module page summarizes cleanup forecast capability
+
+- **WHEN** the page describes AI-shaped bloat advisories
+- **THEN** it SHALL also describe cleanup forecasts, AI-bloat index, preserve signals, and remediation packets at a high level
+- **AND** it SHALL route users to `modules.specfact.io` for exact flags, JSON fields, and AI IDE workflow details
+- **AND** it SHALL preserve the warning that bloat-shape findings are not AI-authorship proof

--- a/openspec/changes/docs-15-clean-code-bazooka-onboarding/specs/docs-aha-moment-entry/spec.md
+++ b/openspec/changes/docs-15-clean-code-bazooka-onboarding/specs/docs-aha-moment-entry/spec.md
@@ -9,3 +9,10 @@ The quickstart SHALL let a new user run a scored review quickly and understand t
 - **WHEN** the quickstart explains `specfact code review run`
 - **THEN** it SHALL include a short cleanup loop for AI-assisted code: run JSON, inspect cleanup forecast and AI-bloat index, hand remediation packets to an AI IDE, and re-run review
 - **AND** it SHALL link to the modules AI bloat quickstart for exact command and report details
+
+#### Scenario: Docs entry points share the AI-bloat defense hook
+
+- **WHEN** users read `docs/index.md`, `docs/README.md`, or the getting-started landing page
+- **THEN** those surfaces SHALL use the same AI-bloat defense first-contact story as the README
+- **AND** they SHALL route users to the quickstart before deep module topology
+- **AND** they SHALL preserve the docs/modules ownership boundary for exact Code Review command and schema details

--- a/openspec/changes/docs-15-clean-code-bazooka-onboarding/specs/docs-aha-moment-entry/spec.md
+++ b/openspec/changes/docs-15-clean-code-bazooka-onboarding/specs/docs-aha-moment-entry/spec.md
@@ -1,0 +1,11 @@
+## MODIFIED Requirements
+
+### Requirement: Quickstart leads to a scored code review aha moment
+
+The quickstart SHALL let a new user run a scored review quickly and understand the next useful action after the first report.
+
+#### Scenario: Quickstart explains cleanup handoff loop
+
+- **WHEN** the quickstart explains `specfact code review run`
+- **THEN** it SHALL include a short cleanup loop for AI-assisted code: run JSON, inspect cleanup forecast and AI-bloat index, hand remediation packets to an AI IDE, and re-run review
+- **AND** it SHALL link to the modules AI bloat quickstart for exact command and report details

--- a/openspec/changes/docs-15-clean-code-bazooka-onboarding/specs/readme-first-contact/spec.md
+++ b/openspec/changes/docs-15-clean-code-bazooka-onboarding/specs/readme-first-contact/spec.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: README gives first-contact users a fast validation path
+
+The README SHALL give first-contact users a concise path to run SpecFact on a real repository and understand the most important output.
+
+#### Scenario: README introduces cleanup forecast as a value path
+
+- **WHEN** the Code Review bundle supports cleanup forecasts and AI IDE remediation packets
+- **THEN** the README SHALL mention that SpecFact can quantify likely cleanup impact for AI-assisted codebases
+- **AND** it SHALL describe the JSON report as the portable handoff artifact for AI IDE cleanup
+- **AND** it SHALL avoid presenting `ai_bloat` as AI-authorship detection

--- a/openspec/changes/docs-15-clean-code-bazooka-onboarding/specs/readme-first-contact/spec.md
+++ b/openspec/changes/docs-15-clean-code-bazooka-onboarding/specs/readme-first-contact/spec.md
@@ -10,3 +10,10 @@ The README SHALL give first-contact users a concise path to run SpecFact on a re
 - **THEN** the README SHALL mention that SpecFact can quantify likely cleanup impact for AI-assisted codebases
 - **AND** it SHALL describe the JSON report as the portable handoff artifact for AI IDE cleanup
 - **AND** it SHALL avoid presenting `ai_bloat` as AI-authorship detection
+
+#### Scenario: README leads with AI-bloat defense without hiding broader validation
+
+- **WHEN** a first-contact visitor reads the README hero and fast-start sections
+- **THEN** the README SHALL present AI-bloat defense as the lead hook for Python-first AI-assisted code
+- **AND** it SHALL still explain that SpecFact uses deterministic review, contracts, specs, tests, and policy evidence rather than built-in AI
+- **AND** it SHALL avoid "Swiss-knife" wording in above-the-fold product identity copy

--- a/openspec/changes/docs-15-clean-code-bazooka-onboarding/specs/review-report-model/spec.md
+++ b/openspec/changes/docs-15-clean-code-bazooka-onboarding/specs/review-report-model/spec.md
@@ -9,3 +9,13 @@ Core documentation that summarizes `ReviewReport` SHALL acknowledge additive mod
 - **WHEN** core docs show or describe review JSON
 - **THEN** they SHALL state that Code Review bundle versions may add cleanup forecast and remediation handoff fields
 - **AND** they SHALL tell consumers to treat unknown fields as additive metadata rather than schema-breaking changes
+
+### Requirement: Public metadata reinforces the AI-bloat defense hook
+
+GitHub and package-facing metadata SHALL reinforce the same first-contact story used in the README and docs landing pages.
+
+#### Scenario: Public metadata is aligned
+
+- **WHEN** a user sees GitHub repository metadata, PyPI/package metadata, or docs site metadata before opening the README
+- **THEN** that metadata SHALL emphasize AI-bloat defense, deterministic code review, cleanup forecasts, and spec/contract evidence
+- **AND** it SHALL not use "Swiss-knife" wording as the primary product identity

--- a/openspec/changes/docs-15-clean-code-bazooka-onboarding/specs/review-report-model/spec.md
+++ b/openspec/changes/docs-15-clean-code-bazooka-onboarding/specs/review-report-model/spec.md
@@ -1,0 +1,11 @@
+## MODIFIED Requirements
+
+### Requirement: Review report documentation stays compatible with module-owned extensions
+
+Core documentation that summarizes `ReviewReport` SHALL acknowledge additive module-owned fields without duplicating the full module schema.
+
+#### Scenario: Report examples mention additive cleanup fields
+
+- **WHEN** core docs show or describe review JSON
+- **THEN** they SHALL state that Code Review bundle versions may add cleanup forecast and remediation handoff fields
+- **AND** they SHALL tell consumers to treat unknown fields as additive metadata rather than schema-breaking changes

--- a/openspec/changes/docs-15-clean-code-bazooka-onboarding/tasks.md
+++ b/openspec/changes/docs-15-clean-code-bazooka-onboarding/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: docs-15-clean-code-bazooka-onboarding
+
+## 1. GitHub readiness and OpenSpec setup
+
+- [x] 1.1 Create OpenSpec change `docs-15-clean-code-bazooka-onboarding`.
+- [x] 1.2 Create GitHub issue [#584](https://github.com/nold-ai/specfact-cli/issues/584), link it under Feature [#356](https://github.com/nold-ai/specfact-cli/issues/356), and label it with `documentation`, `enhancement`, `openspec`, `change-proposal`, and `code-review`.
+- [x] 1.3 Confirm issue project assignment, open/Todo state, parent linkage, blocked-by relationship, source tracking, and paired modules issue reference.
+- [x] 1.4 Add `openspec/CHANGE_ORDER.md` row under active work.
+- [x] 1.5 Validate the OpenSpec change with `openspec validate docs-15-clean-code-bazooka-onboarding --strict`.
+
+## 2. Spec-first docs tests
+
+- [ ] 2.1 Add or update docs assertions for README clean-code cleanup wording.
+- [ ] 2.2 Add or update docs assertions for quickstart cleanup forecast and AI IDE handoff wording.
+- [ ] 2.3 Add or update docs assertions for the Code Review module handoff page.
+- [ ] 2.4 Record failing-before evidence in `TDD_EVIDENCE.md`.
+
+## 3. Documentation updates
+
+- [ ] 3.1 Update `README.md` with the cleanup forecast / AI IDE handoff value path.
+- [ ] 3.2 Update `docs/getting-started/quickstart.md` with the JSON-first cleanup loop.
+- [ ] 3.3 Update `docs/modules/code-review.md` to reference cleanup forecasts, AI-bloat index, remediation packets, and modules docs as canonical command/schema reference.
+- [ ] 3.4 Keep all cross-site links aligned with the modules docs permalink contract.
+
+## 4. Verification
+
+- [ ] 4.1 Run targeted docs tests and record passing evidence.
+- [ ] 4.2 Run required docs quality gates for the touched scope.
+- [ ] 4.3 Run SpecFact code review for changed docs/test scope if the repository gate applies.
+- [ ] 4.4 Update `TDD_EVIDENCE.md` with passing evidence and before/after docs summary.

--- a/openspec/changes/docs-15-clean-code-bazooka-onboarding/tasks.md
+++ b/openspec/changes/docs-15-clean-code-bazooka-onboarding/tasks.md
@@ -10,21 +10,25 @@
 
 ## 2. Spec-first docs tests
 
-- [ ] 2.1 Add or update docs assertions for README clean-code cleanup wording.
-- [ ] 2.2 Add or update docs assertions for quickstart cleanup forecast and AI IDE handoff wording.
-- [ ] 2.3 Add or update docs assertions for the Code Review module handoff page.
-- [ ] 2.4 Record failing-before evidence in `TDD_EVIDENCE.md`.
+- [x] 2.1 Add or update docs assertions for README clean-code cleanup wording.
+- [x] 2.2 Add or update docs assertions for quickstart cleanup forecast and AI IDE handoff wording.
+- [x] 2.3 Add or update docs assertions for the Code Review module handoff page.
+- [x] 2.4 Add or update docs/package metadata assertions for the AI-bloat defense hook and removal of Swiss-knife positioning.
+- [x] 2.5 Record failing-before evidence in `TDD_EVIDENCE.md`.
 
 ## 3. Documentation updates
 
-- [ ] 3.1 Update `README.md` with the cleanup forecast / AI IDE handoff value path.
-- [ ] 3.2 Update `docs/getting-started/quickstart.md` with the JSON-first cleanup loop.
-- [ ] 3.3 Update `docs/modules/code-review.md` to reference cleanup forecasts, AI-bloat index, remediation packets, and modules docs as canonical command/schema reference.
-- [ ] 3.4 Keep all cross-site links aligned with the modules docs permalink contract.
+- [x] 3.1 Update `README.md` with the cleanup forecast / AI IDE handoff value path.
+- [x] 3.2 Update `docs/getting-started/quickstart.md` with the JSON-first cleanup loop.
+- [x] 3.3 Update `docs/modules/code-review.md` to reference cleanup forecasts, AI-bloat index, remediation packets, and modules docs as canonical command/schema reference.
+- [x] 3.4 Update `docs/index.md`, `docs/README.md`, `docs/getting-started/README.md`, and `docs/_config.yml` so docs entry points share the AI-bloat defense first-contact story.
+- [x] 3.5 Update package metadata in `pyproject.toml`, `setup.py`, and `src/specfact_cli/__init__.py`.
+- [x] 3.6 Keep all cross-site links aligned with the modules docs permalink contract.
+- [x] 3.7 Apply and verify GitHub repository description/topics metadata.
 
 ## 4. Verification
 
-- [ ] 4.1 Run targeted docs tests and record passing evidence.
-- [ ] 4.2 Run required docs quality gates for the touched scope.
-- [ ] 4.3 Run SpecFact code review for changed docs/test scope if the repository gate applies.
-- [ ] 4.4 Update `TDD_EVIDENCE.md` with passing evidence and before/after docs summary.
+- [x] 4.1 Run targeted docs tests and record passing evidence.
+- [x] 4.2 Run required docs quality gates for the touched scope.
+- [x] 4.3 Run SpecFact code review for changed docs/test scope if the repository gate applies.
+- [x] 4.4 Update `TDD_EVIDENCE.md` with passing evidence and before/after docs summary.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "specfact-cli"
-version = "0.47.3"
-description = "The swiss knife CLI for agile DevOps teams. Keep backlog, specs, tests, and code in sync with validation and contract enforcement for new projects and long-lived codebases."
+version = "0.47.4"
+description = "AI-bloat defense CLI for Python teams. Run deterministic code review, cleanup forecasts, and spec/contract evidence for AI-assisted and brownfield delivery."
 readme = "README.md"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }  # Apache License 2.0
@@ -14,8 +14,12 @@ authors = [
 ]
 keywords = [
     "agile",
+    "ai-bloat",
     "devops",
     "backlog",
+    "code-review",
+    "clean-code",
+    "technical-debt",
     "scrum",
     "kanban",
     "safe",

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,10 @@ from setuptools import find_packages, setup
 if __name__ == "__main__":
     _setup = setup(
         name="specfact-cli",
-        version="0.47.3",
+        version="0.47.4",
         description=(
-            "The swiss knife CLI for agile DevOps teams. Keep backlog, specs, tests, and code in sync with "
-            "validation and contract enforcement for new projects and long-lived codebases."
+            "AI-bloat defense CLI for Python teams. Run deterministic code review, cleanup forecasts, "
+            "and spec/contract evidence for AI-assisted and brownfield delivery."
         ),
         packages=find_packages(where="src"),
         package_dir={"": "src"},

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """
-SpecFact CLI - Spec→Contract→Sentinel tool for contract-driven development.
+SpecFact CLI - AI-bloat defense CLI for Python teams.
 """
 
 # Package version: keep in sync with pyproject.toml, setup.py, src/specfact_cli/__init__.py
-__version__ = "0.47.3"
+__version__ = "0.47.4"

--- a/src/specfact_cli/__init__.py
+++ b/src/specfact_cli/__init__.py
@@ -1,7 +1,8 @@
 """
-SpecFact CLI - The swiss knife CLI for agile DevOps teams.
+SpecFact CLI - AI-bloat defense CLI for Python teams.
 
 This package provides command-line tools for:
+- Defending AI-assisted code against cleanup bloat
 - Turning code into clear specs and plans
 - Keeping backlog, specs, tests, and code in sync
 - Enforcing validation and contract checks before production
@@ -75,6 +76,6 @@ def _install_progressive_disclosure() -> None:
 # keeps missing-command and missing-parameter UX consistent outside the root CLI too.
 _install_progressive_disclosure()
 
-__version__ = "0.47.3"
+__version__ = "0.47.4"
 
 __all__ = ["__version__"]

--- a/tests/unit/docs/docs_test_constants.py
+++ b/tests/unit/docs/docs_test_constants.py
@@ -1,4 +1,4 @@
 """Shared constants for README/docs first-contact contract tests."""
 
-HOOK = "Review AI-assisted code against your own contracts."
-SUBHOOK = "Catch drift before it reaches PR or main."
+HOOK = "Defend AI-assisted Python code from bloat before it reaches PR."
+SUBHOOK = "Run deterministic review, cleanup forecasts, and spec/contract evidence locally."

--- a/tests/unit/docs/test_first_contact_story.py
+++ b/tests/unit/docs/test_first_contact_story.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import tomllib
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -14,13 +15,20 @@ from tests.unit.docs.docs_test_constants import HOOK, SUBHOOK
 REPO_ROOT = Path(__file__).resolve().parents[3]
 README = REPO_ROOT / "README.md"
 DOCS_INDEX = REPO_ROOT / "docs" / "index.md"
+DOCS_README = REPO_ROOT / "docs" / "README.md"
+GETTING_STARTED = REPO_ROOT / "docs" / "getting-started" / "README.md"
+QUICKSTART = REPO_ROOT / "docs" / "getting-started" / "quickstart.md"
+CODE_REVIEW_MODULE = REPO_ROOT / "docs" / "modules" / "code-review.md"
 CONTRIBUTING = REPO_ROOT / "CONTRIBUTING.md"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+SETUP_PY = REPO_ROOT / "setup.py"
+PACKAGE_INIT = REPO_ROOT / "src" / "specfact_cli" / "__init__.py"
 
 ABSOLUTE_URL_RE = re.compile(r"https?://[^\s)>'\"`]+")
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _require_entrypoint_files() -> None:
+def require_entrypoint_files() -> None:
     if not REPO_ROOT.exists():
         pytest.skip(f"Repository root missing: expected at {REPO_ROOT}", allow_module_level=True)
     if not README.is_file():
@@ -78,6 +86,58 @@ def test_docs_index_matches_proof_first_story() -> None:
     assert "## What is SpecFact?" in docs_index
     _assert_contains_url_host(docs_index, "modules.specfact.io", "docs/index.md")
     assert "default starting point" in docs_index.lower()
+
+
+def test_docs_entrypoints_share_ai_bloat_defense_story() -> None:
+    for path in (DOCS_README, GETTING_STARTED, QUICKSTART):
+        content = _read(path)
+        assert "AI-bloat defense" in content
+        assert "cleanup forecast" in content
+        assert "remediation packet" in content
+        assert "AI-authorship detection" in content
+        _assert_contains_url_host(content, "modules.specfact.io", str(path.relative_to(REPO_ROOT)))
+
+
+def test_quickstart_documents_json_first_cleanup_loop() -> None:
+    quickstart = _read(QUICKSTART)
+    expected_steps = (
+        "Run simplify-focused review with JSON output",
+        "Inspect `cleanup_forecast` and the AI-bloat index",
+        "Hand remediation packets to your AI IDE",
+        "Re-run review for proof",
+    )
+    for step in expected_steps:
+        assert step in quickstart
+
+
+def test_code_review_handoff_mentions_cleanup_forecast_and_modules_ownership() -> None:
+    docs = _read(CODE_REVIEW_MODULE)
+    for needle in (
+        "cleanup forecast",
+        "AI-bloat index",
+        "preserve reasons",
+        "remediation packets",
+        "modules.specfact.io/bundles/code-review/run/",
+        "modules.specfact.io/quickstart-ai-bloat/",
+    ):
+        assert needle in docs
+    assert "AI-authorship proof" in docs
+
+
+def test_distribution_description_mentions_ai_bloat_defense_cli() -> None:
+    pyproject = tomllib.loads(_read(PYPROJECT))
+    description = pyproject["project"]["description"]
+    keywords = set(pyproject["project"]["keywords"])
+    setup_py = _read(SETUP_PY)
+    package_init = _read(PACKAGE_INIT)
+
+    assert "AI-bloat defense CLI" in description
+    assert "cleanup forecasts" in description
+    assert {"ai-bloat", "code-review", "clean-code", "technical-debt"} <= keywords
+    assert "AI-bloat defense CLI" in setup_py
+    assert "AI-bloat defense CLI" in package_init
+    for metadata_text in (description, setup_py, package_init):
+        assert "swiss knife" not in metadata_text.lower()
 
 
 def test_contributing_guidance_mentions_entrypoint_story_hierarchy() -> None:

--- a/tests/unit/docs/test_release_docs_parity.py
+++ b/tests/unit/docs/test_release_docs_parity.py
@@ -4,7 +4,10 @@ import re
 from pathlib import Path
 from urllib.parse import ParseResult, unquote, urlparse
 
+import pytest
 import yaml
+
+from tests.unit.docs.docs_test_constants import HOOK
 
 
 MODULES_DOCS_HOST = "modules.specfact.io"
@@ -13,6 +16,19 @@ MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
 HTML_HREF_RE = re.compile(r'href="([^"]+)"')
 JEKYLL_RELATIVE_URL_RE = re.compile(r'\{\{\s*[\'"]([^\'"]+)[\'"]\s*\|\s*relative_url\s*\}\}')
 REQUIRED_NAV_FRONT_MATTER_KEYS = ("layout", "title", "permalink")
+REMOVED_AUTHORED_DOCS_SYNTAX = (
+    ("specfact project plan", "specfact project plan"),
+    ("project import from-bridge", "project import from-bridge"),
+    ("backlog policy", "backlog policy"),
+    ("spec contract", "spec contract"),
+    ("specfact spec api", "specfact spec api"),
+    ("spec sdd", "spec sdd"),
+    ("spec generate ", "spec generate <subcommand>"),
+)
+CURRENT_COMMAND_REFERENCE_CASES = (
+    ("spec commands", ("spec validate", "spec backward-compat", "spec generate-tests", "spec mock")),
+    ("backlog subcommands", ("backlog ceremony", "backlog refine", "backlog daily", "backlog sync")),
+)
 
 
 def _repo_root() -> Path:
@@ -348,11 +364,11 @@ def test_module_contracts_reference_external_bundle_boundary() -> None:
 def test_readme_and_docs_index_define_core_and_modules_split() -> None:
     readme = _repo_file("README.md").read_text(encoding="utf-8")
     docs_index = _repo_file("docs/index.md").read_text(encoding="utf-8")
-    assert "Review AI-assisted code against your own contracts." in readme
+    assert HOOK in readme
     assert "## Documentation topology" in readme
     assert "Module-specific deep docs are canonically owned by `specfact-cli-modules`" in readme
     _assert_mentions_modules_docs_site(readme)
-    assert "Review AI-assisted code against your own contracts." in docs_index
+    assert HOOK in docs_index
     assert "canonical starting point for the core CLI story" in docs_index
     assert "docs.specfact.io` is the default starting point" in docs_index
     _assert_mentions_modules_docs_site(docs_index)
@@ -435,39 +451,10 @@ def _fmt_hits(hits: list[tuple[str, int, str]]) -> str:
     return "\n".join(f"  {path}:{lineno}  {line}" for path, lineno, line in hits)
 
 
-def test_removed_project_plan_syntax_absent_from_authored_docs() -> None:
-    hits = _scan_authored_docs("specfact project plan")
-    assert not hits, f"Removed syntax 'specfact project plan' still present:\n{_fmt_hits(hits)}"
-
-
-def test_removed_project_import_from_bridge_syntax_absent_from_authored_docs() -> None:
-    hits = _scan_authored_docs("project import from-bridge")
-    assert not hits, f"Removed syntax 'project import from-bridge' still present:\n{_fmt_hits(hits)}"
-
-
-def test_removed_backlog_policy_syntax_absent_from_authored_docs() -> None:
-    hits = _scan_authored_docs("backlog policy")
-    assert not hits, f"Removed syntax 'backlog policy' still present:\n{_fmt_hits(hits)}"
-
-
-def test_removed_spec_contract_syntax_absent_from_authored_docs() -> None:
-    hits = _scan_authored_docs("spec contract")
-    assert not hits, f"Removed syntax 'spec contract' still present:\n{_fmt_hits(hits)}"
-
-
-def test_removed_spec_api_syntax_absent_from_authored_docs() -> None:
-    hits = _scan_authored_docs("specfact spec api")
-    assert not hits, f"Removed syntax 'specfact spec api' still present:\n{_fmt_hits(hits)}"
-
-
-def test_removed_spec_sdd_syntax_absent_from_authored_docs() -> None:
-    hits = _scan_authored_docs("spec sdd")
-    assert not hits, f"Removed syntax 'spec sdd' still present:\n{_fmt_hits(hits)}"
-
-
-def test_removed_spec_generate_syntax_absent_from_authored_docs() -> None:
-    hits = _scan_authored_docs("spec generate ")
-    assert not hits, f"Removed syntax 'spec generate <subcommand>' still present:\n{_fmt_hits(hits)}"
+@pytest.mark.parametrize(("syntax", "label"), REMOVED_AUTHORED_DOCS_SYNTAX)
+def test_removed_syntax_absent_from_authored_docs(syntax: str, label: str) -> None:
+    hits = _scan_authored_docs(syntax)
+    assert not hits, f"Removed syntax '{label}' still present:\n{_fmt_hits(hits)}"
 
 
 # ---------------------------------------------------------------------------
@@ -480,10 +467,9 @@ def test_current_code_import_from_bridge_documented() -> None:
     assert hits, "Current syntax 'code import' must appear in at least one authored doc"
 
 
-def test_current_spec_commands_documented_in_commands_reference() -> None:
-    commands_doc = _repo_file("docs/reference/commands.md").read_text(encoding="utf-8")
-    for cmd in ("spec validate", "spec backward-compat", "spec generate-tests", "spec mock"):
-        assert cmd in commands_doc, f"Current command '{cmd}' missing from docs/reference/commands.md"
+@pytest.mark.parametrize(("label", "commands"), CURRENT_COMMAND_REFERENCE_CASES)
+def test_current_commands_documented_in_commands_reference(label: str, commands: tuple[str, ...]) -> None:
+    _assert_commands_reference_includes(label, commands)
 
 
 def test_current_govern_enforce_sdd_documented() -> None:
@@ -491,10 +477,10 @@ def test_current_govern_enforce_sdd_documented() -> None:
     assert "govern enforce" in commands_doc, "'govern enforce' must appear in commands reference"
 
 
-def test_current_backlog_subcommands_documented_in_commands_reference() -> None:
+def _assert_commands_reference_includes(label: str, commands: tuple[str, ...]) -> None:
     commands_doc = _repo_file("docs/reference/commands.md").read_text(encoding="utf-8")
-    for sub in ("backlog ceremony", "backlog refine", "backlog daily", "backlog sync"):
-        assert sub in commands_doc, f"Current subcommand '{sub}' missing from commands reference"
+    for command in commands:
+        assert command in commands_doc, f"Current {label} command '{command}' missing from docs/reference/commands.md"
 
 
 def test_all_published_docs_markdown_files_have_jekyll_front_matter() -> None:
@@ -511,14 +497,17 @@ def test_all_published_docs_markdown_files_have_jekyll_front_matter() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_navigation_links_resolve_to_published_docs_routes() -> None:
-    failures, _ = _scan_navigation_targets()
-    assert not failures, "Broken navigation docs links:\n" + "\n".join(sorted(failures))
+def test_docs_links_resolve_to_published_docs_targets() -> None:
+    link_failure_groups = (
+        ("Broken navigation docs links", _scan_navigation_targets()[0]),
+        ("Broken authored docs links", _scan_authored_doc_link_failures()[0]),
+    )
+    for label, failures in link_failure_groups:
+        _assert_no_link_failures(failures, label)
 
 
-def test_authored_internal_docs_links_resolve_to_published_docs_targets() -> None:
-    failures, _ = _scan_authored_doc_link_failures()
-    assert not failures, "Broken authored docs links:\n" + "\n".join(sorted(failures))
+def _assert_no_link_failures(failures: list[str], label: str) -> None:
+    assert not failures, f"{label}:\n" + "\n".join(sorted(failures))
 
 
 def test_navigation_link_targets_have_required_front_matter_keys() -> None:

--- a/tests/unit/scripts/test_code_review_module_docs.py
+++ b/tests/unit/scripts/test_code_review_module_docs.py
@@ -25,3 +25,17 @@ def test_code_review_docs_describe_json_first_ledger_usage() -> None:
     assert "~/.specfact/ledger.json" in docs
     assert "Supabase" in docs
     assert "optional" in docs.lower()
+
+
+def test_code_review_docs_describe_ai_bloat_handoff_without_schema_duplication() -> None:
+    docs = _docs_text()
+    for needle in (
+        "cleanup forecast",
+        "AI-bloat index",
+        "preserve reasons",
+        "remediation packets",
+        "modules.specfact.io/bundles/code-review/run/",
+        "modules.specfact.io/quickstart-ai-bloat/",
+    ):
+        assert needle in docs
+    assert "AI-authorship proof" in docs

--- a/tests/unit/test_core_docs_site_contract.py
+++ b/tests/unit/test_core_docs_site_contract.py
@@ -1,8 +1,9 @@
 import re
 from pathlib import Path
-from urllib.parse import urlparse
 
 import yaml
+
+from tests.unit.docs.docs_test_constants import HOOK
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -30,12 +31,6 @@ def _config() -> dict[str, object]:
     return yaml.safe_load(_read(DOCS_CONFIG))
 
 
-def _contains_url_host(content: str, host: str) -> bool:
-    """Return whether the text contains at least one absolute URL for the host."""
-
-    return any(urlparse(match.group(0).rstrip(".,;:")).netloc == host for match in ABSOLUTE_URL_RE.finditer(content))
-
-
 def _contains_markdown_link_target(content: str, target_url: str) -> bool:
     """Return whether the text contains a markdown link targeting the URL."""
 
@@ -55,7 +50,8 @@ def test_core_docs_config_targets_public_core_domain() -> None:
 def test_core_landing_page_marks_core_repo_as_canonical_owner() -> None:
     index = _read(DOCS_INDEX)
 
-    assert "SpecFact is the validation and alignment layer for software delivery." in index
+    assert HOOK in index
+    assert "AI-bloat defense" in index
     assert "canonical starting point for the core CLI story" in index
     assert "module-deep workflows" in index
     assert _contains_markdown_link_target(index, "https://modules.specfact.io/")


### PR DESCRIPTION
## Summary

- Reposition README, docs entrypoints, quickstart, code-review handoff, package metadata, and repo metadata guidance around AI-bloat defense for Python teams.
- Add docs/tests that lock the new first-contact story, cleanup forecast loop, AI IDE handoff, and non-AI-authorship-detection framing.
- Expand and complete OpenSpec change `docs-15-clean-code-bazooka-onboarding`, including TDD evidence and GitHub metadata verification.
- Bump package version to `0.47.4` because package metadata changed.

Closes #584.

## Validation

- `openspec validate docs-15-clean-code-bazooka-onboarding --strict`
- `hatch run pytest tests/unit/docs/test_first_contact_story.py tests/unit/docs/test_wow_entrypoint_contract.py tests/unit/docs/test_release_docs_parity.py tests/unit/test_core_docs_site_contract.py tests/unit/scripts/test_code_review_module_docs.py -q`
- `hatch run docs-validate`
- `hatch run check-version-sources`
- `hatch run lint`
- `hatch run python scripts/pre_commit_code_review.py setup.py src/__init__.py src/specfact_cli/__init__.py tests/unit/docs/docs_test_constants.py tests/unit/docs/test_first_contact_story.py tests/unit/docs/test_release_docs_parity.py tests/unit/scripts/test_code_review_module_docs.py tests/unit/test_core_docs_site_contract.py`
- Pre-commit Block 1 and Block 2 passed during commit, including code review with 0 findings.