### PR TITLE
Add requirements evidence input model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.49.0] - 2026-07-07
+
+### Added
+
+- **Requirements evidence input model**: add normalized requirement input
+  records, source references, business rules, constraints, completeness
+  findings, evidence links, and ProjectBundle extension payload helpers for
+  validation evidence without making SpecFact the requirement authoring system.
+
+### Fixed
+
+- **Test-suite stability**: make analyzer entry-point path containment robust to
+  macOS path aliases, tolerate Rich-wrapped module init output, and keep
+  explicitly scoped module discovery isolated so the full smart-test suite runs
+  without baseline failures.
+
+---
+
 ## [0.48.2] - 2026-07-06
 
 ### Added

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -171,6 +171,9 @@
     - title: ProjectBundle Schema
       url: /reference/projectbundle-schema/
       expertise: [advanced]
+    - title: Requirements Evidence Input Model
+      url: /reference/requirements-evidence-input-model/
+      expertise: [advanced]
     - title: Dependency Resolution
       url: /reference/dependency-resolution/
       expertise: [advanced]

--- a/docs/index.md
+++ b/docs/index.md
@@ -156,6 +156,7 @@ bundle-specific adapters, and authoring guidance.
 - **[Command Reference](/reference/commands/)** - Full command surface
 - **[Module Categories](/reference/module-categories/)** - Category taxonomy
 - **[Module Contracts](/reference/module-contracts/)** - Contract interfaces
+- **[Requirements Evidence Input Model](/reference/requirements-evidence-input-model/)** - Requirement input records for validation evidence
 - **[Operational Modes](/core-cli/modes/)** - CI/CD and CoPilot modes
 - **[Debug Logging](/core-cli/debug-logging/)** - Diagnostic logging
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -24,6 +24,7 @@ For bundle-specific deep command guides and runbooks, use the canonical modules 
 - **[Module Contracts](module-contracts.md)** - Runtime-facing interfaces and ownership boundary
 - **[Module Security](module-security.md)** - Marketplace/module integrity and publisher metadata
 - **[Bridge Registry](bridge-registry.md)** - Registry-facing bridge converter declarations
+- **[Requirements Evidence Input Model](requirements-evidence-input-model.md)** - Requirement input records used by validation evidence
 - **[Directory Structure](directory-structure.md)** - Project structure and organization
 - **[Feature Keys](feature-keys.md)** - Key normalization and formats
 - **[Dependency Resolution](dependency-resolution.md)** - Module/pip dependency resolution behavior

--- a/docs/reference/requirements-evidence-input-model.md
+++ b/docs/reference/requirements-evidence-input-model.md
@@ -1,0 +1,78 @@
+---
+layout: default
+title: Requirements Evidence Input Model
+permalink: /reference/requirements-evidence-input-model/
+description: Normalized requirement input records used by SpecFact validation evidence.
+keywords: [requirements, validation, evidence, projectbundle, schema-extension]
+audience: [team, enterprise]
+expertise_level: [advanced]
+doc_owner: specfact-cli
+tracks:
+  - src/specfact_cli/models/requirements.py
+  - tests/unit/models/test_requirements.py
+last_reviewed: 2026-07-07
+exempt: false
+exempt_reason: ""
+---
+
+# Requirements Evidence Input Model
+
+SpecFact can store normalized requirement input records for validation evidence.
+These records point back to upstream sources such as issues, documents,
+OpenSpec changes, Spec Kit artifacts, or local files. SpecFact does not become
+the requirement authoring system or product-management source of truth.
+
+## Model Surface
+
+Use `RequirementInput` when an adapter or validation step needs a compact
+requirement record:
+
+- `requirement_id`: stable requirement identifier
+- `schema_version`: requirement input schema version
+- `title`: short requirement title
+- `sources`: one or more upstream source references
+- `business_rules`: optional Given/When/Then rules imported from the source
+- `constraints`: optional performance, security, integration, compliance, UX, or operational constraints
+- `evidence_links`: optional architecture, spec, code, test, validation, or requirement evidence targets
+- `completeness_findings`: advisory profile-aware findings
+
+## ProjectBundle Extension
+
+Requirement inputs are carried through the existing `ProjectBundle.extensions`
+field under `requirements.inputs`. This keeps bundles backward compatible:
+
+```python
+from specfact_cli.models.requirements import (
+    RequirementInput,
+    RequirementSourceReference,
+    requirements_input_extension_payload,
+)
+
+requirement = RequirementInput(
+    requirement_id="REQ-123",
+    schema_version="1",
+    title="Checkout preserves selected currency",
+    sources=[
+        RequirementSourceReference(
+            source_type="issue",
+            locator="https://github.com/example/repo/issues/123",
+        )
+    ],
+)
+
+bundle.set_extension(
+    "requirements",
+    "inputs",
+    requirements_input_extension_payload([requirement]),
+)
+```
+
+## Compatibility Notes
+
+- Missing `schema_version` is invalid for a requirement input record.
+- At least one source reference is required so evidence can explain where the
+  requirement came from.
+- Profile completeness findings are advisory evidence. They can affect
+  validation severity without blocking model construction by themselves.
+- No requirement authoring commands or backlog write-back behavior are provided
+  by this model.

--- a/openspec/changes/requirements-01-data-model/CHANGE_VALIDATION.md
+++ b/openspec/changes/requirements-01-data-model/CHANGE_VALIDATION.md
@@ -1,31 +1,38 @@
-# Change Validation: requirements-01-data-model
+# Change Validation Report: requirements-01-data-model
 
-- **Validated on (UTC):** 2026-02-15T21:54:26Z
-- **Workflow:** /wf-validate-change (proposal-stage dry-run validation)
+- **Validation Date (Europe/Berlin):** 2026-07-07T22:21:00+02:00
+- **Workflow:** OpenSpec validate-change refresh before implementation
 - **Strict command:** `openspec validate requirements-01-data-model --strict`
 - **Result:** PASS
 
 ## Scope Summary
 
-- **New capabilities:** requirements-data-model
+- **New capabilities:** requirements-evidence-input-model
 - **Modified capabilities:** data-models
-- **Declared dependencies:** arch-07 (schema extension system, #213) for ProjectBundle extension
-- **Proposed affected code paths:** - `src/specfact_cli/models/requirements.py` (new);- `src/specfact_cli/models/project.py` (extend via arch-07 schema extensions)
+- **Declared dependencies:** existing ProjectBundle schema extension system
+- **Proposed affected code paths:**
+  - `src/specfact_cli/models/requirements.py` (new)
+  - `src/specfact_cli/models/__init__.py` (exports)
+  - `tests/unit/models/test_requirements.py`
+  - `tests/unit/models/test_schema_extensions.py`
+  - `docs/reference/requirements-evidence-input-model.md`
 
 ## Breaking-Change Analysis (Dry-Run)
 
-- Interface changes are proposal-level only; no production code modifications were performed in this workflow stage.
-- Proposed modified capabilities are additive/extension-oriented in the current spec deltas and do not require immediate breaking migrations at proposal time.
-- Backward-compatibility risk is primarily sequencing-related (dependency ordering), not signature-level breakage at this stage.
+- The change adds new Pydantic model classes and exports.
+- ProjectBundle integration remains optional through the existing `extensions` field and does not add a required schema field.
+- Existing bundles without `requirements.inputs` remain backward compatible.
+- No public command surface is added.
 
 ## Dependency and Integration Review
 
-- Dependency declarations align with the 2026-02-15 architecture layer integration plan sequencing.
-- Cross-change integration points are explicitly represented in proposal/spec/task artifacts.
-- No additional mandatory scope expansion was required to pass strict OpenSpec validation.
+- Scope aligns with `openspec/CHANGE_ORDER.md`: optional normalized requirements-input records for validation evidence.
+- GitHub issue #238 was verified as open with project status `Todo`, not `in progress`, on 2026-07-07.
+- The public issue body and title were updated to match the narrowed validation-evidence format.
+- The internal wiki mirror `wiki/sources/requirements-01-data-model.md` was updated and `wiki_rebuild_graph.py` was run from the internal repo root.
 
 ## Validation Outcome
 
 - Required artifacts are present: `proposal.md`, `design.md`, `specs/**/*.md`, `tasks.md`.
 - Strict OpenSpec validation passed.
-- Change is ready for implementation-phase intake once prerequisites are satisfied.
+- Change is ready for TDD implementation intake.

--- a/openspec/changes/requirements-01-data-model/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-01-data-model/TDD_EVIDENCE.md
@@ -1,0 +1,69 @@
+# TDD Evidence: requirements-01-data-model
+
+## Failing-before
+
+- **Timestamp (Europe/Berlin):** 2026-07-07T22:24:00+02:00
+- **Command:** `hatch run pytest tests/unit/models/test_requirements.py tests/unit/models/test_schema_extensions.py -q`
+- **Result:** FAIL, expected
+- **Summary:** Pytest collected zero tests and failed during collection because
+  `specfact_cli.models.requirements` does not exist yet.
+- **Key error:** `ModuleNotFoundError: No module named 'specfact_cli.models.requirements'`
+
+## Passing-after
+
+- **Timestamp (Europe/Berlin):** 2026-07-07T22:39:00+02:00
+- **Command:** `hatch run pytest tests/unit/models/test_requirements.py tests/unit/models/test_schema_extensions.py -q`
+- **Result:** PASS
+- **Summary:** 20 targeted unit tests passed, covering requirement input
+  serialization, missing `schema_version`, required source references, advisory
+  completeness findings, ProjectBundle extension payload round-tripping, and
+  contract-boundary rejection of invalid extension payloads.
+
+## Quality Gates
+
+- **Timestamp (Europe/Berlin):** 2026-07-07T22:43:00+02:00
+- **Result:** PASS for changed scope and required metadata gates.
+- **Commands:**
+  - `openspec validate requirements-01-data-model --strict`
+  - `hatch run pytest tests/unit/models/test_requirements.py tests/unit/models/test_schema_extensions.py -q`
+  - `hatch run type-check`
+  - `hatch run lint`
+  - `hatch run contract-test`
+  - `hatch run check-version-sources`
+  - `hatch run check-pypi-ahead`
+  - `hatch run verify-modules-signature`
+  - `hatch run semgrep-sast`
+  - `hatch run semgrep-sast-gate --results /tmp/specfact-requirements-01-semgrep.json --baseline tools/semgrep/sast-baseline.json`
+  - `hatch run bandit-scan`
+  - `hatch run smart-test`
+  - `hatch run specfact code review run --json --out /tmp/req01-code-review-final.json --scope changed`
+- **Review summary:** SpecFact code review returned `overall_verdict: PASS`,
+  `ci_exit_code: 0`, `score: 120`, and zero findings after the contract-boundary
+  remediation.
+
+## Full Suite Remediation
+
+- **Timestamp (Europe/Berlin):** 2026-07-07T23:27:13+02:00
+- **Command:** `hatch run smart-test`
+- **Result:** PASS.
+- **Summary:** 2785 tests passed, 11 skipped, and 2 third-party deprecation
+  warnings remained. The earlier 9 baseline failures were fixed by resolving
+  analyzer entry-point paths before repository containment checks, tolerating Rich
+  output wrapping in the module init assertion, and preventing ambient
+  project-scoped modules from leaking into explicitly scoped discovery tests.
+  The analyzer integration and E2E tests intentionally keep raw
+  `TemporaryDirectory()` paths, and
+  `TestCodeAnalyzer::test_resolve_entry_point_accepts_canonical_path_alias`
+  covers symlink/canonical-path aliases without hard-coded `/var` or
+  `/private/var` assumptions.
+- **Log:** `logs/tests/test_run_20260707_232713.log`.
+
+## Final Review Notes
+
+- **Timestamp (Europe/Berlin):** 2026-07-07T23:32:17+02:00
+- **Command:** `SPECFACT_MODULES_ROOTS=/Users/dom/git/nold-ai/specfact-cli-modules/packages hatch run specfact code review run --json --out /tmp/req01-code-review-final3.json --scope changed`
+- **Result:** PASS_WITH_ADVISORY, `ci_exit_code: 0`, `score: 95`.
+- **Summary:** Changed-line enforcement found no blocking findings. The remaining
+  advisories are pre-existing whole-file KISS/AI-bloat findings in
+  `src/specfact_cli/analyzers/code_analyzer.py`; the production path-resolution
+  fix was retained to avoid masking OS-specific path alias failures in tests.

--- a/openspec/changes/requirements-01-data-model/design.md
+++ b/openspec/changes/requirements-01-data-model/design.md
@@ -1,42 +1,45 @@
 ## Context
 
-This change implements proposal scope for `requirements-01-data-model` from the 2026-02-15 architecture-layer integration plan. It is proposal-stage only and defines implementation strategy without changing runtime code.
+This change implements `requirements-01-data-model` as a validation input model. Upstream tools remain the systems of record for requirement intent; SpecFact only stores normalized references and evidence links needed for deterministic validation, drift checks, and downstream adapters.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- Define an implementation approach that stays within the proposal scope.
-- Keep compatibility with existing module registry, adapter bridge, and contract-first patterns.
-- Preserve offline-first behavior and deterministic CLI execution.
+- Define a compact, source-reference-first requirement input model.
+- Keep compatibility with existing ProjectBundle schema extensions.
+- Preserve offline-first behavior and deterministic validation evidence.
+- Avoid taking ownership of product-management or requirement-authoring workflows.
 
 **Non-Goals:**
 
-- No production code implementation in this stage.
-- No schema-breaking changes outside declared capabilities.
-- No dependency expansion beyond the proposal and plan.
+- No interactive requirement authoring commands.
+- No bidirectional backlog sync.
+- No required ProjectBundle schema field.
+- No dependency expansion beyond existing Pydantic, icontract, and beartype runtime dependencies.
 
 ## Decisions
 
-- Use module-oriented integration and registry lazy-loading patterns already used in SpecFact CLI.
-- Keep all public APIs contract-first with `@icontract` and `@beartype`.
-- Make all behavior extensions opt-in or backward-compatible by default.
-- Add/modify OpenSpec deltas first so tests can be derived before implementation.
+- Represent upstream sources explicitly with `RequirementSourceReference` so evidence can point back to issues, docs, OpenSpec changes, Spec Kit artifacts, or local files.
+- Store requirement inputs as ordinary Pydantic models and let import adapters populate them later.
+- Use the existing ProjectBundle `extensions` field with namespace `requirements.inputs`; do not add a first-class required ProjectBundle field.
+- Keep helper APIs contract-first with `@icontract` and `@beartype`.
+- Treat profile-aware completeness as evidence severity data, not a hard authoring workflow.
 
 ## Risks / Trade-offs
 
-- [Dependency ordering drift] -> Mitigation: gate implementation tasks on declared prerequisites.
-- [Capability overlap with adjacent changes] -> Mitigation: keep this change scoped to listed capabilities only.
-- [Documentation drift] -> Mitigation: include explicit docs update tasks in apply phase.
+- [Scope creep into planning workflow] -> Mitigation: docs and specs state that SpecFact consumes requirement context; it does not own authoring.
+- [ProjectBundle compatibility regression] -> Mitigation: use optional extension storage and regression tests for bundles without extensions.
+- [Evidence ambiguity] -> Mitigation: require source references and stable IDs on requirement input records.
 
 ## Migration Plan
 
-1. Implement this change only after listed dependencies are implemented.
+1. Align proposal, tasks, and spec deltas to the validation-evidence framing.
 2. Add tests from spec scenarios and capture failing-first evidence.
-3. Implement minimal production changes needed for passing scenarios.
-4. Run quality gates and then open PR to `dev`.
+3. Implement minimal model and export changes needed for passing scenarios.
+4. Update docs, changelog, and version files.
+5. Run quality gates, code review, and OpenSpec validation before PR.
 
 ## Open Questions
 
-- Dependency summary: Depends on arch-07-schema-extension-system.
-- Whether additional cross-change sequencing constraints should be hard-blocked in `openspec/CHANGE_ORDER.md`.
+- GitHub issue hierarchy metadata for issue #238 does not expose parent/blocker fields through `gh issue view`; the roadmap places it under Requirements Layer / Epic #256 and notes the older arch-07 dependency.

--- a/openspec/changes/requirements-01-data-model/proposal.md
+++ b/openspec/changes/requirements-01-data-model/proposal.md
@@ -66,6 +66,6 @@ validation evidence and drift.
 - **GitHub Issue**: #238
 - **Issue URL**: <https://github.com/nold-ai/specfact-cli/issues/238>
 - **Repository**: nold-ai/specfact-cli
-- **Last Synced Status**: proposed
+- **Last Synced Status**: in_review
 - **Sanitized**: false
 <!-- content_hash: 1dad52a86e44c9f9 -->

--- a/openspec/changes/requirements-01-data-model/proposal.md
+++ b/openspec/changes/requirements-01-data-model/proposal.md
@@ -12,14 +12,12 @@ validation evidence and drift.
 
 - **NEW**: Pydantic models in `src/specfact_cli/models/requirements.py` for
   normalized requirement inputs, business rules, constraints, source references,
-  and validation evidence links.
-- **NEW**: Optional storage convention under `.specfact/requirements/` for
-  imported or normalized records used by validation runs.
+  completeness findings, and validation evidence links.
 - **NEW**: Schema versioning for forward-compatible adapters.
 - **NEW**: Profile-aware completeness checks that affect validation severity, not
   planning workflow ownership.
-- **EXTEND**: `ProjectBundle` receives an optional requirements-input namespace
-  through the existing schema extension system.
+- **EXTEND**: `ProjectBundle` can carry requirement input records through the
+  existing `requirements.inputs` schema-extension namespace.
 
 ## Out of Scope
 
@@ -40,6 +38,26 @@ validation evidence and drift.
 - `data-models`: ProjectBundle extended with an optional requirements-input
   namespace.
 
+## Impact
+
+- **Affected specs**: `requirements-evidence-input-model`, `data-models`
+- **Affected code**:
+  - `src/specfact_cli/models/requirements.py`
+  - `src/specfact_cli/models/__init__.py`
+  - `src/specfact_cli/models/project.py` extension usage remains backward compatible
+- **Affected tests**:
+  - `tests/unit/models/test_requirements.py`
+  - `tests/unit/models/test_schema_extensions.py`
+- **Affected docs**:
+  - `docs/reference/requirements-evidence-input-model.md`
+  - `CHANGELOG.md`
+- **Integration points**: downstream import adapters and validation evidence graph
+  changes consume these records; this change does not introduce backlog write-back
+  or requirement-authoring commands.
+- **Rollback plan**: remove the new requirements model module, exports, docs page,
+  and extension tests; existing ProjectBundle serialization remains compatible
+  because the namespace lives in optional extension data.
+
 ---
 
 ## Source Tracking
@@ -47,6 +65,7 @@ validation evidence and drift.
 <!-- source_repo: nold-ai/specfact-cli -->
 - **GitHub Issue**: #238
 - **Issue URL**: <https://github.com/nold-ai/specfact-cli/issues/238>
+- **Repository**: nold-ai/specfact-cli
 - **Last Synced Status**: proposed
 - **Sanitized**: false
 <!-- content_hash: 1dad52a86e44c9f9 -->

--- a/openspec/changes/requirements-01-data-model/proposal.md
+++ b/openspec/changes/requirements-01-data-model/proposal.md
@@ -49,6 +49,9 @@ validation evidence and drift.
   - `tests/unit/models/test_requirements.py`
   - `tests/unit/models/test_schema_extensions.py`
 - **Affected docs**:
+  - `docs/_data/nav.yml`
+  - `docs/index.md`
+  - `docs/reference/README.md`
   - `docs/reference/requirements-evidence-input-model.md`
   - `CHANGELOG.md`
 - **Integration points**: downstream import adapters and validation evidence graph

--- a/openspec/changes/requirements-01-data-model/specs/data-models/spec.md
+++ b/openspec/changes/requirements-01-data-model/specs/data-models/spec.md
@@ -1,19 +1,19 @@
 ## MODIFIED Requirements
 
-### Requirement: Data Models
+### Requirement: Requirements Input Extension Namespace
 
-The system SHALL extend project models to include requirements payloads with schema versioning.
+The system SHALL support requirement input payloads through the existing ProjectBundle schema extension mechanism.
 
 #### Scenario: Project bundle accepts requirements namespace
 
-- **GIVEN** a project bundle with requirements entries
+- **GIVEN** a project bundle with `requirements.inputs` extension entries
 - **WHEN** model validation runs
-- **THEN** the requirements namespace is accepted
+- **THEN** the requirements namespace is accepted through the existing extensions field
 - **AND** existing non-requirements fields remain backward compatible.
 
 #### Scenario: Schema version is required for requirements artifacts
 
 - **GIVEN** a requirement document without `schema_version`
 - **WHEN** it is loaded
-- **THEN** validation fails
+- **THEN** requirement input validation fails
 - **AND** output indicates the missing version field.

--- a/openspec/changes/requirements-01-data-model/specs/requirements-data-model/spec.md
+++ b/openspec/changes/requirements-01-data-model/specs/requirements-data-model/spec.md
@@ -1,19 +1,26 @@
 ## ADDED Requirements
 
-### Requirement: Requirements Data Model
+### Requirement: Requirements Evidence Input Model
 
-The system SHALL define structured business requirement artifacts stored under `.specfact/requirements/`.
+The system SHALL define normalized requirement input records that preserve upstream source references for validation evidence.
 
-#### Scenario: Requirement artifact captures business intent and constraints
+#### Scenario: Requirement input captures source-backed intent and constraints
 
-- **GIVEN** a requirement file `.specfact/requirements/REQ-123.req.yaml`
-- **WHEN** it is validated
-- **THEN** it includes business outcome, business rules, and architectural constraints
-- **AND** each business rule has a stable rule identifier.
+- **GIVEN** a requirement input record carried in `requirements.inputs`
+- **WHEN** validation evidence reads the record
+- **THEN** it includes a stable requirement identifier, schema version, title, and at least one upstream source reference
+- **AND** it MAY include business rules, constraints, and profile completeness findings.
 
-#### Scenario: Trace references are represented explicitly
+#### Scenario: Evidence links are represented explicitly
 
-- **GIVEN** requirement trace metadata
+- **GIVEN** requirement evidence metadata
 - **WHEN** artifacts are parsed
-- **THEN** architecture, spec, code, and test references are stored as explicit lists
-- **AND** trace references are serializable to JSON evidence output.
+- **THEN** architecture, spec, code, test, and validation references are stored as explicit evidence links
+- **AND** evidence links are serializable to JSON output.
+
+#### Scenario: Profile completeness is advisory evidence
+
+- **GIVEN** a requirement input with profile completeness findings
+- **WHEN** validation evidence is produced
+- **THEN** each finding records the profile, severity, field path, and message
+- **AND** missing optional profile fields do not make the requirement input unusable.

--- a/openspec/changes/requirements-01-data-model/tasks.md
+++ b/openspec/changes/requirements-01-data-model/tasks.md
@@ -32,4 +32,4 @@
 
 - [x] 5.1 Update version files and `CHANGELOG.md` with a minor feature release entry.
 - [x] 5.2 Review `openspec/CHANGE_ORDER.md` status/dependency notes; no implementation sequencing change required.
-- [ ] 5.3 Open a PR from `feature/requirements-01-data-model` to `dev` with spec/test/code/docs evidence.
+- [x] 5.3 Open a PR from `feature/requirements-01-data-model` to `dev` with spec/test/code/docs evidence.

--- a/openspec/changes/requirements-01-data-model/tasks.md
+++ b/openspec/changes/requirements-01-data-model/tasks.md
@@ -2,29 +2,34 @@
 
 ## 1. Branch and dependency guardrails
 
-- [ ] 1.1 Create dedicated worktree branch `feature/requirements-01-data-model` from `dev` before implementation work: `scripts/worktree.sh create feature/requirements-01-data-model`.
-- [ ] 1.2 Verify prerequisite changes are implemented or explicitly accepted as parallel work.
-- [ ] 1.3 Reconfirm scope against the 2026-02-15 architecture integration plan and this proposal.
+- [x] 1.1 Create dedicated worktree branch `feature/requirements-01-data-model` from `dev` before implementation work: `scripts/worktree.sh create feature/requirements-01-data-model`.
+- [x] 1.2 Refresh GitHub hierarchy cache, verify issue #238 is not in progress, and confirm project/label metadata is present.
+- [x] 1.3 Reconfirm scope against `openspec/CHANGE_ORDER.md`: keep this change as optional normalized requirements-input records for validation evidence.
+- [x] 1.4 Update the public GitHub issue body to match the narrowed validation-evidence format.
 
 ## 2. Spec-first and test-first preparation
 
-- [ ] 2.1 Finalize `specs/` deltas for all listed capabilities and cross-check scenario completeness.
-- [ ] 2.2 Add/update tests mapped to new and modified scenarios.
-- [ ] 2.3 Run targeted tests to capture failing-first behavior and record results in `TDD_EVIDENCE.md`.
+- [x] 2.1 Finalize `specs/` deltas for all listed capabilities and cross-check scenario completeness.
+- [x] 2.2 Add/update tests mapped to new and modified scenarios.
+- [x] 2.3 Run targeted tests to capture failing-first behavior and record results in `TDD_EVIDENCE.md`.
 
 ## 3. Implementation
 
-- [ ] 3.1 Implement minimal production code required to satisfy the new scenarios.
-- [ ] 3.2 Add/update contract decorators and type enforcement on public APIs.
-- [ ] 3.3 Update command wiring, adapters, and models required by this change scope only.
+- [x] 3.1 Implement `src/specfact_cli/models/requirements.py` with requirement input, source reference, rule, constraint, completeness finding, and evidence-link models.
+- [x] 3.2 Add/update `@beartype` and `@icontract` enforcement on public helper APIs.
+- [x] 3.3 Export the new models from `specfact_cli.models`.
+- [x] 3.4 Keep ProjectBundle integration limited to existing schema extensions under `requirements.inputs`; do not add requirement-authoring commands.
 
 ## 4. Validation and documentation
 
-- [ ] 4.1 Re-run tests and quality gates until all changed scenarios pass.
-- [ ] 4.2 Update user-facing docs and navigation for changed/added commands and workflows.
-- [ ] 4.3 Run `openspec validate requirements-01-data-model --strict` and resolve all issues.
+- [x] 4.1 Re-run tests and quality gates until all changed scenarios pass.
+- [x] 4.2 Identify affected documentation (`docs/`, `README.md`, `docs/index.md`) and update docs/navigation so requirement evidence inputs are learnable without implying SpecFact owns requirements.
+- [x] 4.3 Run module-signature verification; if signed module assets changed, bump module versions and re-sign before PR.
+- [x] 4.4 Run `openspec validate requirements-01-data-model --strict` and resolve all issues.
+- [x] 4.5 Run SpecFact code review JSON, independent static analysis, and clean-code gates; resolve all findings.
 
 ## 5. Delivery
 
-- [ ] 5.1 Update `openspec/CHANGE_ORDER.md` status/dependency notes if implementation sequencing changed.
-- [ ] 5.2 Open a PR from `feature/requirements-01-data-model` to `dev` with spec/test/code/docs evidence.
+- [x] 5.1 Update version files and `CHANGELOG.md` with a minor feature release entry.
+- [x] 5.2 Review `openspec/CHANGE_ORDER.md` status/dependency notes; no implementation sequencing change required.
+- [ ] 5.3 Open a PR from `feature/requirements-01-data-model` to `dev` with spec/test/code/docs evidence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "specfact-cli"
-version = "0.48.2"
+version = "0.49.0"
 description = "AI-bloat defense CLI for Python teams. Run deterministic code review, cleanup forecasts, and spec/contract evidence for AI-assisted and brownfield delivery."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 if __name__ == "__main__":
     _setup = setup(
         name="specfact-cli",
-        version="0.48.2",
+        version="0.49.0",
         description=(
             "AI-bloat defense CLI for Python teams. Run deterministic code review, cleanup forecasts, "
             "and spec/contract evidence for AI-assisted and brownfield delivery."

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,4 +3,4 @@ SpecFact CLI - AI-bloat defense CLI for Python teams.
 """
 
 # Package version: keep in sync with pyproject.toml, setup.py, src/specfact_cli/__init__.py
-__version__ = "0.48.2"
+__version__ = "0.49.0"

--- a/src/specfact_cli/__init__.py
+++ b/src/specfact_cli/__init__.py
@@ -76,6 +76,6 @@ def _install_progressive_disclosure() -> None:
 # keeps missing-command and missing-parameter UX consistent outside the root CLI too.
 _install_progressive_disclosure()
 
-__version__ = "0.48.2"
+__version__ = "0.49.0"
 
 __all__ = ["__version__"]

--- a/src/specfact_cli/analyzers/code_analyzer.py
+++ b/src/specfact_cli/analyzers/code_analyzer.py
@@ -128,10 +128,11 @@ class CodeAnalyzer:
     def _resolve_analyzer_entry_point(repo_path: Path, entry_point: Path | None) -> Path | None:
         if entry_point is None:
             return None
-        resolved = entry_point if entry_point.is_absolute() else (repo_path / entry_point).resolve()
+        resolved_repo_path = repo_path.resolve()
+        resolved = entry_point.resolve() if entry_point.is_absolute() else (resolved_repo_path / entry_point).resolve()
         if not resolved.exists():
             raise ValueError(f"Entry point does not exist: {resolved}")
-        if not str(resolved).startswith(str(repo_path)):
+        if not resolved.is_relative_to(resolved_repo_path):
             raise ValueError(f"Entry point must be within repository: {resolved}")
         return resolved
 

--- a/src/specfact_cli/models/__init__.py
+++ b/src/specfact_cli/models/__init__.py
@@ -37,6 +37,22 @@ from specfact_cli.models.project import (
     SectionLock,
 )
 from specfact_cli.models.protocol import Protocol, Transition
+from specfact_cli.models.requirements import (
+    REQUIREMENTS_INPUT_SCHEMA_VERSION,
+    BusinessRule,
+    RequirementCompletenessFinding,
+    RequirementCompletenessSeverity,
+    RequirementConstraint,
+    RequirementConstraintType,
+    RequirementEvidenceLink,
+    RequirementEvidenceLinkType,
+    RequirementInput,
+    RequirementsInputExtensionPayload,
+    RequirementSourceReference,
+    RequirementSourceType,
+    load_requirements_input_extension,
+    requirements_input_extension_payload,
+)
 from specfact_cli.models.sdd import (
     SDDCoverageThresholds,
     SDDEnforcementBudget,
@@ -49,6 +65,7 @@ from specfact_cli.models.source_tracking import SourceTracking
 
 
 __all__ = [
+    "REQUIREMENTS_INPUT_SCHEMA_VERSION",
     "AdapterType",
     "ArtifactMapping",
     "BridgeConfig",
@@ -57,6 +74,7 @@ __all__ = [
     "BundleManifest",
     "BundleVersions",
     "Business",
+    "BusinessRule",
     "ChangeArchive",
     "ChangeProposal",
     "ChangeTracking",
@@ -84,6 +102,16 @@ __all__ = [
     "Protocol",
     "ProtocolIndex",
     "Release",
+    "RequirementCompletenessFinding",
+    "RequirementCompletenessSeverity",
+    "RequirementConstraint",
+    "RequirementConstraintType",
+    "RequirementEvidenceLink",
+    "RequirementEvidenceLinkType",
+    "RequirementInput",
+    "RequirementSourceReference",
+    "RequirementSourceType",
+    "RequirementsInputExtensionPayload",
     "SDDCoverageThresholds",
     "SDDEnforcementBudget",
     "SDDHow",
@@ -100,4 +128,6 @@ __all__ = [
     "TemplateSection",
     "Transition",
     "ValidationReport",
+    "load_requirements_input_extension",
+    "requirements_input_extension_payload",
 ]

--- a/src/specfact_cli/models/requirements.py
+++ b/src/specfact_cli/models/requirements.py
@@ -1,0 +1,187 @@
+"""Requirement evidence input models.
+
+These models normalize upstream requirement context for validation evidence.
+They do not make SpecFact the authoring system or source of truth for
+requirements.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any, cast
+
+from beartype import beartype
+from icontract import ensure, require
+from pydantic import BaseModel, ConfigDict, Field
+
+
+REQUIREMENTS_INPUT_SCHEMA_VERSION = "1"
+
+
+class RequirementSourceType(StrEnum):
+    """Supported upstream source reference types."""
+
+    ISSUE = "issue"
+    DOCUMENT = "document"
+    OPENSPEC_CHANGE = "openspec_change"
+    SPECKIT_SPEC = "speckit_spec"
+    FILE = "file"
+    BACKLOG_ITEM = "backlog_item"
+
+
+class RequirementEvidenceLinkType(StrEnum):
+    """Kinds of downstream evidence linked from a requirement input."""
+
+    ARCHITECTURE = "architecture"
+    SPEC = "spec"
+    CODE = "code"
+    TEST = "test"
+    VALIDATION = "validation"
+    REQUIREMENT = "requirement"
+
+
+class RequirementConstraintType(StrEnum):
+    """Supported requirement constraint categories."""
+
+    PERFORMANCE = "performance"
+    SECURITY = "security"
+    INTEGRATION = "integration"
+    COMPLIANCE = "compliance"
+    UX = "ux"
+    OPERATIONAL = "operational"
+
+
+class RequirementCompletenessSeverity(StrEnum):
+    """Advisory completeness finding severity."""
+
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+@beartype
+class RequirementSourceReference(BaseModel):
+    """Reference to an upstream requirement source."""
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    source_type: RequirementSourceType = Field(..., description="Type of upstream requirement source")
+    locator: str = Field(..., min_length=1, description="Source locator such as URL, file path, or change ID")
+    title: str | None = Field(default=None, description="Human-readable source title")
+    revision: str | None = Field(default=None, description="Optional source revision, commit, or version")
+
+
+@beartype
+class BusinessRule(BaseModel):
+    """Business rule imported from upstream requirement context."""
+
+    rule_id: str = Field(..., min_length=1, description="Stable business rule identifier")
+    name: str = Field(..., min_length=1, description="Rule name")
+    given: str = Field(..., min_length=1, description="Given clause for validation scenario context")
+    when: str = Field(..., min_length=1, description="When clause for validation scenario context")
+    then: str = Field(..., min_length=1, description="Then clause for validation scenario context")
+    priority: str | None = Field(default=None, description="Optional upstream priority such as MoSCoW")
+
+
+@beartype
+class RequirementConstraint(BaseModel):
+    """Constraint imported from upstream requirement context."""
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    constraint_id: str = Field(..., min_length=1, description="Stable constraint identifier")
+    constraint_type: RequirementConstraintType = Field(..., description="Constraint category")
+    statement: str = Field(..., min_length=1, description="Constraint statement")
+    validation_criteria: list[str] = Field(default_factory=list, description="Criteria used to validate constraint")
+
+
+@beartype
+class RequirementEvidenceLink(BaseModel):
+    """Link from requirement input to downstream validation evidence."""
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    link_type: RequirementEvidenceLinkType = Field(..., description="Evidence target category")
+    target: str = Field(..., min_length=1, description="Evidence target locator")
+    relation: str = Field(default="references", min_length=1, description="Relationship to the target")
+
+
+@beartype
+class RequirementCompletenessFinding(BaseModel):
+    """Profile-aware completeness finding stored as advisory evidence."""
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    profile: str = Field(..., min_length=1, description="Profile that produced this finding")
+    severity: RequirementCompletenessSeverity = Field(..., description="Finding severity")
+    field_path: str = Field(..., min_length=1, description="Requirement field path")
+    message: str = Field(..., min_length=1, description="Human-readable completeness guidance")
+
+
+@beartype
+class RequirementInput(BaseModel):
+    """Normalized requirement context consumed by validation evidence."""
+
+    schema_version: str = Field(..., min_length=1, description="Requirement input schema version")
+    requirement_id: str = Field(..., min_length=1, description="Stable requirement identifier")
+    title: str = Field(..., min_length=1, description="Requirement title")
+    summary: str | None = Field(default=None, description="Optional upstream requirement summary")
+    sources: list[RequirementSourceReference] = Field(
+        ...,
+        min_length=1,
+        description="Upstream requirement source references",
+    )
+    business_rules: list[BusinessRule] = Field(default_factory=list, description="Imported business rules")
+    constraints: list[RequirementConstraint] = Field(default_factory=list, description="Imported constraints")
+    evidence_links: list[RequirementEvidenceLink] = Field(default_factory=list, description="Evidence target links")
+    completeness_findings: list[RequirementCompletenessFinding] = Field(
+        default_factory=list,
+        description="Profile-aware advisory completeness findings",
+    )
+
+
+@beartype
+class RequirementsInputExtensionPayload(BaseModel):
+    """Serializable ProjectBundle extension payload for requirement inputs."""
+
+    schema_version: str = Field(
+        default=REQUIREMENTS_INPUT_SCHEMA_VERSION,
+        min_length=1,
+        description="Requirements extension payload schema version",
+    )
+    requirements: list[RequirementInput] = Field(default_factory=list, description="Requirement input records")
+
+
+def _payload_has_schema_version(result: dict[str, Any]) -> bool:
+    return result.get("schema_version") == REQUIREMENTS_INPUT_SCHEMA_VERSION
+
+
+def _payload_has_requirements_list(result: dict[str, Any]) -> bool:
+    return isinstance(result.get("requirements"), list)
+
+
+def _payload_is_valid_extension(payload: dict[str, Any]) -> bool:
+    try:
+        RequirementsInputExtensionPayload.model_validate(payload)
+    except ValueError:
+        return False
+    return True
+
+
+@beartype
+@require(lambda records: all(isinstance(record, RequirementInput) for record in records))
+@ensure(_payload_has_schema_version)
+@ensure(_payload_has_requirements_list)
+def requirements_input_extension_payload(records: list[RequirementInput]) -> dict[str, Any]:
+    """Return a JSON-serializable ProjectBundle extension payload."""
+    payload = RequirementsInputExtensionPayload(requirements=records)
+    return cast(dict[str, Any], payload.model_dump(mode="json"))
+
+
+@beartype
+@require(lambda payload: isinstance(payload, dict))
+@require(_payload_is_valid_extension)
+@ensure(lambda result: all(isinstance(record, RequirementInput) for record in result))
+def load_requirements_input_extension(payload: dict[str, Any]) -> list[RequirementInput]:
+    """Load requirement input records from a ProjectBundle extension payload."""
+    return RequirementsInputExtensionPayload.model_validate(payload).requirements

--- a/src/specfact_cli/models/requirements.py
+++ b/src/specfact_cli/models/requirements.py
@@ -8,7 +8,7 @@ requirements.
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from beartype import beartype
 from icontract import ensure, require
@@ -122,7 +122,7 @@ class RequirementCompletenessFinding(BaseModel):
 class RequirementInput(BaseModel):
     """Normalized requirement context consumed by validation evidence."""
 
-    schema_version: str = Field(..., min_length=1, description="Requirement input schema version")
+    schema_version: Literal["1"] = Field(..., description="Requirement input schema version")
     requirement_id: str = Field(..., min_length=1, description="Stable requirement identifier")
     title: str = Field(..., min_length=1, description="Requirement title")
     summary: str | None = Field(default=None, description="Optional upstream requirement summary")
@@ -144,9 +144,8 @@ class RequirementInput(BaseModel):
 class RequirementsInputExtensionPayload(BaseModel):
     """Serializable ProjectBundle extension payload for requirement inputs."""
 
-    schema_version: str = Field(
+    schema_version: Literal["1"] = Field(
         default=REQUIREMENTS_INPUT_SCHEMA_VERSION,
-        min_length=1,
         description="Requirements extension payload schema version",
     )
     requirements: list[RequirementInput] = Field(default_factory=list, description="Requirement input records")

--- a/src/specfact_cli/registry/module_discovery.py
+++ b/src/specfact_cli/registry/module_discovery.py
@@ -91,6 +91,16 @@ def _append_explicit_module_roots(roots: list[tuple[str, Path]]) -> None:
         roots.append(("custom", path))
 
 
+def _should_include_workspace_project_root(options: _DiscoveryRootOptions, legacy: bool) -> bool:
+    only_user_root_is_explicit = (
+        options.user_root is not None
+        and options.builtin_root is None
+        and options.marketplace_root is None
+        and options.custom_root is None
+    )
+    return options.project_base_path is not None or legacy or only_user_root_is_explicit
+
+
 def _discovery_root_list(options: _DiscoveryRootOptions) -> list[tuple[str, Path]]:
     from specfact_cli.registry.module_packages import get_modules_root, get_workspace_modules_root
 
@@ -98,7 +108,7 @@ def _discovery_root_list(options: _DiscoveryRootOptions) -> list[tuple[str, Path
     effective_builtin_root = options.builtin_root or get_modules_root()
     effective_project_root = (
         get_workspace_modules_root(options.project_base_path)
-        if options.project_base_path is not None or legacy
+        if _should_include_workspace_project_root(options, legacy)
         else None
     )
     effective_user_root = options.user_root or USER_MODULES_ROOT

--- a/src/specfact_cli/registry/module_discovery.py
+++ b/src/specfact_cli/registry/module_discovery.py
@@ -94,8 +94,13 @@ def _append_explicit_module_roots(roots: list[tuple[str, Path]]) -> None:
 def _discovery_root_list(options: _DiscoveryRootOptions) -> list[tuple[str, Path]]:
     from specfact_cli.registry.module_packages import get_modules_root, get_workspace_modules_root
 
+    legacy = _resolve_include_legacy_roots(options)
     effective_builtin_root = options.builtin_root or get_modules_root()
-    effective_project_root = get_workspace_modules_root(options.project_base_path)
+    effective_project_root = (
+        get_workspace_modules_root(options.project_base_path)
+        if options.project_base_path is not None or legacy
+        else None
+    )
     effective_user_root = options.user_root or USER_MODULES_ROOT
     effective_marketplace_root = options.marketplace_root or MARKETPLACE_MODULES_ROOT
     effective_custom_root = options.custom_root or CUSTOM_MODULES_ROOT
@@ -119,7 +124,6 @@ def _discovery_root_list(options: _DiscoveryRootOptions) -> list[tuple[str, Path
         ]
     )
 
-    legacy = _resolve_include_legacy_roots(options)
     if legacy:
         _append_legacy_module_roots(roots)
     return roots

--- a/tests/unit/analyzers/test_code_analyzer.py
+++ b/tests/unit/analyzers/test_code_analyzer.py
@@ -78,6 +78,22 @@ class TestCodeAnalyzer:
         with patch("shutil.which", return_value="/usr/bin/semgrep"), patch("subprocess.run", side_effect=_fake_run):
             assert analyzer._run_semgrep_patterns(source_file) == []
 
+    def test_resolve_entry_point_accepts_canonical_path_alias(self, tmp_path: Path) -> None:
+        """Absolute entry points should be compared after canonical resolution."""
+        repo_path = tmp_path / "repo"
+        entry_path = repo_path / "src"
+        entry_path.mkdir(parents=True)
+        alias_path = tmp_path / "repo-link"
+
+        try:
+            alias_path.symlink_to(repo_path, target_is_directory=True)
+        except OSError as exc:
+            pytest.skip(f"directory symlinks are unavailable: {exc}")
+
+        resolved = CodeAnalyzer._resolve_analyzer_entry_point(repo_path.resolve(), alias_path / "src")
+
+        assert resolved == entry_path.resolve()
+
     def test_should_skip_test_files(self):
         """Test that test files are skipped."""
         analyzer = CodeAnalyzer(Path("."))

--- a/tests/unit/models/test_requirements.py
+++ b/tests/unit/models/test_requirements.py
@@ -1,0 +1,139 @@
+"""Tests for requirement evidence input models."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from icontract import ViolationError
+from pydantic import ValidationError
+
+from specfact_cli.models.requirements import (
+    BusinessRule,
+    RequirementCompletenessFinding,
+    RequirementCompletenessSeverity,
+    RequirementConstraint,
+    RequirementConstraintType,
+    RequirementEvidenceLink,
+    RequirementEvidenceLinkType,
+    RequirementInput,
+    RequirementSourceReference,
+    RequirementSourceType,
+    load_requirements_input_extension,
+    requirements_input_extension_payload,
+)
+
+
+def test_requirement_input_serializes_source_backed_evidence() -> None:
+    """Requirement inputs preserve source references and evidence links."""
+    requirement = RequirementInput(
+        requirement_id="REQ-123",
+        schema_version="1",
+        title="Checkout preserves selected currency",
+        sources=[
+            RequirementSourceReference(
+                source_type=RequirementSourceType.ISSUE,
+                locator="https://github.com/nold-ai/specfact-cli/issues/238",
+                title="Requirements Evidence Input Model",
+            )
+        ],
+        business_rules=[
+            BusinessRule(
+                rule_id="RULE-1",
+                name="Currency stays stable",
+                given="a shopper selected EUR",
+                when="checkout validation runs",
+                then="the evidence references EUR as the expected currency",
+                priority="must",
+            )
+        ],
+        constraints=[
+            RequirementConstraint(
+                constraint_id="CON-1",
+                constraint_type=RequirementConstraintType.COMPLIANCE,
+                statement="Currency evidence must be auditable",
+                validation_criteria=["evidence link exists"],
+            )
+        ],
+        evidence_links=[
+            RequirementEvidenceLink(
+                link_type=RequirementEvidenceLinkType.TEST,
+                target="tests/unit/models/test_requirements.py::test_requirement_input_serializes_source_backed_evidence",
+                relation="validated-by",
+            )
+        ],
+    )
+
+    dumped = json.loads(requirement.model_dump_json())
+
+    assert dumped["requirement_id"] == "REQ-123"
+    assert dumped["sources"][0]["source_type"] == "issue"
+    assert dumped["business_rules"][0]["rule_id"] == "RULE-1"
+    assert dumped["constraints"][0]["constraint_type"] == "compliance"
+    assert dumped["evidence_links"][0]["link_type"] == "test"
+
+
+def test_requirement_input_requires_schema_version() -> None:
+    """Requirement input validation rejects artifacts without schema_version."""
+    with pytest.raises(ValidationError, match="schema_version"):
+        RequirementInput.model_validate(
+            {
+                "requirement_id": "REQ-123",
+                "title": "Missing schema version",
+                "sources": [{"source_type": "issue", "locator": "https://example.test/issue/123"}],
+            }
+        )
+
+
+def test_requirement_input_requires_at_least_one_source_reference() -> None:
+    """Requirement inputs must preserve at least one upstream source reference."""
+    with pytest.raises(ValidationError, match="sources"):
+        RequirementInput(requirement_id="REQ-123", schema_version="1", title="No source", sources=[])
+
+
+def test_profile_completeness_findings_are_advisory_evidence() -> None:
+    """Profile findings are stored as evidence without blocking model creation."""
+    requirement = RequirementInput(
+        requirement_id="REQ-124",
+        schema_version="1",
+        title="Enterprise profile advisory",
+        sources=[RequirementSourceReference(source_type=RequirementSourceType.DOCUMENT, locator="docs/product.md")],
+        completeness_findings=[
+            RequirementCompletenessFinding(
+                profile="enterprise",
+                severity=RequirementCompletenessSeverity.WARNING,
+                field_path="regulatory_references",
+                message="Enterprise profile should include regulatory references.",
+            )
+        ],
+    )
+
+    assert requirement.completeness_findings[0].profile == "enterprise"
+    assert requirement.completeness_findings[0].severity == "warning"
+
+
+def test_requirements_extension_payload_round_trips_records() -> None:
+    """ProjectBundle extensions can carry requirement inputs as serializable payloads."""
+    requirement = RequirementInput(
+        requirement_id="REQ-125",
+        schema_version="1",
+        title="Extension payload",
+        sources=[
+            RequirementSourceReference(
+                source_type=RequirementSourceType.OPENSPEC_CHANGE, locator="requirements-01-data-model"
+            )
+        ],
+    )
+
+    payload = requirements_input_extension_payload([requirement])
+    loaded = load_requirements_input_extension(payload)
+
+    assert payload["schema_version"] == "1"
+    assert payload["requirements"][0]["requirement_id"] == "REQ-125"
+    assert loaded == [requirement]
+
+
+def test_requirements_extension_loader_rejects_invalid_payload_at_contract_boundary() -> None:
+    """Invalid extension payloads fail before Pydantic validation internals."""
+    with pytest.raises(ViolationError):
+        load_requirements_input_extension({"schema_version": "1", "requirements": [{"requirement_id": "REQ-126"}]})

--- a/tests/unit/models/test_requirements.py
+++ b/tests/unit/models/test_requirements.py
@@ -85,6 +85,19 @@ def test_requirement_input_requires_schema_version() -> None:
         )
 
 
+def test_requirement_input_rejects_unknown_schema_version() -> None:
+    """Requirement input validation rejects unsupported per-record schema versions."""
+    with pytest.raises(ValidationError, match="schema_version"):
+        RequirementInput.model_validate(
+            {
+                "requirement_id": "REQ-123",
+                "schema_version": "999",
+                "title": "Unsupported schema version",
+                "sources": [{"source_type": "issue", "locator": "https://example.test/1"}],
+            }
+        )
+
+
 def test_requirement_input_requires_at_least_one_source_reference() -> None:
     """Requirement inputs must preserve at least one upstream source reference."""
     with pytest.raises(ValidationError, match="sources"):
@@ -137,3 +150,9 @@ def test_requirements_extension_loader_rejects_invalid_payload_at_contract_bound
     """Invalid extension payloads fail before Pydantic validation internals."""
     with pytest.raises(ViolationError):
         load_requirements_input_extension({"schema_version": "1", "requirements": [{"requirement_id": "REQ-126"}]})
+
+
+def test_requirements_extension_loader_rejects_unknown_payload_schema_version() -> None:
+    """Invalid extension schema versions fail at the loader contract boundary."""
+    with pytest.raises(ViolationError):
+        load_requirements_input_extension({"schema_version": "999", "requirements": []})

--- a/tests/unit/models/test_schema_extensions.py
+++ b/tests/unit/models/test_schema_extensions.py
@@ -13,6 +13,12 @@ import yaml
 
 from specfact_cli.models.plan import Feature, Product
 from specfact_cli.models.project import ProjectBundle
+from specfact_cli.models.requirements import (
+    RequirementInput,
+    RequirementSourceReference,
+    RequirementSourceType,
+    requirements_input_extension_payload,
+)
 
 
 class TestFeatureExtensions:
@@ -111,6 +117,26 @@ class TestProjectBundleExtensions:
         bundle.set_extension("sync", "last_sync_timestamp", "2025-01-15T12:00:00Z")
         assert bundle.get_extension("sync", "last_sync_timestamp") == "2025-01-15T12:00:00Z"
         assert bundle.get_extension("sync", "missing", default="def") == "def"
+
+    def test_project_bundle_accepts_requirements_inputs_namespace(self) -> None:
+        """requirements.inputs SHALL remain optional schema-extension data."""
+        bundle = self._minimal_bundle()
+        requirement = RequirementInput(
+            requirement_id="REQ-123",
+            schema_version="1",
+            title="Evidence input",
+            sources=[
+                RequirementSourceReference(
+                    source_type=RequirementSourceType.OPENSPEC_CHANGE,
+                    locator="requirements-01-data-model",
+                )
+            ],
+        )
+
+        bundle.set_extension("requirements", "inputs", requirements_input_extension_payload([requirement]))
+
+        payload = bundle.get_extension("requirements", "inputs")
+        assert payload["requirements"][0]["requirement_id"] == "REQ-123"
 
 
 class TestBackwardCompatibility:

--- a/tests/unit/modules/module_registry/test_commands.py
+++ b/tests/unit/modules/module_registry/test_commands.py
@@ -1477,7 +1477,7 @@ def test_module_init_project_scope_defaults_to_cwd_repo(monkeypatch, tmp_path: P
     assert result.exit_code == 0
     assert captured["target_root"] == tmp_path / ".specfact" / "modules"
     assert "Seeded 1 module(s) into" in result.stdout
-    assert str(tmp_path / ".specfact" / "modules") in result.stdout
+    assert str(tmp_path / ".specfact" / "modules") in result.stdout.replace("\n", "")
 
 
 def test_module_init_project_scope_supports_explicit_repo(monkeypatch, tmp_path: Path) -> None:

--- a/tests/unit/registry/test_module_discovery.py
+++ b/tests/unit/registry/test_module_discovery.py
@@ -175,6 +175,31 @@ def test_project_shadow_warning_is_actionable_and_emitted_once(tmp_path: Path, m
     assert "specfact module uninstall backlog-core --scope user" in warnings[0]
 
 
+def test_discover_all_modules_with_explicit_user_root_preserves_project_scope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """First-run discovery passes user_root explicitly but still needs project modules."""
+    repo_root = tmp_path / "repo"
+    project_root = repo_root / ".specfact" / "modules"
+    builtin_root = tmp_path / "builtin"
+    user_root = tmp_path / "user-modules"
+    _write_manifest(builtin_root, "init")
+    _write_manifest(project_root, "project-only")
+
+    monkeypatch.chdir(repo_root)
+    monkeypatch.setattr(module_discovery, "MARKETPLACE_MODULES_ROOT", tmp_path / "missing-marketplace")
+    monkeypatch.setattr(module_discovery, "CUSTOM_MODULES_ROOT", tmp_path / "missing-custom")
+    monkeypatch.setattr(
+        "specfact_cli.registry.module_packages.get_modules_root",
+        lambda: builtin_root,
+    )
+
+    discovered = discover_all_modules(user_root=user_root)
+
+    sources = {entry.metadata.name: entry.source for entry in discovered}
+    assert sources == {"init": "builtin", "project-only": "project"}
+
+
 def test_discover_all_modules_for_project_ignores_cwd_legacy_roots_by_default(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/validators/test_repro_checker.py
+++ b/tests/unit/validators/test_repro_checker.py
@@ -482,8 +482,8 @@ class TestReproChecker:
             ):
                 report = checker.run_all_checks()
 
-        assert report.active_plan_path == str(outside_plan)
-        assert report.enforcement_config_path == str(outside_enforce)
+        assert report.active_plan_path == str(outside_plan.resolve())
+        assert report.enforcement_config_path == str(outside_enforce.resolve())
         console_calls = "\n".join(str(call) for call in console_mock.print.call_args_list)
         assert "Could not collect metadata" not in console_calls
 


### PR DESCRIPTION
## Description

Adds a normalized requirements evidence input model for validation and drift
evidence. The change keeps SpecFact out of the requirement-authoring role:
Spec Kit, OpenSpec, backlog systems, docs, and issue trackers remain the source
of planning intent, while SpecFact stores local evidence records.

## Type of Change

- [x] Feature
- [x] Bug fix / test-suite stability
- [x] Documentation
- [x] OpenSpec change

## Summary

- Add Pydantic models for requirement inputs, source references, business rules,
  constraints, completeness findings, evidence links, and ProjectBundle
  extension payload helpers.
- Update OpenSpec change `requirements-01-data-model`, reference docs, docs
  navigation, changelog, and version sources for `0.49.0`.
- Fix the 9 local full-suite failures by moving macOS path-alias handling into
  production analyzer entry-point resolution, making module init output
  assertions Rich-wrap tolerant, and keeping explicit module discovery isolated
  from unrelated ambient project roots.
- Address review feedback by preserving project-scoped discovery when
  first-run checks pass an explicit `user_root`, enforcing known requirement
  schema versions, and listing all touched docs surfaces in OpenSpec Impact.

## Contract-First Testing Evidence

- Added failing-first model/schema tests before implementing
  `specfact_cli.models.requirements`.
- Added regression coverage for canonical analyzer path aliases and
  first-run-style module discovery with explicit `user_root`.
- Contract-test passed after review fixes, including runtime contracts,
  CrossHair exploration, and 21 scenario tests.

## How Has This Been Tested?

- `hatch run pytest tests/unit/models/test_requirements.py tests/unit/models/test_schema_extensions.py -q` -> 20 passed
- Focused review-fix regression set -> 25 passed
- `hatch run smart-test` -> 2789 tests passed; latest log: `logs/tests/test_run_20260707_235435.log`
- `hatch run lint` -> passed
- `hatch run type-check` -> 0 errors, existing warning baseline
- `hatch run contract-test` -> passed
- `openspec validate requirements-01-data-model --strict` -> passed
- `hatch run check-version-sources` -> passed
- `git diff --check` -> passed
- SpecFact code review after review fixes -> `PASS`, exit 0, score 120, no findings

## Test Environment

- Local macOS/Darwin worktree:
  `/Users/dom/git/nold-ai/specfact-cli-worktrees/feature/requirements-01-data-model`
- Python 3.12.13 via Hatch
- Target branch: `dev`

## Checklist

- [x] OpenSpec proposal/design/spec/tasks updated
- [x] Docs and navigation updated
- [x] Version sources bumped consistently
- [x] Changelog updated
- [x] Issue #238 synced with final scope and validation evidence
- [x] Code review comments addressed
- [x] Quality gates run

## Quality Gates

- [x] OpenSpec strict validation
- [x] Focused unit/regression tests
- [x] Full smart-test suite
- [x] Lint
- [x] Type check
- [x] Contract-test
- [x] Version-source check
- [x] SpecFact code review

Closes #238