### PR TITLE
feat(init): add validation profile layering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [0.48.0] - 2026-07-06
+## [0.48.1] - 2026-07-06
 
 ### Added
 
@@ -18,6 +18,12 @@ All notable changes to this project will be documented in this file.
   `enterprise` validation tiers for `specfact init`, including deterministic
   config layering, source annotations, clean-code defaults, and refreshed
   OpenSpec evidence.
+
+### Security
+
+- **Docs dependency lockfile**: update `concurrent-ruby` in `docs/Gemfile.lock`
+  to `1.3.7`, remediating Dependabot alerts GHSA-6wx8-w4f5-wwcr,
+  GHSA-h8w8-99g7-qmvj, and GHSA-wv3x-4vxv-whpp.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [0.48.1] - 2026-07-06
+## [0.48.2] - 2026-07-06
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.48.0] - 2026-07-06
+
+### Added
+
+- **Validation profile layering**: add `solo`, `startup`, `mid_size`, and
+  `enterprise` validation tiers for `specfact init`, including deterministic
+  config layering, source annotations, clean-code defaults, and refreshed
+  OpenSpec evidence.
+
+---
+
 ## [0.47.11] - 2026-06-14
 
 ### Fixed

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
     colorator (1.1.0)
-    concurrent-ruby (1.3.5)
+    concurrent-ruby (1.3.7)
     csv (3.3.5)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)

--- a/docs/core-cli/init.md
+++ b/docs/core-cli/init.md
@@ -29,13 +29,27 @@ specfact init ide [OPTIONS]
 | Option | Type | Description |
 |--------|------|-------------|
 | `--repo` | DIRECTORY | Repository path (default: current directory) |
-| `--profile` | TEXT | First-run profile preset (see below) |
+| `--profile` | TEXT | Validation tier or legacy first-run profile preset (see below) |
 | `--install` | TEXT | Comma-separated bundle names or `all` to install without prompting |
 | `--install-deps` | | Install required packages for contract enhancement |
 
-## Profiles
+## Validation Tiers
 
-Profiles select a default set of bundles appropriate for your team setup:
+Validation tier profiles write `.specfact/config.yaml` with deterministic defaults and source annotations:
+
+| Profile | Clean-code default | Validation posture |
+|---------|--------------------|--------------------|
+| `solo` | `advisory` | Fast local feedback |
+| `startup` | `advisory_then_mixed` | Team defaults with gradual enforcement |
+| `mid_size` | `mixed` | Mixed advisory and blocking checks |
+| `enterprise` | `hard` | Required evidence and hard-fail governance |
+
+Config layers resolve in this order: profile defaults, org baseline, repo overlay, developer-local override.
+The generated config records `source_annotations` for the winning value of each key.
+
+## Legacy Workflow Presets
+
+Legacy presets still select a default set of bundles appropriate for your team setup:
 
 | Profile | Description |
 |---------|-------------|
@@ -45,7 +59,10 @@ Profiles select a default set of bundles appropriate for your team setup:
 | `enterprise-full-stack` | All official bundles including governance and adapters |
 
 ```bash
-# Bootstrap with the solo-developer preset
+# Bootstrap with a validation tier
+specfact init --profile startup
+
+# Bootstrap with the legacy solo-developer preset
 specfact init --profile solo-developer
 
 # Install specific bundles during init

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -214,6 +214,10 @@ installed backlog bundle, not by the permanent core command surface.
 
 Profile outcomes:
 
+Validation tiers (`solo`, `startup`, `mid_size`, `enterprise`) write deterministic validation config
+with clean-code defaults of `advisory`, `advisory_then_mixed`, `mixed`, and `hard` respectively.
+Legacy workflow presets remain available for bundle-first bootstrap:
+
 | Profile | Installed bundles | Available groups |
 |---|---|---|
 | `solo-developer` | `specfact-codebase`, `specfact-code-review` | `code` |

--- a/docs/reference/module-categories.md
+++ b/docs/reference/module-categories.md
@@ -82,7 +82,9 @@ Compatibility note:
 
 ## First-Run Profiles
 
-`specfact init` supports profile presets and explicit bundle selection:
+`specfact init` supports validation tiers, legacy profile presets, and explicit bundle selection.
+Validation tiers (`solo`, `startup`, `mid_size`, `enterprise`) write layered validation config with
+source annotations. Legacy workflow presets still install the bundle sets below:
 
 - `solo-developer` -> `specfact-codebase`
 - `backlog-team` -> `specfact-backlog`, `specfact-project`, `specfact-codebase`

--- a/docs/reference/module-categories.md
+++ b/docs/reference/module-categories.md
@@ -84,18 +84,26 @@ Compatibility note:
 
 `specfact init` supports validation tiers, legacy profile presets, and explicit bundle selection.
 Validation tiers (`solo`, `startup`, `mid_size`, `enterprise`) write layered validation config with
-source annotations. Legacy workflow presets still install the bundle sets below:
+source annotations. Tier-based profiles install the current bundle sets below:
 
-- `solo-developer` -> `specfact-codebase`
-- `backlog-team` -> `specfact-backlog`, `specfact-project`, `specfact-codebase`
-- `api-first-team` -> `specfact-spec`, `specfact-codebase` (and `specfact-project` is auto-installed as a dependency)
-- `enterprise-full-stack` -> `specfact-project`, `specfact-backlog`, `specfact-codebase`, `specfact-spec`, `specfact-govern`
+- `solo` -> `specfact-codebase`, `specfact-code-review`
+- `startup` -> `specfact-project`, `specfact-backlog`, `specfact-codebase`, `specfact-code-review`
+- `mid_size` -> `specfact-project`, `specfact-backlog`, `specfact-codebase`, `specfact-spec`, `specfact-code-review`
+- `enterprise` -> `specfact-project`, `specfact-backlog`, `specfact-codebase`, `specfact-spec`, `specfact-govern`, `specfact-code-review`
+
+Legacy workflow presets remain accepted for compatibility. They map to the corresponding validation
+tier for config defaults while preserving their historical install selections:
+
+- `solo-developer` -> `solo`
+- `backlog-team` -> `startup`
+- `api-first-team` -> `mid_size`
+- `enterprise-full-stack` -> `enterprise`
 
 Examples:
 
 ```bash
-specfact init --profile solo-developer
-specfact init --install backlog,codebase
+specfact init --profile startup
+specfact init --install backlog,code-review
 specfact init --install all
 ```
 

--- a/openspec/changes/profile-01-config-layering/CHANGE_VALIDATION.md
+++ b/openspec/changes/profile-01-config-layering/CHANGE_VALIDATION.md
@@ -1,28 +1,28 @@
-# Change Validation: profile-01-config-layering
+# CHANGE VALIDATION
 
-- **Validated on (UTC):** 2026-03-22T22:28:26+00:00
-- **Workflow:** /wf-validate-change (proposal-stage dry-run validation)
-- **Strict command:** `openspec validate profile-01-config-layering --strict`
-- **Result:** PASS
+- Change: `profile-01-config-layering`
+- Date: 2026-07-06
+- Command: `openspec validate profile-01-config-layering --strict`
+- Result: PASS
+
+## Refresh Notes
+
+- Refreshed the February 2026 proposal/design language against the July 2026 validation-evidence roadmap in `openspec/CHANGE_ORDER.md`.
+- Removed stale proposal-stage wording that said no runtime code would change.
+- Kept the change scoped to core `init`, validation tier defaults, config layering, and source annotations.
+- Preserved legacy first-run workflow presets as compatibility input while making validation tiers the config-authority surface.
+- Replaced ceremony-oriented wording with validation-support module language.
 
 ## Scope Summary
 
-- **Primary capability:** `profile-config-layering`
-- **Clean-code delta:** tier profiles now own clean-code default modes instead of a parallel clean-code profile system
-- **Declared dependencies:** policy and governance consumers that inherit tier defaults
-
-## Breaking-Change Analysis (Dry-Run)
-
-- The delta refines default resolution rather than expanding the public command set.
-- The main risk is config-authority drift, which is resolved by keeping tier defaults in one place.
-
-## Dependency and Integration Review
-
-- The clean-code default mapping aligns with `policy-02-packs-and-modes`.
-- No additional dependent changes needed to be created to keep the ownership graph coherent.
+- Primary capability: `profile-config-layering`.
+- Modified capability: `init-module-state`.
+- Clean-code delta: tier profiles own clean-code default modes instead of a parallel clean-code profile system.
+- Declared dependencies: none; this remains the first Wave 2 validation foundation change.
 
 ## Validation Outcome
 
-- Required artifacts are present and parseable.
+- Required OpenSpec artifacts are present and parseable.
 - Strict OpenSpec validation passed.
-- Change remains authoritative for tier-derived clean-code defaults.
+- Implementation evidence is recorded in `TDD_EVIDENCE.md`.
+- PR-readiness status: ready pending PR creation and normal review.

--- a/openspec/changes/profile-01-config-layering/TDD_EVIDENCE.md
+++ b/openspec/changes/profile-01-config-layering/TDD_EVIDENCE.md
@@ -147,6 +147,19 @@
 - Command: `hatch run verify-modules-signature-push --version-check-base origin/dev`
 - Result: Passed, 4 module manifests verified.
 
+- Timestamp: 2026-07-06 23:56 CEST
+- Source: PR #624 GitHub compatibility rerun on commit `0a56c828`.
+- Finding addressed: Python 3.11 compatibility still failed because runtime built-in module loading reported `init` integrity verification failure; the PR checksum gate had passed in relaxed mode, but runtime verification uses the strict payload checksum.
+- Fix: regenerated `src/specfact_cli/modules/init/module-package.yaml` with the signed/stable payload checksum `sha256:bfadcf13364a94bcf9e0b26e288386f04ecfb23ab932201e487188d17fc499e4`.
+
+- Timestamp: 2026-07-06 23:56 CEST
+- Command: `hatch run python -c "from pathlib import Path; import yaml; from specfact_cli.models.module_package import ModulePackageMetadata; from specfact_cli.registry.module_installer import verify_module_artifact; p=Path('src/specfact_cli/modules/init'); data=yaml.safe_load((p/'module-package.yaml').read_text()); meta=ModulePackageMetadata(**data); print(verify_module_artifact(p, meta, allow_unsigned=True))"`
+- Result: Passed; runtime verification returned `True`.
+
+- Timestamp: 2026-07-06 23:57 CEST
+- Command: `hatch run py311:test tests/unit/cli/test_lean_help_output.py::test_stale_lazy_flat_shim_prints_install_guidance tests/unit/cli/test_lean_help_output.py::test_lazy_delegate_bare_group_shows_full_help_and_missing_subcommand tests/unit/modules/init/test_init_ide_prompt_selection.py::test_init_ide_malformed_vscode_settings_exits_nonzero tests/unit/specfact_cli/registry/test_init_module_lifecycle_ux.py::test_init_rejects_deprecated_list_modules_option tests/integration/test_core_slimming.py::test_init_profile_solo_developer_exits_zero_and_code_group_mounted tests/integration/test_core_slimming.py::test_init_profile_enterprise_full_stack_help_shows_eight_commands tests/integration/test_core_slimming.py::test_init_install_all_same_as_enterprise tests/integration/test_core_slimming.py::test_stale_flat_shim_plan_exits_with_removed_alias_guidance tests/integration/test_core_slimming.py::test_init_cicd_mode_no_profile_no_install_exits_one -q`
+- Result: Passed, 9 passed. This covers the exact Python 3.11 compatibility failures from the GitHub job after refreshing the runtime checksum.
+
 - Timestamp: 2026-07-06 23:40 CEST
 - Command: `hatch run specfact code review run --scope changed --json --out .specfact/code-review.json`
 - Result: Passed with advisory, CI exit code 0, score 96, 0 blocking findings on changed lines.

--- a/openspec/changes/profile-01-config-layering/TDD_EVIDENCE.md
+++ b/openspec/changes/profile-01-config-layering/TDD_EVIDENCE.md
@@ -1,0 +1,110 @@
+# TDD Evidence: profile-01-config-layering
+
+## Stale-change refresh
+
+- Timestamp: 2026-07-06 23:18 CEST
+- Result: Refreshed February 2026 OpenSpec artifacts before PR preparation.
+- Evidence:
+  - `proposal.md` now records the 2026-07-06 implementation refresh and PR-candidate status.
+  - `design.md` no longer describes the change as proposal-stage only or non-code.
+  - `specs/init-module-state/spec.md` now uses validation-support module language instead of stale ceremony positioning.
+  - `CHANGE_VALIDATION.md` now records the current strict validation result.
+
+## Failing-before run
+
+- Timestamp: 2026-07-06 22:02 CEST
+- Command: `hatch run pytest tests/unit/modules/init/test_first_run_selection.py -q`
+- Result: Failed as expected before production implementation.
+- Evidence:
+  - `test_validation_tier_profiles_resolve_clean_code_defaults` failed because `first_run_selection.resolve_profile_config` did not exist.
+  - `test_profile_config_layering_records_winning_sources` failed because `first_run_selection.resolve_profile_config` did not exist.
+  - `test_init_startup_profile_writes_layered_config_and_enables_startup_modules` failed because `startup` was rejected as an unknown profile.
+
+## Passing-after runs
+
+- Timestamp: 2026-07-06 22:04 CEST
+- Command: `hatch run pytest tests/unit/modules/init/test_first_run_selection.py -q`
+- Result: Passed, 24 passed.
+
+- Timestamp: 2026-07-06 22:08 CEST
+- Command: `hatch run pytest tests/unit/modules/init/test_first_run_selection.py -q`
+- Result: Passed, 24 passed.
+
+- Timestamp: 2026-07-06 22:08 CEST
+- Command: `hatch run pytest tests/e2e/test_first_run_init.py -q`
+- Result: Passed, 2 passed.
+
+## Quality and OpenSpec gates
+
+- Timestamp: 2026-07-06 22:07 CEST
+- Command: `hatch run format`
+- Result: Passed.
+
+- Timestamp: 2026-07-06 22:07 CEST
+- Command: `hatch run type-check`
+- Result: Passed with existing repository warnings; touched resolver warning removed.
+
+- Timestamp: 2026-07-06 22:08 CEST
+- Command: `openspec validate profile-01-config-layering --strict`
+- Result: Passed.
+
+- Timestamp: 2026-07-06 22:09 CEST
+- Command: `hatch run yaml-lint`
+- Result: Passed.
+
+- Timestamp: 2026-07-06 22:09 CEST
+- Command: `hatch run lint`
+- Result: Passed.
+
+- Timestamp: 2026-07-06 23:02 CEST
+- Command: `hatch run pytest tests/unit/modules/init/test_first_run_selection.py -q`
+- Result: Passed, 24 passed.
+
+- Timestamp: 2026-07-06 23:02 CEST
+- Command: `hatch run pytest tests/e2e/test_first_run_init.py -q`
+- Result: Passed, 2 passed.
+
+- Timestamp: 2026-07-06 23:02 CEST
+- Command: `openspec validate profile-01-config-layering --strict`
+- Result: Passed.
+
+- Timestamp: 2026-07-06 23:03 CEST
+- Command: `hatch run format`
+- Result: Passed.
+
+- Timestamp: 2026-07-06 23:03 CEST
+- Command: `hatch run type-check`
+- Result: Passed with existing repository warnings; 0 errors.
+
+- Timestamp: 2026-07-06 23:03 CEST
+- Command: `hatch run yaml-lint`
+- Result: Passed.
+
+- Timestamp: 2026-07-06 23:04 CEST
+- Command: `hatch run lint`
+- Result: Passed. Initial sandbox run failed in pylint process-pool system-limit detection; rerun outside sandbox passed with 10.00/10.
+
+- Timestamp: 2026-07-06 23:04 CEST
+- Command: `hatch run contract-test`
+- Result: Passed with cached changed-scope result: no modified files detected.
+
+- Timestamp: 2026-07-06 23:04 CEST
+- Command: `hatch run specfact code review run --scope changed --json --out .specfact/code-review.json`
+- Result: Passed with advisory, CI exit code 0, score 96, 9 advisory findings, 0 blocking findings.
+- Advisory disposition: not fixed in this PR. Findings are legacy clean-code/KISS/YAGNI advisories around existing `commands.py` helpers and `init_ide` size/shape, not regressions introduced by profile config layering. Changing them here would expand scope beyond the OpenSpec story.
+
+- Timestamp: 2026-07-06 23:04 CEST
+- Command: `hatch run bandit-scan`
+- Result: Passed. No medium/high issues identified.
+
+- Timestamp: 2026-07-06 23:08 CEST
+- Command: `SEMGREP_ENABLE_VERSION_CHECK=0 hatch run semgrep-sast --json --output logs/static-analysis/semgrep.json`
+- Result: Passed, 0 findings.
+
+- Timestamp: 2026-07-06 23:08 CEST
+- Command: `hatch run semgrep-sast-gate --results logs/static-analysis/semgrep.json --baseline tools/semgrep/sast-baseline.json`
+- Result: Passed, 0 current findings and 0 accepted baseline findings.
+
+- Timestamp: 2026-07-06 23:04 CEST
+- Command: `hatch run smart-test`
+- Result: Inconclusive. The tool had no incremental baseline, expanded to a full 2,783-test suite, and was stopped after unrelated broad-suite failures appeared outside the changed scope. Targeted unit/e2e tests above provide changed-scope coverage for this PR.

--- a/openspec/changes/profile-01-config-layering/TDD_EVIDENCE.md
+++ b/openspec/changes/profile-01-config-layering/TDD_EVIDENCE.md
@@ -108,3 +108,77 @@
 - Timestamp: 2026-07-06 23:04 CEST
 - Command: `hatch run smart-test`
 - Result: Inconclusive. The tool had no incremental baseline, expanded to a full 2,783-test suite, and was stopped after unrelated broad-suite failures appeared outside the changed scope. Targeted unit/e2e tests above provide changed-scope coverage for this PR.
+
+## PR review follow-up evidence
+
+- Timestamp: 2026-07-06 23:31 CEST
+- Source: PR #624 GitHub review and CI logs.
+- Findings addressed: stale init module checksum/signature metadata, missing `code-review` `init --install` alias, stale tier docs wording, unguarded profile config write error handling, stale generated profile overlay on repeated `init --profile`, missing policy-weakening warning coverage, and duplicated tier module defaults.
+
+- Timestamp: 2026-07-06 23:33 CEST
+- Command: `hatch run pytest tests/unit/modules/init/test_first_run_selection.py::test_install_code_review_alias_resolves_to_code_review_bundle tests/unit/modules/init/test_first_run_selection.py::test_developer_local_weakening_org_policy_emits_warning tests/unit/modules/init/test_first_run_selection.py::test_profile_defaults_derive_enabled_modules_from_profile_presets tests/unit/modules/init/test_first_run_selection.py::test_write_profile_config_rerun_does_not_keep_prior_generated_profile tests/unit/modules/init/test_first_run_selection.py::test_init_profile_malformed_existing_config_exits_nonzero -q`
+- Result: Failed as expected before implementation, 3 failed and 2 passed. Failing cases covered the missing `code-review` alias, stale generated profile overlay, and unhandled malformed config error.
+
+- Timestamp: 2026-07-06 23:34 CEST
+- Command: `hatch run pytest tests/unit/modules/init/test_first_run_selection.py::test_install_code_review_alias_resolves_to_code_review_bundle tests/unit/modules/init/test_first_run_selection.py::test_developer_local_weakening_org_policy_emits_warning tests/unit/modules/init/test_first_run_selection.py::test_profile_defaults_derive_enabled_modules_from_profile_presets tests/unit/modules/init/test_first_run_selection.py::test_write_profile_config_rerun_does_not_keep_prior_generated_profile tests/unit/modules/init/test_first_run_selection.py::test_init_profile_malformed_existing_config_exits_nonzero -q`
+- Result: Passed, 5 passed.
+
+- Timestamp: 2026-07-06 23:36 CEST
+- Command: `hatch run pytest tests/e2e/test_core_slimming_e2e.py::test_e2e_init_profile_solo_developer_then_code_group_available tests/e2e/test_core_slimming_e2e.py::test_e2e_init_profile_api_first_team_then_spec_contract_help tests/e2e/test_first_run_init.py::test_init_profile_solo_developer_completes_in_temp_workspace tests/e2e/test_wow_entrypoint.py::test_init_solo_developer_exits_zero_in_temp_git_repo tests/e2e/test_wow_entrypoint.py::test_after_wow_profile_mock_bundles_registry_lists_code_for_step_two tests/e2e/test_wow_entrypoint.py::test_after_wow_profile_only_code_review_does_not_expose_code_command tests/integration/test_core_slimming.py::test_init_profile_solo_developer_exits_zero_and_code_group_mounted tests/integration/test_core_slimming.py::test_init_profile_enterprise_full_stack_help_shows_eight_commands tests/integration/test_core_slimming.py::test_init_install_all_same_as_enterprise tests/integration/test_core_slimming.py::test_stale_flat_shim_plan_exits_with_removed_alias_guidance tests/integration/test_core_slimming.py::test_init_cicd_mode_no_profile_no_install_exits_one 'tests/unit/cli/test_error_guidance.py::test_cli_misuse_matrix_shows_contextual_help_once[bare module-args1]' tests/unit/cli/test_lean_help_output.py::test_stale_lazy_flat_shim_prints_install_guidance tests/unit/cli/test_lean_help_output.py::test_lazy_delegate_bare_group_shows_full_help_and_missing_subcommand tests/unit/modules/init/test_init_ide_prompt_selection.py::test_init_ide_malformed_vscode_settings_exits_nonzero tests/unit/specfact_cli/registry/test_init_module_lifecycle_ux.py::test_init_rejects_deprecated_list_modules_option -q`
+- Result: Passed, 15 passed and 1 expected skip. This covers the Python 3.12 CI failures observed on PR #624.
+
+- Timestamp: 2026-07-06 23:37 CEST
+- Command: `hatch run py311:test tests/unit/modules/init/test_first_run_selection.py::test_install_code_review_alias_resolves_to_code_review_bundle tests/unit/modules/init/test_first_run_selection.py::test_write_profile_config_rerun_does_not_keep_prior_generated_profile tests/unit/modules/init/test_first_run_selection.py::test_init_profile_malformed_existing_config_exits_nonzero tests/unit/cli/test_lean_help_output.py::test_stale_lazy_flat_shim_prints_install_guidance tests/integration/test_core_slimming.py::test_init_profile_solo_developer_exits_zero_and_code_group_mounted -q`
+- Result: Passed, 5 passed. This covers the Python 3.11 CI failure class observed on PR #624.
+
+- Timestamp: 2026-07-06 23:38 CEST
+- Command: `hatch run lint`
+- Result: Passed, 0 errors, 0 warnings, 0 notes; pylint rated 10.00/10.
+
+- Timestamp: 2026-07-06 23:38 CEST
+- Command: `hatch run type-check`
+- Result: Passed with existing repository warnings; focused touched-file type check passed with 0 errors, 0 warnings, 0 notes.
+
+- Timestamp: 2026-07-06 23:38 CEST
+- Command: `hatch run check-docs-commands`
+- Result: Passed, 382 unique command prefixes checked.
+
+- Timestamp: 2026-07-06 23:40 CEST
+- Command: `hatch run verify-modules-signature-push --version-check-base origin/dev`
+- Result: Passed, 4 module manifests verified.
+
+- Timestamp: 2026-07-06 23:40 CEST
+- Command: `hatch run specfact code review run --scope changed --json --out .specfact/code-review.json`
+- Result: Passed with advisory, CI exit code 0, score 96, 0 blocking findings on changed lines.
+- Advisory disposition: not fixed in this PR. Remaining advisories are pre-existing function-size/YAGNI signals in `src/specfact_cli/modules/init/src/commands.py` outside the review-fix lines. The direct regression and review findings were addressed; broader init refactoring is intentionally out of scope for this PR repair.
+
+## Dependabot remediation evidence
+
+- Timestamp: 2026-07-06 23:43 CEST
+- Source: GitHub Dependabot alerts #3, #4, and #5.
+- Findings addressed: `concurrent-ruby` in `docs/Gemfile.lock` was vulnerable to GHSA-6wx8-w4f5-wwcr, GHSA-h8w8-99g7-qmvj, and GHSA-wv3x-4vxv-whpp for versions `< 1.3.7`.
+- Fix: updated `docs/Gemfile.lock` from `concurrent-ruby 1.3.5` to `1.3.7`.
+
+- Timestamp: 2026-07-06 23:43 CEST
+- Command: `GEM_HOME=/tmp/specfact-bundler-2.3.5 GEM_PATH=/tmp/specfact-bundler-2.3.5 BUNDLE_GEMFILE=docs/Gemfile /tmp/specfact-bundler-2.3.5/bin/bundle _2.3.5_ update concurrent-ruby --patch`
+- Result: Inconclusive due local Ruby 2.6 resolver incompatibility with existing docs lockfile gems requiring Ruby >=2.7. No lockfile drift occurred from this failed resolver run; the minimal patched-version lockfile update was applied manually.
+
+- Timestamp: 2026-07-06 23:44 CEST
+- Command: `ruby -e 'lock = File.read("docs/Gemfile.lock"); abort("missing patched concurrent-ruby") unless lock.include?("concurrent-ruby (1.3.7)"); abort("still vulnerable") if lock.include?("concurrent-ruby (1.3.5)") || lock.include?("concurrent-ruby (1.3.6)"); puts "docs/Gemfile.lock concurrent-ruby patched"'`
+- Result: Passed.
+
+- Timestamp: 2026-07-06 23:44 CEST
+- Command: `GEM_HOME=/tmp/specfact-bundler-2.3.5 GEM_PATH=/tmp/specfact-bundler-2.3.5 BUNDLE_GEMFILE=docs/Gemfile /tmp/specfact-bundler-2.3.5/bin/bundle _2.3.5_ platform`
+- Result: Passed; Bundler parsed the lockfile and reported supported platforms.
+
+- Timestamp: 2026-07-06 23:45 CEST
+- Command: `hatch run license-check`
+- Result: Passed, 0 license violations.
+
+- Timestamp: 2026-07-06 23:45 CEST
+- Command: `hatch run security-audit`
+- Result: Passed. No high-severity Python vulnerabilities found; pip CVE warning remains CVSS 0.0 and below gate threshold.
+
+- Timestamp: 2026-07-06 23:45 CEST
+- Command: `hatch run bandit-scan`
+- Result: Passed. No medium/high issues identified.

--- a/openspec/changes/profile-01-config-layering/design.md
+++ b/openspec/changes/profile-01-config-layering/design.md
@@ -1,18 +1,22 @@
 ## Context
 
-This change implements proposal scope for `profile-01-config-layering` from the 2026-02-15 architecture-layer integration plan. It is proposal-stage only and defines implementation strategy without changing runtime code.
+This change implements `profile-01-config-layering` from the 2026-02-15 architecture-layer integration plan, refreshed on 2026-07-06 against the validation-evidence roadmap in `openspec/CHANGE_ORDER.md`.
+
+The current implementation target is core `init` and config resolution. Profiles are validation rollout tiers, not broad ceremony or lifecycle enablement.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- Define an implementation approach that stays within the proposal scope.
-- Keep compatibility with existing module registry, adapter bridge, and contract-first patterns.
+- Add deterministic config layering for profile defaults, org baseline, repo overlay, and developer-local overrides.
+- Keep compatibility with existing first-run workflow presets and module registry behavior.
 - Preserve offline-first behavior and deterministic CLI execution.
+- Make tier-derived clean-code defaults part of one shared profile resolver.
 
 **Non-Goals:**
 
-- No production code implementation in this stage.
+- No profile package under the stale `modules/profile/...` structure.
+- No separate clean-code profile selector outside validation tiers.
 - No schema-breaking changes outside declared capabilities.
 - No dependency expansion beyond the proposal and plan.
 
@@ -22,6 +26,8 @@ This change implements proposal scope for `profile-01-config-layering` from the 
 - Keep all public APIs contract-first with `@icontract` and `@beartype`.
 - Make all behavior extensions opt-in or backward-compatible by default.
 - Add/modify OpenSpec deltas first so tests can be derived before implementation.
+- Store winning-source provenance in generated config as `source_annotations`.
+- Preserve legacy profile names as bundle presets, while mapping them to validation tiers when config is written.
 
 ## Risks / Trade-offs
 
@@ -31,12 +37,12 @@ This change implements proposal scope for `profile-01-config-layering` from the 
 
 ## Migration Plan
 
-1. Implement this change only after listed dependencies are implemented.
-2. Add tests from spec scenarios and capture failing-first evidence.
-3. Implement minimal production changes needed for passing scenarios.
+1. Add tests from spec scenarios and capture failing-first evidence.
+2. Implement minimal production changes needed for passing scenarios.
+3. Update user-facing docs for validation tiers and legacy profile presets.
 4. Run quality gates and then open PR to `dev`.
 
 ## Open Questions
 
-- Dependency summary: None (foundation change in Wave A).
-- Whether additional cross-change sequencing constraints should be hard-blocked in `openspec/CHANGE_ORDER.md`.
+- Dependency summary: None; this remains the first Wave 2 validation foundation change.
+- No additional cross-change sequencing constraints were required during the 2026-07-06 refresh.

--- a/openspec/changes/profile-01-config-layering/proposal.md
+++ b/openspec/changes/profile-01-config-layering/proposal.md
@@ -18,6 +18,17 @@ layering around validation.
 - Implementation MUST keep profiles focused on validation rollout and evidence
   strictness, not broad ceremony enablement.
 
+## Implementation Refresh (2026-07-06)
+
+- Revalidated against the July validation-evidence roadmap in
+  `openspec/CHANGE_ORDER.md`.
+- Kept the scope in core `init` and config resolution; no profile package or
+  separate ceremony workflow layer is introduced.
+- Preserved legacy first-run workflow presets as compatibility aliases while
+  adding validation tier profiles as the new config-authority surface.
+- Updated OpenSpec tasks, design notes, validation evidence, and docs before
+  PR preparation.
+
 ## What Changes
 
 - **NEW**: Deterministic config layering: profile defaults -> org baseline -> repo
@@ -51,6 +62,6 @@ layering around validation.
 <!-- source_repo: nold-ai/specfact-cli -->
 - **GitHub Issue**: #237
 - **Issue URL**: <https://github.com/nold-ai/specfact-cli/issues/237>
-- **Last Synced Status**: proposed
+- **Last Synced Status**: implementation-ready / PR candidate on `feature/profile-01-config-layering-baseline`
 - **Sanitized**: false
 <!-- content_hash: d7dfe1519fa64668 -->

--- a/openspec/changes/profile-01-config-layering/specs/init-module-state/spec.md
+++ b/openspec/changes/profile-01-config-layering/specs/init-module-state/spec.md
@@ -8,7 +8,7 @@ The system SHALL initialize module state according to the active profile selecte
 
 - **GIVEN** `specfact init --profile startup`
 - **WHEN** init writes module state
-- **THEN** enabled modules include sync and ceremony capabilities for startup
+- **THEN** enabled modules include the startup validation-support bundle set
 - **AND** modules outside the startup profile default set remain disabled unless explicitly enabled.
 
 #### Scenario: Backward compatible default behavior

--- a/openspec/changes/profile-01-config-layering/specs/profile-config-layering/spec.md
+++ b/openspec/changes/profile-01-config-layering/specs/profile-config-layering/spec.md
@@ -13,16 +13,16 @@ The system SHALL resolve configuration using deterministic layer precedence.
 
 #### Scenario: Profile-specific defaults are applied
 
-- **GIVEN** `specfact init --profile enterprise`
+- **GIVEN** `specfact init --profile solo`, `startup`, `mid_size`, or `enterprise`
 - **WHEN** profile config is generated
-- **THEN** policy mode defaults to enterprise-grade enforcement
-- **AND** requirements schema includes enterprise-required fields.
+- **THEN** the selected tier provides deterministic defaults for validation severity, policy mode, evidence persistence, clean-code mode, module activation, and requirements schema
+- **AND** enterprise defaults include enterprise-required requirements schema fields.
 
 #### Scenario: Clean-code defaults are inherited from the selected tier
 
-- **GIVEN** `specfact init --profile startup`
+- **GIVEN** profile defaults are generated for `solo`, `startup`, `mid_size`, and `enterprise`
 - **WHEN** profile config is generated
-- **THEN** the clean-code policy pack defaults to advisory mode with gradual promotion to mixed
+- **THEN** clean-code defaults are `solo -> advisory`, `startup -> advisory_then_mixed`, `mid_size -> mixed`, and `enterprise -> hard`
 - **AND** no separate clean-code profile selector is required in the resolved config
 
 #### Scenario: Invalid profile is rejected

--- a/openspec/changes/profile-01-config-layering/tasks.md
+++ b/openspec/changes/profile-01-config-layering/tasks.md
@@ -2,30 +2,31 @@
 
 ## 1. Branch and dependency guardrails
 
-- [ ] 1.1 Create dedicated worktree branch `feature/profile-01-config-layering` from `dev` before implementation work: `scripts/worktree.sh create feature/profile-01-config-layering`.
-- [ ] 1.2 Verify prerequisite changes are implemented or explicitly accepted as parallel work.
-- [ ] 1.3 Reconfirm scope against the 2026-02-15 architecture integration plan and this proposal.
+- [x] 1.1 Create dedicated worktree branch `feature/profile-01-config-layering-baseline` from `dev` before implementation work.
+- [x] 1.2 Verify prerequisite changes are implemented or explicitly accepted as parallel work.
+- [x] 1.3 Reconfirm scope against the 2026-02-15 architecture integration plan and this proposal.
+- [x] 1.4 Refresh stale February proposal/design/spec wording against the July validation-evidence roadmap before PR preparation.
 
 ## 2. Spec-first and test-first preparation
 
-- [ ] 2.1 Finalize `specs/` deltas for all listed capabilities and cross-check scenario completeness.
-- [ ] 2.2 Add/update tests mapped to new and modified scenarios.
-- [ ] 2.3 Run targeted tests to capture failing-first behavior and record results in `TDD_EVIDENCE.md`.
+- [x] 2.1 Finalize `specs/` deltas for all listed capabilities and cross-check scenario completeness.
+- [x] 2.2 Add/update tests mapped to new and modified scenarios.
+- [x] 2.3 Run targeted tests to capture failing-first behavior and record results in `TDD_EVIDENCE.md`.
 
 ## 3. Implementation
 
-- [ ] 3.1 Implement minimal production code required to satisfy the new scenarios.
-- [ ] 3.2 Add/update contract decorators and type enforcement on public APIs.
-- [ ] 3.3 Update command wiring, adapters, and models required by this change scope only.
-- [ ] 3.4 Map tier profiles to clean-code defaults in the shared resolver so downstream consumers inherit one source of truth for clean-code mode selection.
+- [x] 3.1 Implement minimal production code required to satisfy the new scenarios.
+- [x] 3.2 Add/update contract decorators and type enforcement on public APIs.
+- [x] 3.3 Update command wiring, adapters, and models required by this change scope only.
+- [x] 3.4 Map tier profiles to clean-code defaults in the shared resolver so downstream consumers inherit one source of truth for clean-code mode selection.
 
 ## 4. Validation and documentation
 
-- [ ] 4.1 Re-run tests and quality gates until all changed scenarios pass.
-- [ ] 4.2 Update user-facing docs and navigation for changed/added commands and workflows.
-- [ ] 4.3 Run `openspec validate profile-01-config-layering --strict` and resolve all issues.
+- [x] 4.1 Re-run tests and quality gates until all changed scenarios pass.
+- [x] 4.2 Update user-facing docs and navigation for changed/added commands and workflows.
+- [x] 4.3 Run `openspec validate profile-01-config-layering --strict` and resolve all issues.
 
 ## 5. Delivery
 
-- [ ] 5.1 Update `openspec/CHANGE_ORDER.md` status/dependency notes if implementation sequencing changed.
-- [ ] 5.2 Open a PR from `feature/profile-01-config-layering` to `dev` with spec/test/code/docs evidence.
+- [x] 5.1 Confirm `openspec/CHANGE_ORDER.md` did not need status/dependency updates; implementation sequencing stayed unchanged.
+- [ ] 5.2 Open a PR from `feature/profile-01-config-layering-baseline` to `dev` with spec/test/code/docs evidence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "specfact-cli"
-version = "0.48.0"
+version = "0.48.1"
 description = "AI-bloat defense CLI for Python teams. Run deterministic code review, cleanup forecasts, and spec/contract evidence for AI-assisted and brownfield delivery."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "specfact-cli"
-version = "0.48.1"
+version = "0.48.2"
 description = "AI-bloat defense CLI for Python teams. Run deterministic code review, cleanup forecasts, and spec/contract evidence for AI-assisted and brownfield delivery."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "specfact-cli"
-version = "0.47.11"
+version = "0.48.0"
 description = "AI-bloat defense CLI for Python teams. Run deterministic code review, cleanup forecasts, and spec/contract evidence for AI-assisted and brownfield delivery."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 if __name__ == "__main__":
     _setup = setup(
         name="specfact-cli",
-        version="0.47.11",
+        version="0.48.0",
         description=(
             "AI-bloat defense CLI for Python teams. Run deterministic code review, cleanup forecasts, "
             "and spec/contract evidence for AI-assisted and brownfield delivery."

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 if __name__ == "__main__":
     _setup = setup(
         name="specfact-cli",
-        version="0.48.0",
+        version="0.48.1",
         description=(
             "AI-bloat defense CLI for Python teams. Run deterministic code review, cleanup forecasts, "
             "and spec/contract evidence for AI-assisted and brownfield delivery."

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 if __name__ == "__main__":
     _setup = setup(
         name="specfact-cli",
-        version="0.48.1",
+        version="0.48.2",
         description=(
             "AI-bloat defense CLI for Python teams. Run deterministic code review, cleanup forecasts, "
             "and spec/contract evidence for AI-assisted and brownfield delivery."

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,4 +3,4 @@ SpecFact CLI - AI-bloat defense CLI for Python teams.
 """
 
 # Package version: keep in sync with pyproject.toml, setup.py, src/specfact_cli/__init__.py
-__version__ = "0.48.0"
+__version__ = "0.48.1"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,4 +3,4 @@ SpecFact CLI - AI-bloat defense CLI for Python teams.
 """
 
 # Package version: keep in sync with pyproject.toml, setup.py, src/specfact_cli/__init__.py
-__version__ = "0.48.1"
+__version__ = "0.48.2"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,4 +3,4 @@ SpecFact CLI - AI-bloat defense CLI for Python teams.
 """
 
 # Package version: keep in sync with pyproject.toml, setup.py, src/specfact_cli/__init__.py
-__version__ = "0.47.11"
+__version__ = "0.48.0"

--- a/src/specfact_cli/__init__.py
+++ b/src/specfact_cli/__init__.py
@@ -76,6 +76,6 @@ def _install_progressive_disclosure() -> None:
 # keeps missing-command and missing-parameter UX consistent outside the root CLI too.
 _install_progressive_disclosure()
 
-__version__ = "0.48.0"
+__version__ = "0.48.1"
 
 __all__ = ["__version__"]

--- a/src/specfact_cli/__init__.py
+++ b/src/specfact_cli/__init__.py
@@ -76,6 +76,6 @@ def _install_progressive_disclosure() -> None:
 # keeps missing-command and missing-parameter UX consistent outside the root CLI too.
 _install_progressive_disclosure()
 
-__version__ = "0.47.11"
+__version__ = "0.48.0"
 
 __all__ = ["__version__"]

--- a/src/specfact_cli/__init__.py
+++ b/src/specfact_cli/__init__.py
@@ -76,6 +76,6 @@ def _install_progressive_disclosure() -> None:
 # keeps missing-command and missing-parameter UX consistent outside the root CLI too.
 _install_progressive_disclosure()
 
-__version__ = "0.48.1"
+__version__ = "0.48.2"
 
 __all__ = ["__version__"]

--- a/src/specfact_cli/modules/init/module-package.yaml
+++ b/src/specfact_cli/modules/init/module-package.yaml
@@ -1,5 +1,5 @@
 name: init
-version: 0.1.38
+version: 0.1.39
 commands:
   - init
 category: core
@@ -17,5 +17,4 @@ publisher:
 description: Initialize SpecFact workspace and bootstrap local configuration.
 license: Apache-2.0
 integrity:
-  checksum: sha256:8741e8fa3408bd38e7d65d0784a25466369955dd9f16f1981a52c0e1550afbe0
-  signature: kPAMdqpcAr92gr+DwxWibXfD0mgCLSb78EwGzoXH3fHct7xss8zt/SFvJLVZ0qkYHA8/4Nu6ls0iihRN9DXhCw==
+  checksum: sha256:bfcd73600a371296824ba21ba8daa45b24627f7e36139f9efd4ab2b805834b20

--- a/src/specfact_cli/modules/init/module-package.yaml
+++ b/src/specfact_cli/modules/init/module-package.yaml
@@ -1,5 +1,5 @@
 name: init
-version: 0.1.39
+version: 0.1.40
 commands:
   - init
 category: core
@@ -17,4 +17,4 @@ publisher:
 description: Initialize SpecFact workspace and bootstrap local configuration.
 license: Apache-2.0
 integrity:
-  checksum: sha256:bfcd73600a371296824ba21ba8daa45b24627f7e36139f9efd4ab2b805834b20
+  checksum: sha256:bfadcf13364a94bcf9e0b26e288386f04ecfb23ab932201e487188d17fc499e4

--- a/src/specfact_cli/modules/init/module-package.yaml
+++ b/src/specfact_cli/modules/init/module-package.yaml
@@ -1,5 +1,5 @@
 name: init
-version: 0.1.37
+version: 0.1.38
 commands:
   - init
 category: core

--- a/src/specfact_cli/modules/init/src/commands.py
+++ b/src/specfact_cli/modules/init/src/commands.py
@@ -48,14 +48,7 @@ from specfact_cli.utils.ide_setup import (
 )
 
 
-VALID_PROFILES: frozenset[str] = frozenset(
-    {
-        "solo-developer",
-        "backlog-team",
-        "api-first-team",
-        "enterprise-full-stack",
-    }
-)
+VALID_PROFILES: frozenset[str] = frozenset(first_run_selection.get_valid_profile_names())
 PROFILE_BUNDLES: dict[str, list[str]] = first_run_selection.PROFILE_PRESETS
 
 install_bundles_for_init = first_run_selection.install_bundles_for_init
@@ -725,7 +718,10 @@ def init(
     profile: str | None = typer.Option(
         None,
         "--profile",
-        help="First-run profile preset: solo-developer, backlog-team, api-first-team, enterprise-full-stack",
+        help=(
+            "Validation tier or legacy workflow preset: solo, startup, mid_size, enterprise, "
+            "solo-developer, backlog-team, api-first-team, enterprise-full-stack"
+        ),
     ),
     install: str | None = typer.Option(
         None,
@@ -751,6 +747,8 @@ def init(
         enabled_module_ids: list[str] = []
         if profile is not None or install is not None:
             enabled_module_ids = _apply_profile_or_install_bundles(profile, install)
+            if profile is not None:
+                first_run_selection.write_profile_config(repo_path, profile)
         elif is_first_run(user_root=INIT_USER_MODULES_ROOT) and is_non_interactive():
             console.print(
                 "[red]Error:[/red] In CI/CD (non-interactive) mode, first-run init requires "

--- a/src/specfact_cli/modules/init/src/commands.py
+++ b/src/specfact_cli/modules/init/src/commands.py
@@ -702,6 +702,21 @@ def init_ide(
         console.print(f"[green]Updated VS Code settings:[/green] {settings_path}")
 
 
+def _write_profile_config_or_exit(repo_path: Path, profile: str) -> None:
+    try:
+        first_run_selection.write_profile_config(repo_path, profile)
+    except ValueError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1) from e
+
+
+def _apply_explicit_profile_or_install(repo_path: Path, profile: str | None, install: str | None) -> list[str]:
+    enabled_module_ids = _apply_profile_or_install_bundles(profile, install)
+    if profile is not None:
+        _write_profile_config_or_exit(repo_path, profile)
+    return enabled_module_ids
+
+
 @app.callback(invoke_without_command=True)
 @require(lambda repo: _is_valid_repo_path(repo), "Repo path must exist and be directory")
 @ensure(lambda result: result is None, "Command should return None")
@@ -746,9 +761,7 @@ def init(
 
         enabled_module_ids: list[str] = []
         if profile is not None or install is not None:
-            enabled_module_ids = _apply_profile_or_install_bundles(profile, install)
-            if profile is not None:
-                first_run_selection.write_profile_config(repo_path, profile)
+            enabled_module_ids = _apply_explicit_profile_or_install(repo_path, profile, install)
         elif is_first_run(user_root=INIT_USER_MODULES_ROOT) and is_non_interactive():
             console.print(
                 "[red]Error:[/red] In CI/CD (non-interactive) mode, first-run init requires "

--- a/src/specfact_cli/modules/init/src/first_run_selection.py
+++ b/src/specfact_cli/modules/init/src/first_run_selection.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import yaml
 from beartype import beartype
@@ -50,6 +50,11 @@ LEGACY_PROFILE_TO_VALIDATION_TIER: dict[str, str] = {
     "enterprise-full-stack": "enterprise",
 }
 
+
+def _canonical_module_ids(bundle_ids: list[str]) -> list[str]:
+    return [f"nold-ai/{bundle_id}" for bundle_id in bundle_ids]
+
+
 _PROFILE_DEFAULTS: dict[str, dict[str, Any]] = {
     "solo": {
         "profile": "solo",
@@ -62,7 +67,7 @@ _PROFILE_DEFAULTS: dict[str, dict[str, Any]] = {
             "mode": "advisory",
         },
         "modules": {
-            "enabled": ["nold-ai/specfact-codebase", "nold-ai/specfact-code-review"],
+            "enabled": _canonical_module_ids(PROFILE_PRESETS["solo"]),
         },
         "requirements_schema": {
             "required_fields": ["id", "title", "acceptance"],
@@ -79,12 +84,7 @@ _PROFILE_DEFAULTS: dict[str, dict[str, Any]] = {
             "mode": "advisory_then_mixed",
         },
         "modules": {
-            "enabled": [
-                "nold-ai/specfact-project",
-                "nold-ai/specfact-backlog",
-                "nold-ai/specfact-codebase",
-                "nold-ai/specfact-code-review",
-            ],
+            "enabled": _canonical_module_ids(PROFILE_PRESETS["startup"]),
         },
         "requirements_schema": {
             "required_fields": ["id", "title", "owner", "acceptance"],
@@ -101,13 +101,7 @@ _PROFILE_DEFAULTS: dict[str, dict[str, Any]] = {
             "mode": "mixed",
         },
         "modules": {
-            "enabled": [
-                "nold-ai/specfact-project",
-                "nold-ai/specfact-backlog",
-                "nold-ai/specfact-codebase",
-                "nold-ai/specfact-spec",
-                "nold-ai/specfact-code-review",
-            ],
+            "enabled": _canonical_module_ids(PROFILE_PRESETS["mid_size"]),
         },
         "requirements_schema": {
             "required_fields": ["id", "title", "owner", "acceptance", "trace_links"],
@@ -124,14 +118,7 @@ _PROFILE_DEFAULTS: dict[str, dict[str, Any]] = {
             "mode": "hard",
         },
         "modules": {
-            "enabled": [
-                "nold-ai/specfact-project",
-                "nold-ai/specfact-backlog",
-                "nold-ai/specfact-codebase",
-                "nold-ai/specfact-spec",
-                "nold-ai/specfact-govern",
-                "nold-ai/specfact-code-review",
-            ],
+            "enabled": _canonical_module_ids(PROFILE_PRESETS["enterprise"]),
         },
         "requirements_schema": {
             "required_fields": [
@@ -148,6 +135,9 @@ _PROFILE_DEFAULTS: dict[str, dict[str, Any]] = {
 }
 
 _RESERVED_CONFIG_KEYS: frozenset[str] = frozenset({"source_annotations", "profile_warnings"})
+_PROFILE_GENERATED_CONFIG_KEYS: frozenset[str] = frozenset(
+    {"validation", "clean_code", "modules", "requirements_schema"}
+)
 _POLICY_STRENGTH: dict[str, int] = {"advisory": 1, "advisory_then_mixed": 2, "mixed": 3, "hard": 4}
 
 _INSTALL_ALL_BUNDLES: tuple[str, ...] = (
@@ -176,6 +166,8 @@ BUNDLE_ALIAS_TO_CANONICAL: dict[str, str] = {
     "backlog": "specfact-backlog",
     "codebase": "specfact-codebase",
     "code": "specfact-codebase",
+    "code-review": "specfact-code-review",
+    "code_review": "specfact-code-review",
     "spec": "specfact-spec",
     "govern": "specfact-govern",
 }
@@ -341,6 +333,28 @@ def _read_yaml_mapping(path: Path) -> dict[str, Any]:
     return raw
 
 
+def _source_tree_contains_profile(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.startswith("profile:")
+    if isinstance(value, Mapping):
+        return any(_source_tree_contains_profile(child) for child in value.values())
+    return False
+
+
+def _repo_overlay_without_generated_profile_values(raw_overlay: Mapping[str, Any]) -> dict[str, Any]:
+    overlay = {str(key): deepcopy(value) for key, value in raw_overlay.items()}
+    overlay.pop("profile", None)
+    source_annotations = overlay.pop("source_annotations", {})
+    overlay.pop("profile_warnings", None)
+    if not isinstance(source_annotations, Mapping):
+        return overlay
+    sources_by_key = {str(key): cast(Any, value) for key, value in source_annotations.items()}
+    for key in _PROFILE_GENERATED_CONFIG_KEYS:
+        if _source_tree_contains_profile(sources_by_key.get(key)):
+            overlay.pop(key, None)
+    return overlay
+
+
 @require(lambda repo_path: isinstance(repo_path, Path), "repo_path must be Path")
 @require(lambda profile: isinstance(profile, str) and profile.strip() != "", "profile must be non-empty string")
 @ensure(lambda result: isinstance(result, ResolvedProfileConfig), "result must be a resolved profile config")
@@ -352,8 +366,7 @@ def write_profile_config(repo_path: Path, profile: str) -> ResolvedProfileConfig
     local_path = specfact_dir / "config.local.yaml"
     org_path = Path.home() / ".specfact" / "config.yaml"
 
-    repo_overlay = _read_yaml_mapping(config_path)
-    repo_overlay.pop("profile", None)
+    repo_overlay = _repo_overlay_without_generated_profile_values(_read_yaml_mapping(config_path))
     resolved = resolve_profile_config(
         profile,
         org_baseline=_read_yaml_mapping(org_path),

--- a/src/specfact_cli/modules/init/src/first_run_selection.py
+++ b/src/specfact_cli/modules/init/src/first_run_selection.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
+from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import yaml
 from beartype import beartype
 from icontract import ensure, require
 
@@ -25,7 +28,127 @@ PROFILE_PRESETS: dict[str, list[str]] = {
         "specfact-spec",
         "specfact-govern",
     ],
+    "solo": ["specfact-codebase", "specfact-code-review"],
+    "startup": ["specfact-project", "specfact-backlog", "specfact-codebase", "specfact-code-review"],
+    "mid_size": ["specfact-project", "specfact-backlog", "specfact-codebase", "specfact-spec", "specfact-code-review"],
+    "enterprise": [
+        "specfact-project",
+        "specfact-backlog",
+        "specfact-codebase",
+        "specfact-spec",
+        "specfact-govern",
+        "specfact-code-review",
+    ],
 }
+
+VALIDATION_TIER_PROFILES: tuple[str, ...] = ("solo", "startup", "mid_size", "enterprise")
+
+LEGACY_PROFILE_TO_VALIDATION_TIER: dict[str, str] = {
+    "solo-developer": "solo",
+    "backlog-team": "startup",
+    "api-first-team": "mid_size",
+    "enterprise-full-stack": "enterprise",
+}
+
+_PROFILE_DEFAULTS: dict[str, dict[str, Any]] = {
+    "solo": {
+        "profile": "solo",
+        "validation": {
+            "severity": "advisory",
+            "policy_mode": "advisory",
+            "evidence_persistence": "local",
+        },
+        "clean_code": {
+            "mode": "advisory",
+        },
+        "modules": {
+            "enabled": ["nold-ai/specfact-codebase", "nold-ai/specfact-code-review"],
+        },
+        "requirements_schema": {
+            "required_fields": ["id", "title", "acceptance"],
+        },
+    },
+    "startup": {
+        "profile": "startup",
+        "validation": {
+            "severity": "mixed",
+            "policy_mode": "mixed",
+            "evidence_persistence": "repo",
+        },
+        "clean_code": {
+            "mode": "advisory_then_mixed",
+        },
+        "modules": {
+            "enabled": [
+                "nold-ai/specfact-project",
+                "nold-ai/specfact-backlog",
+                "nold-ai/specfact-codebase",
+                "nold-ai/specfact-code-review",
+            ],
+        },
+        "requirements_schema": {
+            "required_fields": ["id", "title", "owner", "acceptance"],
+        },
+    },
+    "mid_size": {
+        "profile": "mid_size",
+        "validation": {
+            "severity": "mixed",
+            "policy_mode": "mixed",
+            "evidence_persistence": "repo",
+        },
+        "clean_code": {
+            "mode": "mixed",
+        },
+        "modules": {
+            "enabled": [
+                "nold-ai/specfact-project",
+                "nold-ai/specfact-backlog",
+                "nold-ai/specfact-codebase",
+                "nold-ai/specfact-spec",
+                "nold-ai/specfact-code-review",
+            ],
+        },
+        "requirements_schema": {
+            "required_fields": ["id", "title", "owner", "acceptance", "trace_links"],
+        },
+    },
+    "enterprise": {
+        "profile": "enterprise",
+        "validation": {
+            "severity": "hard",
+            "policy_mode": "hard",
+            "evidence_persistence": "required",
+        },
+        "clean_code": {
+            "mode": "hard",
+        },
+        "modules": {
+            "enabled": [
+                "nold-ai/specfact-project",
+                "nold-ai/specfact-backlog",
+                "nold-ai/specfact-codebase",
+                "nold-ai/specfact-spec",
+                "nold-ai/specfact-govern",
+                "nold-ai/specfact-code-review",
+            ],
+        },
+        "requirements_schema": {
+            "required_fields": [
+                "id",
+                "title",
+                "owner",
+                "acceptance",
+                "trace_links",
+                "risk_classification",
+                "exception_evidence",
+            ],
+        },
+    },
+}
+
+_RESERVED_CONFIG_KEYS: frozenset[str] = frozenset({"source_annotations", "profile_warnings"})
+_POLICY_STRENGTH: dict[str, int] = {"advisory": 1, "advisory_then_mixed": 2, "mixed": 3, "hard": 4}
 
 _INSTALL_ALL_BUNDLES: tuple[str, ...] = (
     "specfact-project",
@@ -83,6 +206,15 @@ BUNDLE_DISPLAY: dict[str, str] = {
 }
 
 
+@dataclass(frozen=True)
+class ResolvedProfileConfig:
+    """Resolved profile config with source annotations for each winning value."""
+
+    values: dict[str, Any]
+    sources: dict[str, Any]
+    warnings: list[str]
+
+
 def _emit_init_bundle_progress() -> bool:
     """Return True when init should print progress (suppressed during pytest)."""
     return os.environ.get("PYTEST_CURRENT_TEST") is None
@@ -105,6 +237,139 @@ def _expand_bundle_install_order(bundle_ids: list[str]) -> list[str]:
             continue
         _add_bundle(bid)
     return to_install
+
+
+def _normalize_profile_key(profile: str) -> str:
+    key = profile.strip().lower()
+    return "mid_size" if key in {"mid-size", "mid_size"} else key
+
+
+@require(lambda profile: isinstance(profile, str) and profile.strip() != "", "profile must be non-empty string")
+@ensure(lambda result: result in VALIDATION_TIER_PROFILES, "result must be a validation tier")
+@beartype
+def resolve_validation_tier(profile: str) -> str:
+    """Map a validation tier or legacy workflow preset to a validation config tier."""
+    key = profile.strip().lower()
+    normalized = _normalize_profile_key(profile)
+    if normalized in VALIDATION_TIER_PROFILES:
+        return normalized
+    if key in LEGACY_PROFILE_TO_VALIDATION_TIER:
+        return LEGACY_PROFILE_TO_VALIDATION_TIER[key]
+    valid = ", ".join(get_valid_profile_names())
+    raise ValueError(f"Unknown profile {profile!r}. Valid profiles: {valid}")
+
+
+def _source_tree(value: Any, source: str) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _source_tree(child, source) for key, child in value.items()}
+    return source
+
+
+def _merge_config_layer(target: dict[str, Any], sources: dict[str, Any], layer: Mapping[str, Any], source: str) -> None:
+    for raw_key, raw_value in layer.items():
+        key = str(raw_key)
+        if key in _RESERVED_CONFIG_KEYS:
+            continue
+        value = deepcopy(raw_value)
+        if isinstance(value, Mapping) and isinstance(target.get(key), dict):
+            existing_source = sources.get(key)
+            if not isinstance(existing_source, dict):
+                sources[key] = {}
+            _merge_config_layer(target[key], sources[key], value, source)
+            continue
+        target[key] = value
+        sources[key] = _source_tree(value, source)
+
+
+def _extract_policy_value(layer: Mapping[str, Any] | None, key: str) -> str | None:
+    if not layer:
+        return None
+    validation = layer.get("validation")
+    if not isinstance(validation, Mapping):
+        return None
+    validation_values: dict[str, Any] = {str(raw_key): raw_value for raw_key, raw_value in validation.items()}
+    value = validation_values.get(key)
+    return value if isinstance(value, str) else None
+
+
+def _local_policy_weakened(org_baseline: Mapping[str, Any] | None, developer_local: Mapping[str, Any] | None) -> bool:
+    for key in ("severity", "policy_mode"):
+        org_value = _extract_policy_value(org_baseline, key)
+        local_value = _extract_policy_value(developer_local, key)
+        if org_value is None or local_value is None:
+            continue
+        if _POLICY_STRENGTH.get(local_value, 0) < _POLICY_STRENGTH.get(org_value, 0):
+            return True
+    return False
+
+
+@require(lambda profile: isinstance(profile, str) and profile.strip() != "", "profile must be non-empty string")
+@ensure(lambda result: isinstance(result, ResolvedProfileConfig), "result must be a resolved profile config")
+@beartype
+def resolve_profile_config(
+    profile: str,
+    *,
+    org_baseline: Mapping[str, Any] | None = None,
+    repo_overlay: Mapping[str, Any] | None = None,
+    developer_local: Mapping[str, Any] | None = None,
+) -> ResolvedProfileConfig:
+    """Resolve profile defaults, org baseline, repo overlay, and developer-local config layers."""
+    tier = resolve_validation_tier(profile)
+    values: dict[str, Any] = {}
+    sources: dict[str, Any] = {}
+    _merge_config_layer(values, sources, _PROFILE_DEFAULTS[tier], f"profile:{tier}")
+    for layer, source in (
+        (org_baseline, "org_baseline"),
+        (repo_overlay, "repo_overlay"),
+        (developer_local, "developer_local"),
+    ):
+        if layer:
+            _merge_config_layer(values, sources, layer, source)
+
+    warnings: list[str] = []
+    if _local_policy_weakened(org_baseline, developer_local):
+        warnings.append("developer_local weakens org validation policy")
+    return ResolvedProfileConfig(values=values, sources=sources, warnings=warnings)
+
+
+def _read_yaml_mapping(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"Config file must contain a mapping: {path}")
+    return raw
+
+
+@require(lambda repo_path: isinstance(repo_path, Path), "repo_path must be Path")
+@require(lambda profile: isinstance(profile, str) and profile.strip() != "", "profile must be non-empty string")
+@ensure(lambda result: isinstance(result, ResolvedProfileConfig), "result must be a resolved profile config")
+@beartype
+def write_profile_config(repo_path: Path, profile: str) -> ResolvedProfileConfig:
+    """Write `.specfact/config.yaml` for the selected profile with source annotations."""
+    specfact_dir = repo_path / ".specfact"
+    config_path = specfact_dir / "config.yaml"
+    local_path = specfact_dir / "config.local.yaml"
+    org_path = Path.home() / ".specfact" / "config.yaml"
+
+    repo_overlay = _read_yaml_mapping(config_path)
+    repo_overlay.pop("profile", None)
+    resolved = resolve_profile_config(
+        profile,
+        org_baseline=_read_yaml_mapping(org_path),
+        repo_overlay=repo_overlay,
+        developer_local=_read_yaml_mapping(local_path),
+    )
+
+    payload = deepcopy(resolved.values)
+    payload["profile"] = resolve_validation_tier(profile)
+    payload["source_annotations"] = resolved.sources
+    if resolved.warnings:
+        payload["profile_warnings"] = resolved.warnings
+
+    specfact_dir.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False), encoding="utf-8")
+    return resolved
 
 
 @dataclass
@@ -235,7 +500,7 @@ def _process_one_bundle_install_row(bid: str, deps: _InitBundleInstallDeps) -> N
 @beartype
 def resolve_profile_bundles(profile: str) -> list[str]:
     """Resolve a profile name to the list of canonical bundle ids to install."""
-    key = profile.strip().lower()
+    key = _normalize_profile_key(profile)
     if key not in PROFILE_PRESETS:
         valid = ", ".join(sorted(PROFILE_PRESETS))
         raise ValueError(f"Unknown profile {profile!r}. Valid profiles: {valid}")

--- a/tests/unit/modules/init/test_first_run_selection.py
+++ b/tests/unit/modules/init/test_first_run_selection.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 from typer.testing import CliRunner
 
 from specfact_cli.modules.init.src import commands as init_commands, first_run_selection as frs
@@ -51,6 +52,39 @@ def test_profile_enterprise_full_stack_resolves_to_all_five_bundles() -> None:
         "specfact-govern",
     }
     assert len(bundles) == 5
+
+
+def test_validation_tier_profiles_resolve_clean_code_defaults() -> None:
+    expected_modes = {
+        "solo": "advisory",
+        "startup": "advisory_then_mixed",
+        "mid_size": "mixed",
+        "enterprise": "hard",
+    }
+
+    for profile, mode in expected_modes.items():
+        resolved = frs.resolve_profile_config(profile)
+        assert resolved.values["clean_code"]["mode"] == mode
+        assert resolved.sources["clean_code"]["mode"] == f"profile:{profile}"
+
+
+def test_profile_config_layering_records_winning_sources() -> None:
+    resolved = frs.resolve_profile_config(
+        "solo",
+        org_baseline={
+            "validation": {"severity": "mixed"},
+            "clean_code": {"mode": "mixed"},
+        },
+        repo_overlay={"validation": {"severity": "hard"}},
+        developer_local={"clean_code": {"mode": "advisory"}},
+    )
+
+    assert resolved.values["validation"]["severity"] == "hard"
+    assert resolved.sources["validation"]["severity"] == "repo_overlay"
+    assert resolved.values["clean_code"]["mode"] == "advisory"
+    assert resolved.sources["clean_code"]["mode"] == "developer_local"
+    assert resolved.values["validation"]["policy_mode"] == "advisory"
+    assert resolved.sources["validation"]["policy_mode"] == "profile:solo"
 
 
 def test_profile_nonexistent_raises_with_valid_list() -> None:
@@ -206,6 +240,45 @@ def test_init_profile_enables_profile_modules_and_uses_repo_for_discovery(
     assert isinstance(enable_ids, list)
     assert set(enable_ids) == {"nold-ai/specfact-codebase", "nold-ai/specfact-code-review"}
     assert captured["preserve_existing"] is True
+
+
+def test_init_startup_profile_writes_layered_config_and_enables_startup_modules(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_get_discovered_modules_for_state(**kwargs: object) -> list[dict[str, object]]:
+        captured.update(kwargs)
+        return [{"id": "nold-ai/specfact-project", "enabled": True}]
+
+    monkeypatch.setattr("specfact_cli.modules.init.src.commands.install_bundles_for_init", lambda *_a, **_k: None)
+    monkeypatch.setattr("specfact_cli.modules.init.src.commands.is_first_run", lambda **_: True)
+    monkeypatch.setattr(
+        "specfact_cli.modules.init.src.commands.get_discovered_modules_for_state",
+        _fake_get_discovered_modules_for_state,
+    )
+    monkeypatch.setattr("specfact_cli.modules.init.src.commands.write_modules_state", lambda _: None)
+    monkeypatch.setattr("specfact_cli.modules.init.src.commands.run_discovery_and_write_cache", lambda _: None)
+    monkeypatch.setattr(
+        "specfact_cli.modules.init.src.commands.detect_env_manager", lambda _: MagicMock(manager=MagicMock())
+    )
+
+    with _telemetry_track_context():
+        result = runner.invoke(
+            app,
+            ["--repo", str(tmp_path), "--profile", "startup"],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, result.output
+    config_path = tmp_path / ".specfact" / "config.yaml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert config["profile"] == "startup"
+    assert config["clean_code"]["mode"] == "advisory_then_mixed"
+    assert config["source_annotations"]["clean_code"]["mode"] == "profile:startup"
+    enable_ids = captured["enable_ids"]
+    assert isinstance(enable_ids, list)
+    assert {"nold-ai/specfact-project", "nold-ai/specfact-backlog"} <= set(enable_ids)
 
 
 def test_init_profile_enterprise_full_stack_calls_installer_with_all_five(

--- a/tests/unit/modules/init/test_first_run_selection.py
+++ b/tests/unit/modules/init/test_first_run_selection.py
@@ -87,6 +87,24 @@ def test_profile_config_layering_records_winning_sources() -> None:
     assert resolved.sources["validation"]["policy_mode"] == "profile:solo"
 
 
+def test_developer_local_weakening_org_policy_emits_warning() -> None:
+    resolved = frs.resolve_profile_config(
+        "enterprise",
+        org_baseline={"validation": {"severity": "hard", "policy_mode": "hard"}},
+        developer_local={"validation": {"severity": "advisory"}},
+    )
+
+    assert "developer_local weakens org validation policy" in resolved.warnings
+
+
+def test_profile_defaults_derive_enabled_modules_from_profile_presets() -> None:
+    for profile in frs.VALIDATION_TIER_PROFILES:
+        resolved = frs.resolve_profile_config(profile)
+        expected = [f"nold-ai/{bundle}" for bundle in frs.resolve_profile_bundles(profile)]
+
+        assert resolved.values["modules"]["enabled"] == expected
+
+
 def test_profile_nonexistent_raises_with_valid_list() -> None:
     with pytest.raises(ValueError) as exc_info:
         frs.resolve_profile_bundles("nonexistent")
@@ -102,6 +120,13 @@ def test_install_backlog_codebase_resolves_to_two_bundles() -> None:
     bundles = frs.resolve_install_bundles("backlog,codebase")
     assert set(bundles) == {"specfact-backlog", "specfact-codebase"}
     assert len(bundles) == 2
+
+
+def test_install_code_review_alias_resolves_to_code_review_bundle() -> None:
+    assert frs.resolve_install_bundles("backlog,code-review") == [
+        "specfact-backlog",
+        "specfact-code-review",
+    ]
 
 
 def test_install_all_resolves_to_all_five_bundles() -> None:
@@ -279,6 +304,51 @@ def test_init_startup_profile_writes_layered_config_and_enables_startup_modules(
     enable_ids = captured["enable_ids"]
     assert isinstance(enable_ids, list)
     assert {"nold-ai/specfact-project", "nold-ai/specfact-backlog"} <= set(enable_ids)
+
+
+def test_write_profile_config_rerun_does_not_keep_prior_generated_profile(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(frs.Path, "home", lambda: tmp_path / "home")
+
+    frs.write_profile_config(tmp_path, "enterprise")
+    resolved = frs.write_profile_config(tmp_path, "solo")
+
+    config_path = tmp_path / ".specfact" / "config.yaml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert resolved.values["clean_code"]["mode"] == "advisory"
+    assert config["profile"] == "solo"
+    assert config["clean_code"]["mode"] == "advisory"
+    assert config["modules"]["enabled"] == ["nold-ai/specfact-codebase", "nold-ai/specfact-code-review"]
+    assert "nold-ai/specfact-govern" not in config["modules"]["enabled"]
+    assert config["source_annotations"]["modules"]["enabled"] == "profile:solo"
+
+
+def test_init_profile_malformed_existing_config_exits_nonzero(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    specfact_dir = tmp_path / ".specfact"
+    specfact_dir.mkdir()
+    (specfact_dir / "config.yaml").write_text("- not-a-mapping\n", encoding="utf-8")
+
+    monkeypatch.setattr(frs.Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setattr("specfact_cli.modules.init.src.commands.install_bundles_for_init", lambda *_a, **_k: None)
+    monkeypatch.setattr("specfact_cli.modules.init.src.commands.is_first_run", lambda **_: True)
+    monkeypatch.setattr(
+        "specfact_cli.modules.init.src.commands.get_discovered_modules_for_state",
+        lambda **_: [{"id": "init", "enabled": True}],
+    )
+    monkeypatch.setattr("specfact_cli.modules.init.src.commands.write_modules_state", lambda _: None)
+    monkeypatch.setattr("specfact_cli.modules.init.src.commands.run_discovery_and_write_cache", lambda _: None)
+
+    with _telemetry_track_context():
+        result = runner.invoke(
+            app,
+            ["--repo", str(tmp_path), "--profile", "solo"],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 1
+    assert "Error:" in result.output
+    assert "Config file must contain a mapping" in result.output
 
 
 def test_init_profile_enterprise_full_stack_calls_installer_with_all_five(


### PR DESCRIPTION
Closes #237.

## Summary

- Add validation tier profiles for `specfact init --profile`: `solo`, `startup`, `mid_size`, and `enterprise`.
- Resolve profile config with deterministic precedence: profile defaults < org baseline < repo overlay < developer-local override.
- Write `.specfact/config.yaml` with `source_annotations`, tier-derived clean-code defaults, module activation defaults, and policy/evidence posture.
- Refresh the older February 2026 OpenSpec change so proposal/design/spec/evidence match the current validation-evidence roadmap.
- Bump CLI version to `0.48.0` and init module manifest to `0.1.38`.

## Validation

- `hatch run pytest tests/unit/modules/init/test_first_run_selection.py -q` — 24 passed
- `hatch run pytest tests/e2e/test_first_run_init.py -q` — 2 passed
- `openspec validate profile-01-config-layering --strict` — passed
- `hatch run format` — passed
- `hatch run type-check` — 0 errors, existing warnings
- `hatch run lint` — passed, 10.00/10
- `hatch run yaml-lint` — passed
- `hatch run contract-test` — passed cached changed-scope result
- `hatch run specfact code review run --scope changed --json --out .specfact/code-review.json` — PASS_WITH_ADVISORY, 0 blocking
- `hatch run bandit-scan` — no medium/high issues
- `SEMGREP_ENABLE_VERSION_CHECK=0 hatch run semgrep-sast --json --output logs/static-analysis/semgrep.json` — 0 findings
- `hatch run semgrep-sast-gate --results logs/static-analysis/semgrep.json --baseline tools/semgrep/sast-baseline.json` — passed
- Pre-commit on signed commit — passed

## Notes

`hatch run smart-test` was inconclusive locally because no incremental baseline was available, so it expanded to the broad 2,783-test suite and hit unrelated existing failures outside the changed scope. Targeted unit/e2e coverage and the required OpenSpec/review/static-analysis gates are recorded in `openspec/changes/profile-01-config-layering/TDD_EVIDENCE.md`.

SpecFact review advisories are legacy clean-code/KISS/YAGNI findings around existing `commands.py` helpers and `init_ide` shape, not new blocking findings introduced by this PR.
