### PR TITLE
docs: align use-case claims with validation-evidence positioning

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -11,7 +11,9 @@ expertise_level: [beginner]
 
 This guide will help you get started with SpecFact CLI in under 60 seconds — first with **no install** (uvx), then with a **persistent** install (pip) when you want IDE workflows and a stable `specfact` command.
 
-> **Primary use case**: validation evidence and AI-bloat defense for AI-assisted and brownfield Python delivery — deterministic review, drift detection, and spec/contract evidence before code reaches PR. See the [5-Minute Quickstart](quickstart.md) for a full walkthrough.
+> **Primary use case**: validation evidence and AI-bloat defense for AI-assisted and brownfield Python delivery —
+> deterministic review, drift detection, and spec/contract evidence before code reaches PR.
+> See the [5-Minute Quickstart](quickstart.md) for a full walkthrough.
 
 ## Try it now — no install required
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -11,7 +11,7 @@ expertise_level: [beginner]
 
 This guide will help you get started with SpecFact CLI in under 60 seconds — first with **no install** (uvx), then with a **persistent** install (pip) when you want IDE workflows and a stable `specfact` command.
 
-> **Primary use case**: brownfield code modernization — reverse-engineering existing codebases into documented specs with runtime contract enforcement. See the [5-Minute Quickstart](quickstart.md) for a full walkthrough.
+> **Primary use case**: validation evidence and AI-bloat defense for AI-assisted and brownfield Python delivery — deterministic review, drift detection, and spec/contract evidence before code reaches PR. See the [5-Minute Quickstart](quickstart.md) for a full walkthrough.
 
 ## Try it now — no install required
 

--- a/docs/getting-started/tutorial-openspec-speckit.md
+++ b/docs/getting-started/tutorial-openspec-speckit.md
@@ -7,7 +7,7 @@ permalink: /getting-started/tutorial-openspec-speckit/
 # Tutorial: Using SpecFact with OpenSpec or Spec-Kit
 
 > **Complete step-by-step guide for new users**  
-> Learn how to use SpecFact CLI with OpenSpec or Spec-Kit for brownfield code modernization
+> Learn how to use SpecFact CLI with OpenSpec or Spec-Kit to validate existing codebases and keep specs, contracts, and code in sync
 
 **Time**: 15-30 minutes | **Prerequisites**: Python 3.11+, basic command-line knowledge
 

--- a/docs/guides/integrations-overview.md
+++ b/docs/guides/integrations-overview.md
@@ -50,7 +50,8 @@ SpecFact CLI integrations fall into four main categories:
 - Learning and exploration of state machines and contracts
 - Single-developer projects and rapid prototyping
 
-**Key difference**: Spec-Kit focuses on **new feature authoring**, while SpecFact CLI focuses on **validating existing code and defending it against AI-bloat and drift**.
+**Key difference**: Spec-Kit focuses on **new feature authoring**, while SpecFact CLI focuses on
+**validating existing code and defending it against AI-bloat and drift**.
 
 **See also**: [Spec-Kit Journey Guide](./speckit-journey.md)
 

--- a/docs/guides/integrations-overview.md
+++ b/docs/guides/integrations-overview.md
@@ -50,7 +50,7 @@ SpecFact CLI integrations fall into four main categories:
 - Learning and exploration of state machines and contracts
 - Single-developer projects and rapid prototyping
 
-**Key difference**: Spec-Kit focuses on **new feature authoring**, while SpecFact CLI focuses on **brownfield code modernization**.
+**Key difference**: Spec-Kit focuses on **new feature authoring**, while SpecFact CLI focuses on **validating existing code and defending it against AI-bloat and drift**.
 
 **See also**: [Spec-Kit Journey Guide](./speckit-journey.md)
 

--- a/docs/guides/speckit-journey.md
+++ b/docs/guides/speckit-journey.md
@@ -7,7 +7,7 @@ permalink: /guides/speckit-journey/
 # The Journey: From Spec-Kit to SpecFact
 
 > **Spec-Kit and SpecFact are complementary, not competitive.**  
-> **Primary Use Case**: SpecFact CLI for brownfield code modernization  
+> **Primary Use Case**: SpecFact CLI for validation evidence and AI-bloat defense on existing codebases  
 > **Secondary Use Case**: Add SpecFact enforcement to Spec-Kit's interactive authoring for new features
 
 ---

--- a/docs/guides/use-cases.md
+++ b/docs/guides/use-cases.md
@@ -10,7 +10,7 @@ redirect_from:
 
 Detailed use cases and examples for SpecFact CLI.
 
-> **Primary Use Case**: Brownfield code modernization (Use Case 1)  
+> **Primary Use Case**: Validation evidence and AI-bloat defense on existing codebases (Use Case 1)  
 > **Secondary Use Case**: Adding enforcement to Spec-Kit projects (Use Case 2)  
 > **Alternative**: Greenfield spec-first development (Use Case 3)  
 > **Validation Use Case**: Sidecar validation of external codebases (Use Case 4) 🆕

--- a/docs/reference/directory-structure.md
+++ b/docs/reference/directory-structure.md
@@ -20,7 +20,10 @@ Use this document for repository-local artifact placement. Use
 [Module Development](../guides/module-development.md) and
 [Publishing modules](../guides/publishing-modules.md) for source/package layout.
 
-> **Primary Use Case**: SpecFact CLI produces **validation evidence and AI-bloat defense** for AI-assisted and brownfield Python delivery - reverse-engineering existing codebases into documented specs, then detecting drift, bloat, and weak contracts before merge. The directory structure reflects this evidence-first approach to existing code.
+> **Primary Use Case**: SpecFact CLI produces **validation evidence and AI-bloat defense** for AI-assisted and
+> brownfield Python delivery - reverse-engineering existing codebases into documented specs, then detecting drift,
+> bloat, and weak contracts before merge. The directory structure reflects this evidence-first approach to
+> existing code.
 
 **CLI-First Approach**: SpecFact works offline, requires no account, and integrates with your existing workflow. Works with VS Code, Cursor, GitHub Actions, pre-commit hooks, or any IDE. No platform to learn, no vendor lock-in.
 

--- a/docs/reference/directory-structure.md
+++ b/docs/reference/directory-structure.md
@@ -20,7 +20,7 @@ Use this document for repository-local artifact placement. Use
 [Module Development](../guides/module-development.md) and
 [Publishing modules](../guides/publishing-modules.md) for source/package layout.
 
-> **Primary Use Case**: SpecFact CLI is designed for **brownfield code modernization** - reverse-engineering existing codebases into documented specs with runtime contract enforcement. The directory structure reflects this brownfield-first approach.
+> **Primary Use Case**: SpecFact CLI produces **validation evidence and AI-bloat defense** for AI-assisted and brownfield Python delivery - reverse-engineering existing codebases into documented specs, then detecting drift, bloat, and weak contracts before merge. The directory structure reflects this evidence-first approach to existing code.
 
 **CLI-First Approach**: SpecFact works offline, requires no account, and integrates with your existing workflow. Works with VS Code, Cursor, GitHub Actions, pre-commit hooks, or any IDE. No platform to learn, no vendor lock-in.
 


### PR DESCRIPTION
## Why

Six docs pages still framed SpecFact by the retired 2025 thesis ("brownfield code modernization with runtime contract enforcement"). The current product thesis in `openspec/CHANGE_ORDER.md` is validation evidence and AI-bloat defense for AI-assisted and brownfield delivery.

## What Changes

Docs-only, 6 one-line edits — no code, no OpenSpec change needed:

- `docs/getting-started/installation.md` — primary-use-case callout rewritten to validation evidence / AI-bloat defense.
- `docs/getting-started/tutorial-openspec-speckit.md` — subtitle reframed from modernization to validation/sync.
- `docs/guides/speckit-journey.md` — primary use case line updated.
- `docs/guides/use-cases.md` — primary use case blockquote updated (Use Case 1 heading/anchors untouched).
- `docs/guides/integrations-overview.md` — key-difference line: validating existing code and defending against AI-bloat/drift.
- `docs/reference/directory-structure.md` — primary-use-case callout rewritten to evidence-first framing.

Kept intentionally: brownfield-as-context mentions (where-to-start, speckit-comparison capability list) and all contract-tooling feature docs (icontract/beartype functionality is shipped and factual).

## Validation

- Pre-commit full pass: markdownlint, command overview/contract checks, `check-docs-commands` (382 prefixes), docs ownership frontmatter — all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)