### PR TITLE
feat(requirements): import upstream evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.52.1] - 2026-07-13
+
+### Fixed
+
+- **Import evidence review hardening**: reject malformed OpenSpec schema
+  declarations, preserve unique deterministic requirement identities, resolve
+  relative source locators from the project root, and tolerate unreadable
+  optional profile configuration.
+
+---
+
 ## [0.52.0] - 2026-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.52.0] - 2026-07-13
+
+### Added
+
+- **Upstream requirements evidence import**: normalize native OpenSpec and
+  Spec Kit requirement sources into deterministic, auditable records, with
+  source hashes, import gates, layered profile mappings, and required-field
+  advisories. Unsupported or customized source schemas now fail closed without
+  emitting partial records.
+
+---
+
 ## [0.51.2] - 2026-07-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.52.2] - 2026-07-13
+
+### Fixed
+
+- **OpenSpec schema import resilience**: reject invalid UTF-8 configuration
+  with the standard fail-closed source-schema diagnostic instead of crashing.
+
+---
+
 ## [0.52.1] - 2026-07-13
 
 ### Fixed

--- a/docs/reference/requirements-context-adapter.md
+++ b/docs/reference/requirements-context-adapter.md
@@ -125,6 +125,11 @@ delegate entirely to these core helpers.
 `requirements import --from-file` remains the generic fallback for records
 outside the supported native profiles.
 
+The currently released requirements module does not expose those native-import
+flags yet. It remains compatible because it uses only `--from-file`; the paired
+module release for #168 will declare a `0.52.0` core compatibility floor before
+exposing `--from-openspec` or `--from-speckit`.
+
 ## Compatibility Notes
 
 - Requirement inputs must include `schema_version` and at least one source

--- a/docs/reference/requirements-context-adapter.md
+++ b/docs/reference/requirements-context-adapter.md
@@ -9,8 +9,10 @@ expertise_level: [advanced]
 doc_owner: specfact-cli
 tracks:
   - src/specfact_cli/requirements/context.py
+  - src/specfact_cli/requirements/importers.py
   - tests/unit/requirements/test_context_adapter.py
-last_reviewed: 2026-07-08
+  - tests/unit/requirements/test_upstream_evidence_imports.py
+last_reviewed: 2026-07-13
 exempt: false
 exempt_reason: ""
 ---
@@ -26,6 +28,10 @@ requirements authoring workflow.
 
 - `normalize_requirement_records(...)` converts source-attributed mappings or
   `RequirementInput` objects into normalized records and bounded diagnostics.
+- `import_openspec_change(...)` reads a native OpenSpec change folder and
+  derives deterministic, source-attributed requirement records.
+- `import_speckit_feature(...)` reads a native Spec Kit feature folder through
+  the existing scanner and derives deterministic requirement records.
 - `attach_requirements_to_bundle(...)` stores normalized records under the
   existing `requirements.inputs` `ProjectBundle` extension.
 - `load_requirements_from_bundle(...)` reads that extension back into
@@ -37,6 +43,49 @@ requirements authoring workflow.
 - `analyze_requirement_traceability(...)` reads `requirements.inputs`; when
   callers supply `known_targets`, it also returns deterministic stale-link drift
   findings for evidence consumers.
+
+Both native import helpers are read-only. They derive stable IDs, preserve
+Given/When/Then scenarios as business rules, and record the parsed artifact's
+`sha256:` revision. Re-running unchanged input produces the same records.
+
+## Source Compatibility Boundary
+
+Imports are deliberately fail-closed. The core supports only fixture-backed
+default Markdown profiles: OpenSpec `spec-driven` (or no declared schema) with
+native `Requirement` and `Scenario` headings, and the default Spec Kit
+`Feature Specification`/`FR-` template. A custom OpenSpec schema, a Spec Kit
+template override/preset/extension root, or unknown required heading produces
+an error `unsupported-source-schema` diagnostic and no records from that
+source.
+
+The adapter does not infer an upstream CLI version from Markdown or fetch a
+live schema during import: native artifacts do not consistently carry a tool
+version, and network-dependent parsing would make CI non-reproducible. To add
+an upstream format, add a pinned representative fixture, extend the core
+profile, and pass its compatibility test before release.
+
+## Import Validation Gates
+
+For OpenSpec and Spec Kit records, `validate_requirement_context(...)` emits
+machine-readable findings for:
+
+- `scenario-unverified`: a derived scenario has no test or validation link.
+- `stale-import`: an artifact's current bytes no longer match its imported
+  `sha256:` revision.
+- `source-missing`: an imported artifact is no longer available.
+- `ambiguous-mapping`: different imported sources claim the same derived ID.
+
+An error-severity finding makes the paired `requirements validate` command
+exit non-zero; the module runtime owns terminal formatting and command flags.
+The core helper also preserves `missing-evidence` as a stable, machine-readable
+finding code.
+
+When no profile is passed, validation resolves the layered profile from the
+organization, repository, and developer-local configuration. The adapter maps
+only evidence-backed required fields: `id`, `title`, `acceptance`, and
+`trace_links`. Other profile fields are surfaced as
+`unsupported-profile-field` advisories rather than requiring OpenSpec or Spec
+Kit authors to add SpecFact metadata.
 
 ```python
 from specfact_cli.models.requirements import RequirementInput, RequirementSourceReference
@@ -69,6 +118,12 @@ result = normalize_requirement_records(
 The `requirements` command group is owned by the requirements module runtime.
 Runtime commands should call the core helpers instead of parsing provider
 payloads directly inside root CLI code.
+
+After this core change ships, the paired module change will add
+`requirements import --from-openspec` and `--from-speckit`; those flags will
+delegate entirely to these core helpers.
+`requirements import --from-file` remains the generic fallback for records
+outside the supported native profiles.
 
 ## Compatibility Notes
 

--- a/openspec/changes/openspec-01-intent-trace/CHANGE_VALIDATION.md
+++ b/openspec/changes/openspec-01-intent-trace/CHANGE_VALIDATION.md
@@ -1,13 +1,104 @@
 # Change Validation Report: openspec-01-intent-trace
 
-**Status**: STALE — revalidation required before implementation.
+**Validation Date**: 2026-07-13 (Europe/Berlin)
+**Change Proposal**: [proposal.md](./proposal.md)
+**Validation Method**: Dry-run interface and dependency analysis against the current core CLI worktree.
 
-The previous report (2026-03-05) validated the retired `## Intent Trace`
-authoring scope (YAML block, `intent-trace.schema.json`, `--import-intent`
-flag). The change was rescoped on 2026-07-13 to import-first requirement
-evidence from native OpenSpec and Spec Kit artifacts (see `proposal.md`,
-Rescope section).
+## Executive Summary
 
-Re-run the change validation workflow against the rescoped proposal and
-replace this file with the new report before starting implementation
-(tracked as task 1.3 in `tasks.md`).
+- Breaking Changes: 0 detected / 0 unresolved
+- Dependent Files: 3 direct core surfaces, plus the paired module runtime issue
+- Impact Level: Medium (new validation behavior; no removed public interface)
+- Validation Result: Pass
+- User Decision: Apply the evidence-compatible required-field mapping and the
+  fail-closed source compatibility boundary approved on 2026-07-13.
+
+The rescoped change preserves the existing `RequirementInput` schema,
+`--from-file` flow, and source types while adding core-owned OpenSpec/Spec Kit
+normalization and deterministic validation gates. The approved
+evidence-compatible required-field mapping defines their semantics against
+that schema without widening it.
+The `specfact-requirements` command wiring remains explicitly paired with
+`nold-ai/specfact-cli-modules#168`; it does not block the core implementation.
+
+The approved compatibility extension adds no public parameter or model change.
+It accepts only fixture-backed default OpenSpec and Spec Kit structural
+profiles, returning `unsupported-source-schema` and no partial records for
+custom or unrecognized sources. This is a non-breaking, additive diagnostic
+contract; #168 will surface it without reimplementing compatibility logic.
+
+## Resolved Required-Field Contract
+
+`id`, `title`, `acceptance`, and `trace_links` map to `requirement_id`,
+`title`, `business_rules`, and `evidence_links`, respectively. Other profile
+fields produce a machine-readable `unsupported-profile-field` advisory and do
+not make imported records incomplete. Owner, risk, and exception metadata stay
+outside this import-first schema until a separately scoped enrichment change
+defines an accountable source for them.
+
+## Interface and Dependency Analysis
+
+### New Core Interfaces
+
+- `src/specfact_cli/requirements/`: OpenSpec and Spec Kit import normalizers
+  will consume existing parser outputs and return `RequirementInput` records.
+- `src/specfact_cli/requirements/context.py`: validation gains four additive
+  finding categories and layered-profile resolution when no explicit profile
+  is supplied.
+
+No parameter is removed, no required parameter is added to an existing public
+API, and no existing model field changes type. The pending decision concerns
+the profile-default validation semantics, not interface compatibility.
+
+### Dependent Files Affected
+
+#### Critical Updates Required
+
+- None before core implementation.
+
+#### Recommended Updates
+
+- `src/specfact_cli/requirements/__init__.py`: export the new core helpers.
+- `tests/unit/requirements/test_context_adapter.py`: cover import normalization,
+  gate categories, profile resolution, idempotency, and source-directory
+  immutability.
+- `nold-ai/specfact-cli-modules#168`: add module command flags and persistence
+  wiring after the core helpers are available.
+
+## Risk Assessment
+
+- Upstream-format drift is contained by a fail-closed compatibility preflight:
+  unsupported schemas or template profiles return
+  `unsupported-source-schema` and no requirement records. Adding a newer
+  profile requires a pinned fixture and explicit core update; import never
+  fetches or guesses a live upstream version.
+- Content hashes intentionally treat any byte change as stale; re-import is the
+  rollback path and remains idempotent.
+- The new default profile source can change validation severity for callers
+  that omit `--profile`; tests must prove explicit profiles still override it.
+
+## Format Validation
+
+- **proposal.md Format**: Pass — required sections, capability mapping, source
+  tracking, ownership split, impact, and rollback constraints are present.
+- **tasks.md Format**: Pass — TDD order is explicit; the required worktree was
+  created first; GitHub synchronization now precedes PR creation; post-merge
+  cleanup is recorded.
+- **specs Format**: Pass — requirements use Given/When/Then scenarios and map
+  to the declared capabilities.
+- **Config.yaml Compliance**: Pass — offline/read-only constraints, contracts,
+  documentation, test-first evidence, and the required-field mapping are
+  accounted for.
+
+## OpenSpec Validation
+
+- **Status**: Pass
+- **Command**: `openspec validate openspec-01-intent-trace --strict`
+- **Issues Found/Fixed**: 2 — task ordering/cleanup and required-field mapping.
+
+## Validation Artifacts
+
+- Worktree: `/Users/dom/git/nold-ai/specfact-cli-worktrees/feature/openspec-01-intent-trace`
+- GitHub readiness: issue #350 is open and Todo, with parent #371, required
+  labels/project assignment, closed blockers #238 and #239, and no items it
+  blocks.

--- a/openspec/changes/openspec-01-intent-trace/TDD_EVIDENCE.md
+++ b/openspec/changes/openspec-01-intent-trace/TDD_EVIDENCE.md
@@ -84,6 +84,20 @@ $ hatch run pytest tests/unit/requirements/test_upstream_evidence_imports.py tes
 The explicit-profile regression assertion also remains green: configured
 profile-derived schema fields cannot override an explicitly passed profile.
 
+### Invalid UTF-8 Schema Remediation (2026-07-13)
+
+```text
+$ hatch run pytest tests/unit/requirements/test_upstream_evidence_imports.py::test_import_openspec_change_rejects_invalid_utf8_schema_without_partial_records -q
+1 failed (UnicodeDecodeError escaped from config.yaml decoding)
+
+$ hatch run pytest tests/unit/requirements/test_upstream_evidence_imports.py tests/unit/requirements/test_context_adapter.py -q
+26 passed
+```
+
+Invalid UTF-8 in an OpenSpec schema configuration now produces the same
+`unsupported-source-schema` fail-closed result as malformed YAML or a
+non-string schema declaration.
+
 ## Final Gate Evidence
 
 ```text

--- a/openspec/changes/openspec-01-intent-trace/TDD_EVIDENCE.md
+++ b/openspec/changes/openspec-01-intent-trace/TDD_EVIDENCE.md
@@ -61,11 +61,41 @@ change-local OpenSpec schema rejection, all supported Spec Kit customization
 root rejections, unknown Markdown markers, and the no-partial-records
 contract for `unsupported-source-schema`.
 
+## PR #646 Review Remediation Evidence (2026-07-13)
+
+### Failing-first
+
+```text
+$ hatch run pytest tests/unit/requirements/test_upstream_evidence_imports.py -q
+7 failed, 11 passed
+```
+
+The failures covered non-string OpenSpec schema declarations, duplicate derived
+OpenSpec/Spec Kit identities, project-root-relative source locators, and
+malformed optional configuration.
+
+### Passing-after
+
+```text
+$ hatch run pytest tests/unit/requirements/test_upstream_evidence_imports.py tests/unit/requirements/test_context_adapter.py -q
+25 passed
+```
+
+The explicit-profile regression assertion also remains green: configured
+profile-derived schema fields cannot override an explicitly passed profile.
+
 ## Final Gate Evidence
 
 ```text
 $ hatch run smart-test
-2837 tests passed; 64.0% coverage
+2844 passed, 9 skipped; 64.0% coverage (local `fail_under = 50` threshold)
+
+This local result is not evidence that the PR's 80% CI quality-gate threshold
+has passed. At the time recorded, the PR Tests job also failed first on the
+unrelated `test_contracts_include_parameters` integration regression, so its
+dependent Quality Gates job did not run. Coverage remediation is repository-wide
+work outside this import-adapter change; this change adds targeted tests for all
+new adapter paths.
 
 $ hatch run contract-test
 Runtime contracts: PASS; contract exploration: PASS; scenario tests: 21 passed

--- a/openspec/changes/openspec-01-intent-trace/TDD_EVIDENCE.md
+++ b/openspec/changes/openspec-01-intent-trace/TDD_EVIDENCE.md
@@ -1,0 +1,82 @@
+# TDD Evidence: openspec-01-intent-trace
+
+**Date**: 2026-07-13 (Europe/Berlin)
+
+## Failing Before Production Code
+
+```text
+$ hatch run pytest tests/unit/requirements/test_upstream_evidence_imports.py -q
+ImportError: cannot import name 'import_openspec_change' from 'specfact_cli.requirements'
+```
+
+The test was added after the OpenSpec delta defined native import, content-hash,
+read-only, gate, and profile-mapping behavior. It failed during collection
+because the core normalizers did not yet exist.
+
+## Iteration Finding
+
+```text
+$ hatch run pytest tests/unit/requirements/test_upstream_evidence_imports.py tests/unit/requirements/test_context_adapter.py -q
+1 failed, 11 passed
+KeyError: 'code'
+```
+
+The expanded deterministic-gate test exposed that the pre-existing
+missing-evidence finding lacked a machine-readable category. The implementation
+now emits `missing-evidence` without changing its severity, message, or
+location contract.
+
+## Passing After Production Code
+
+```text
+$ hatch run pytest tests/unit/requirements/test_upstream_evidence_imports.py tests/unit/requirements/test_context_adapter.py -q
+12 passed in 0.47s
+```
+
+The passing run covers OpenSpec and Spec Kit normalization, deterministic IDs,
+GIVEN/WHEN/THEN preservation, `sha256:` revisions, read-only source behavior,
+all four import gates, explicit-profile precedence, layered-profile resolution,
+and the evidence-compatible required-field mapping.
+
+## Compatibility Boundary: Failing Before Preflight
+
+```text
+$ hatch run pytest tests/unit/requirements/test_upstream_evidence_imports.py -q
+3 failed, 5 passed
+```
+
+The new tests proved that custom OpenSpec schemas, Spec Kit template
+customization roots, and unrecognized Markdown markers were previously
+accepted or silently returned no records without an explanatory diagnostic.
+
+## Compatibility Boundary: Passing After Preflight
+
+```text
+$ hatch run pytest tests/unit/requirements/test_upstream_evidence_imports.py tests/unit/requirements/test_context_adapter.py -q
+18 passed in 0.98s
+```
+
+The compatibility tests cover default profile acceptance, project- and
+change-local OpenSpec schema rejection, all supported Spec Kit customization
+root rejections, unknown Markdown markers, and the no-partial-records
+contract for `unsupported-source-schema`.
+
+## Final Gate Evidence
+
+```text
+$ hatch run smart-test
+2837 tests passed; 64.0% coverage
+
+$ hatch run contract-test
+Runtime contracts: PASS; contract exploration: PASS; scenario tests: 21 passed
+
+$ hatch run specfact code review run --json --out .specfact/code-review.json
+Review completed with no findings.
+
+$ hatch run semgrep-sast --json --output logs/static-analysis/semgrep.json
+$ hatch run semgrep-sast-gate --results logs/static-analysis/semgrep.json --baseline tools/semgrep/sast-baseline.json
+0 current findings; no new findings outside baseline
+
+$ hatch run bandit-scan
+No medium or high issues identified.
+```

--- a/openspec/changes/openspec-01-intent-trace/design.md
+++ b/openspec/changes/openspec-01-intent-trace/design.md
@@ -30,6 +30,8 @@ reads what they already produce.
 - Extend requirement context validation with deterministic pass/fail gate
   categories usable in CI via exit codes and JSON evidence.
 - Keep the whole path read-only toward upstream artifacts.
+- Fail closed when an upstream source declares or signals an untested schema or
+  template profile; do not silently emit zero or partial requirement records.
 
 **Non-Goals:**
 
@@ -95,6 +97,16 @@ overlay -> developer local) instead of a hardcoded `startup` default, and the
 profile's `requirements_schema.required_fields` participates in completeness
 findings. The explicit flag always wins.
 
+The requirements evidence adapter evaluates only the following explicit
+aliases: `id` → `requirement_id`, `title` → `title`, `acceptance` →
+`business_rules`, and `trace_links` → `evidence_links`. A configured field
+outside that set is returned as a machine-readable
+`unsupported-profile-field` advisory, not as missing record metadata. Native
+OpenSpec and Spec Kit artifacts do not consistently supply owner, risk, or
+exception metadata; adding those fields here would violate the import-first,
+read-only boundary. A future enrichment change may define a source and schema
+for that metadata.
+
 ### D5: Import runtime lives in the `specfact-requirements` module
 
 **Decision**: Core owns parsers, normalization, hashing, and gate evaluation
@@ -105,11 +117,37 @@ when the path is omitted.
 **Rationale**: Matches the requirements-02 split (core contracts, module
 runtime) and keeps the module thin.
 
+### D6: Structural compatibility profiles, not inferred tool versions
+
+**Decision**: Core preflight accepts only two explicitly tested profiles:
+
+- OpenSpec's default `spec-driven` schema (or no schema declaration) with
+  native `### Requirement:` and `#### Scenario:` Markdown structure.
+- Spec Kit's default Markdown template with `# Feature Specification:` and
+  functional-requirement (`FR-`) entries, provided no project template
+  override, preset, or extension template root is active.
+
+An OpenSpec custom schema, a Spec Kit customization root, malformed profile
+marker, or an unrecognized required Markdown structure returns an error
+diagnostic with code `unsupported-source-schema` and **zero records** for that
+source. The adapter does not attempt fallback parsing or partial emission.
+
+**Rationale**: Neither source artifact format provides a dependable universal
+tool-version field. Inferring a CLI version from Markdown would be false
+precision. Structural profiles make the supported contract deterministic and
+allow upstream changes to fail visibly until a pinned fixture and an explicit
+profile update are added.
+
+**Alternative rejected**: Fetching a current upstream schema during import.
+That makes CI non-reproducible, introduces network authority into a read-only
+normalizer, and could change results mid-run.
+
 ## Risks / Trade-offs
 
 - **[Risk] Upstream format drift** — OpenSpec/Spec Kit layouts evolve.
-  Mitigation: parsers already exist and are covered by fixtures; import
-  failures degrade to `source-missing`/parse diagnostics, never crashes.
+  Mitigation: profile preflight is fail-closed; unsupported sources emit
+  `unsupported-source-schema` and no records until a core fixture-backed
+  profile is deliberately added.
 - **[Risk] Hash churn on whitespace-only edits** — staleness gate fires on any
   byte change. Accepted: deterministic beats clever; re-import is one command
   and idempotent.
@@ -123,6 +161,9 @@ runtime) and keeps the module thin.
 1. No data migration: existing sidecars validate unchanged.
 2. Docs reposition import-first as the flagship path; `--from-file` stays.
 3. `requirements-03-backlog-sync` ordering note updated in `CHANGE_ORDER.md`.
+4. Adding support for a newer upstream format requires a pinned representative
+   fixture, explicit profile change, and a passing compatibility test before
+   release; it is not discovered dynamically during import.
 
 ## Open Questions
 

--- a/openspec/changes/openspec-01-intent-trace/proposal.md
+++ b/openspec/changes/openspec-01-intent-trace/proposal.md
@@ -74,8 +74,8 @@ this change (see `openspec/CHANGE_ORDER.md`).
   authoring systems of record. SpecFact plan-authoring commands remain
   available but are repositioned as secondary; import-first is the documented
   flagship path. Command deprecation mechanics are out of scope here.
-- **CHANGED (shipped-gap fix, folded in 2026-07-13)**: requirement context
-  validation resolves the effective profile from the layered configuration
+- **CHANGED (shipped-gap fix, folded in 2026-07-13)**: the core
+  `validate_requirement_context` helper resolves the effective profile from the layered configuration
   shipped by `profile-01-config-layering` when no explicit profile is passed
   (an explicit flag always wins), and honors the profile's
   `requirements_schema.required_fields` through an explicit evidence-field
@@ -84,8 +84,9 @@ this change (see `openspec/CHANGE_ORDER.md`).
   fields are emitted as machine-readable `unsupported-profile-field`
   advisories; they never make a native imported record incomplete. This change
   does not add owner, risk, or exception metadata to the import-first schema.
-  Fixes the current gap where `requirements validate` hardcodes the `startup`
-  default and ignores `resolve_profile_config` output entirely.
+  The requirements CLI still hardcodes the `startup` default; the paired
+  module follow-up (#168) will adopt the core helper rather than duplicating
+  profile resolution.
 - **REMOVED (from this change's previous scope)**: the `## Intent Trace` YAML
   authoring block, `intent-trace.schema.json`, and `--import-intent` bridge
   flag. Never implemented; retired before implementation.

--- a/openspec/changes/openspec-01-intent-trace/proposal.md
+++ b/openspec/changes/openspec-01-intent-trace/proposal.md
@@ -58,6 +58,12 @@ this change (see `openspec/CHANGE_ORDER.md`).
   `speckit_spec` source references.
 - **NEW**: Source references from these importers MUST populate `revision`
   with a content hash of the parsed artifact, enabling staleness detection.
+- **NEW**: Import preflight recognizes only the tested default OpenSpec
+  `spec-driven` Markdown profile and the tested default Spec Kit Markdown
+  profile. Custom OpenSpec schemas and Spec Kit template override/preset or
+  extension roots are rejected with a blocking `unsupported-source-schema`
+  diagnostic before any requirement record is emitted; the importer never
+  guesses or returns a partial import.
 - **NEW**: Requirement context validation gains deterministic gate categories:
   `scenario-unverified` (business rule without test/validation evidence link),
   `stale-import` (source content hash no longer matches artifact on disk),
@@ -72,9 +78,14 @@ this change (see `openspec/CHANGE_ORDER.md`).
   validation resolves the effective profile from the layered configuration
   shipped by `profile-01-config-layering` when no explicit profile is passed
   (an explicit flag always wins), and honors the profile's
-  `requirements_schema.required_fields` in completeness findings. Fixes the
-  current gap where `requirements validate` hardcodes the `startup` default
-  and ignores `resolve_profile_config` output entirely.
+  `requirements_schema.required_fields` through an explicit evidence-field
+  mapping: `id` → `requirement_id`, `title` → `title`, `acceptance` →
+  `business_rules`, and `trace_links` → `evidence_links`. Unsupported profile
+  fields are emitted as machine-readable `unsupported-profile-field`
+  advisories; they never make a native imported record incomplete. This change
+  does not add owner, risk, or exception metadata to the import-first schema.
+  Fixes the current gap where `requirements validate` hardcodes the `startup`
+  default and ignores `resolve_profile_config` output entirely.
 - **REMOVED (from this change's previous scope)**: the `## Intent Trace` YAML
   authoring block, `intent-trace.schema.json`, and `--import-intent` bridge
   flag. Never implemented; retired before implementation.
@@ -102,6 +113,9 @@ this change (see `openspec/CHANGE_ORDER.md`).
 - No breaking changes: existing bundles, sidecars, and `--from-file` flows are
   unchanged. Depends on `requirements-01-data-model` and
   `requirements-02-module-commands` (both shipped).
+- This intentionally pins compatibility to source *format profiles*, not an
+  inferred upstream CLI version: native artifacts do not reliably carry one.
+  Future upstream profiles require explicit fixtures and a core adapter update.
 
 ---
 

--- a/openspec/changes/openspec-01-intent-trace/specs/openspec-speckit-evidence-adapter/spec.md
+++ b/openspec/changes/openspec-01-intent-trace/specs/openspec-speckit-evidence-adapter/spec.md
@@ -14,6 +14,8 @@ the upstream artifacts.
 - **WHEN** the OpenSpec import runs against that change folder
 - **THEN** each spec requirement produces a `RequirementInput` with a stable
   derived `requirement_id` of the form `openspec:<change-id>:<capability>:<requirement-slug>`
+- **AND** repeated titles that derive the same slug receive a deterministic
+  ordinal suffix so every record in one import has a unique identity
 - **AND** each scenario is normalized into a `BusinessRule` with its given,
   when, and then clauses preserved
 - **AND** each record carries a `RequirementSourceReference` with
@@ -49,6 +51,8 @@ without requiring any SpecFact-specific metadata in the upstream artifacts.
 - **WHEN** the Spec Kit import runs against that feature folder
 - **THEN** each requirement produces a `RequirementInput` with a stable derived
   `requirement_id` of the form `speckit:<feature-dir>:<requirement-slug>`
+- **AND** repeated requirement text that derives the same slug receives a
+  deterministic ordinal suffix so every record in one import has a unique identity
 - **AND** acceptance scenarios are normalized into `BusinessRule` records
 - **AND** each record carries a `RequirementSourceReference` with
   `source_type` `speckit_spec`
@@ -106,7 +110,7 @@ artifacts do not provide a dependable universal tool-version field.
 #### Scenario: Custom OpenSpec schema is rejected without partial records
 
 - **GIVEN** an OpenSpec change whose project or change configuration declares
-  a schema other than the tested default
+  a schema other than the tested default, or declares a non-string schema value
 - **WHEN** the OpenSpec import runs
 - **THEN** the result contains an error diagnostic with code
   `unsupported-source-schema`

--- a/openspec/changes/openspec-01-intent-trace/specs/openspec-speckit-evidence-adapter/spec.md
+++ b/openspec/changes/openspec-01-intent-trace/specs/openspec-speckit-evidence-adapter/spec.md
@@ -87,3 +87,45 @@ OpenSpec or Spec Kit directories.
 - **WHEN** import, validation, and coverage inspection run to completion
 - **THEN** the byte content and file listing of the upstream directories are
   unchanged
+
+### Requirement: Fail-Closed Source Compatibility
+
+The system SHALL import only explicitly tested native source-format profiles
+and SHALL reject unrecognized or customized source schemas before emitting any
+requirement records. Compatibility SHALL be structural because upstream
+artifacts do not provide a dependable universal tool-version field.
+
+#### Scenario: Default OpenSpec schema is accepted
+
+- **GIVEN** an OpenSpec change using the default `spec-driven` schema (or no
+  explicit schema) and native requirement/scenario Markdown headings
+- **WHEN** the OpenSpec import runs
+- **THEN** the source is accepted by compatibility preflight
+- **AND** normalization proceeds using the default OpenSpec profile.
+
+#### Scenario: Custom OpenSpec schema is rejected without partial records
+
+- **GIVEN** an OpenSpec change whose project or change configuration declares
+  a schema other than the tested default
+- **WHEN** the OpenSpec import runs
+- **THEN** the result contains an error diagnostic with code
+  `unsupported-source-schema`
+- **AND** the result contains no requirement records from that source.
+
+#### Scenario: Customized Spec Kit templates are rejected without partial records
+
+- **GIVEN** a Spec Kit feature under a project with template overrides,
+  presets, or extension template roots
+- **WHEN** the Spec Kit import runs
+- **THEN** the result contains an error diagnostic with code
+  `unsupported-source-schema`
+- **AND** the result contains no requirement records from that source.
+
+#### Scenario: Unrecognized default-format markers are rejected
+
+- **GIVEN** an OpenSpec or Spec Kit source that does not contain the required
+  headings of its tested default Markdown profile
+- **WHEN** the importer preflights the source
+- **THEN** it emits `unsupported-source-schema`
+- **AND** it does not guess a mapping, fetch upstream definitions, or emit a
+  partial import.

--- a/openspec/changes/openspec-01-intent-trace/specs/requirements-module/spec.md
+++ b/openspec/changes/openspec-01-intent-trace/specs/requirements-module/spec.md
@@ -65,9 +65,32 @@ gate categories with profile-driven severity.
 - **THEN** the resolved configured profile decides gate severity instead of a hardcoded default
 - **AND** an explicitly passed profile argument overrides the configured profile.
 
+#### Scenario: Profile required fields use evidence-compatible aliases
+
+- **GIVEN** a resolved profile whose `requirements_schema.required_fields`
+  contains `id`, `title`, `acceptance`, `trace_links`, and a field unsupported
+  by `RequirementInput`
+- **WHEN** requirements context validation runs
+- **THEN** `id`, `title`, `acceptance`, and `trace_links` evaluate
+  `requirement_id`, `title`, `business_rules`, and `evidence_links`,
+  respectively, for completeness findings
+- **AND** the unsupported field produces a machine-readable
+  `unsupported-profile-field` advisory
+- **AND** native imported records are not marked incomplete solely because the
+  upstream artifact has no owner, risk, or exception metadata.
+
 #### Scenario: Ambiguous mappings gate validation
 
 - **GIVEN** two imported requirements that claim the same derived requirement identity from different sources
 - **WHEN** requirements context validation runs
 - **THEN** the validation report contains an `ambiguous-mapping` finding naming both source locators
 - **AND** no record is silently dropped or overwritten.
+
+#### Scenario: Unsupported source format blocks module import
+
+- **GIVEN** a module import request whose OpenSpec schema or Spec Kit template
+  profile is not supported by the core evidence adapter
+- **WHEN** the module delegates import to core
+- **THEN** it surfaces the core `unsupported-source-schema` diagnostic without
+  creating or persisting partial requirement records
+- **AND** it does not implement provider-version detection or fallback parsing.

--- a/openspec/changes/openspec-01-intent-trace/specs/requirements-module/spec.md
+++ b/openspec/changes/openspec-01-intent-trace/specs/requirements-module/spec.md
@@ -30,13 +30,15 @@ gate categories with profile-driven severity.
 - **THEN** bundle-level completeness and coverage counts are reported with missing-evidence requirement IDs
 - **AND** the result is machine-readable for downstream module commands.
 
-#### Scenario: Module import consumes OpenSpec and Spec Kit sources
+#### Pending paired-module follow-up
 
-- **GIVEN** a project with an OpenSpec change folder or a Spec Kit feature folder
-- **WHEN** `specfact requirements import` runs with `--from-openspec` or `--from-speckit` (with or without an explicit path)
-- **THEN** upstream artifacts are imported through the evidence adapter without any hand-authored records file
-- **AND** omitted paths are auto-detected from conventional layouts (`openspec/changes/` and Spec Kit `specs/`)
-- **AND** the merged records are persisted to the bundle requirements sidecar exactly like `--from-file` imports.
+The `specfact requirements import --from-openspec` and `--from-speckit`
+command flags, auto-detection, persistence, and diagnostic rendering remain
+unimplemented in the requirements module. They are owned by
+`nold-ai/specfact-cli-modules#168`; this core change supplies only the helpers
+that the future module runtime will call. Until that module release declares a
+core compatibility floor of `0.52.0`, `--from-file` is the only shipped module
+import path.
 
 #### Scenario: Unverified scenarios gate validation
 
@@ -58,12 +60,20 @@ gate categories with profile-driven severity.
 - **WHEN** requirements context validation runs
 - **THEN** the validation report contains a `source-missing` finding with the unresolved locator.
 
+#### Scenario: Relative source locators resolve from the project root
+
+- **GIVEN** an imported requirement stores a relative source locator
+- **WHEN** validation runs with its project root from a different process directory
+- **THEN** the locator is resolved relative to that project root for missing-source and staleness checks.
+
 #### Scenario: Omitted profile resolves from layered configuration
 
 - **GIVEN** a project whose layered configuration (profile defaults, org baseline, repo overlay, developer local) resolves to a validation profile
 - **WHEN** requirements context validation runs without an explicit profile argument
 - **THEN** the resolved configured profile decides gate severity instead of a hardcoded default
 - **AND** an explicitly passed profile argument overrides the configured profile.
+- **AND** profile-derived `requirements_schema` values from configured layers
+  do not override the explicitly selected profile defaults.
 
 #### Scenario: Profile required fields use evidence-compatible aliases
 

--- a/openspec/changes/openspec-01-intent-trace/tasks.md
+++ b/openspec/changes/openspec-01-intent-trace/tasks.md
@@ -10,41 +10,50 @@ code third. Record evidence in `TDD_EVIDENCE.md`.
 
 ## 1. Branch and dependency guardrails
 
-- [ ] 1.1 Create dedicated worktree branch `feature/openspec-01-intent-trace` from `dev`: `scripts/worktree.sh create feature/openspec-01-intent-trace`.
-- [ ] 1.2 Verify `requirements-01-data-model` and `requirements-02-module-commands` are archived (shipped) in `openspec/changes/archive/`.
-- [ ] 1.3 Re-run change validation for the rescoped proposal and refresh `CHANGE_VALIDATION.md` (previous validation covers the retired Intent Trace scope).
+- [x] 1.1 Create dedicated worktree branch `feature/openspec-01-intent-trace` from `dev`: `scripts/worktree.sh create feature/openspec-01-intent-trace`.
+- [x] 1.2 Verify `requirements-01-data-model` and `requirements-02-module-commands` are archived (shipped) in `openspec/changes/archive/`.
+- [x] 1.3 Re-run change validation for the rescoped proposal and refresh `CHANGE_VALIDATION.md` (previous validation covers the retired Intent Trace scope).
 
 ## 2. Spec-first and test-first preparation
 
-- [ ] 2.1 Finalize `specs/` deltas (`openspec-speckit-evidence-adapter` NEW, `requirements-module` MODIFIED) and cross-check scenario completeness.
-- [ ] 2.2 Add unit tests for OpenSpec import normalization (change folder fixture → `RequirementInput` records with `openspec_change` sources, scenario → `BusinessRule` mapping, `sha256:` revision).
-- [ ] 2.3 Add unit tests for Spec Kit import normalization (feature folder fixture → `RequirementInput` records with `speckit_spec` sources).
-- [ ] 2.4 Add unit tests for gate categories: `scenario-unverified`, `stale-import`, `source-missing`, `ambiguous-mapping`, including profile severity mapping and idempotent re-import.
-- [ ] 2.4b Add unit tests for layered-config profile resolution: omitted profile resolves via `resolve_profile_config` (explicit flag wins), and profile `requirements_schema.required_fields` drives completeness findings.
-- [ ] 2.5 Run targeted tests, capture failing-first output in `TDD_EVIDENCE.md`.
+- [x] 2.1 Finalize `specs/` deltas (`openspec-speckit-evidence-adapter` NEW, `requirements-module` MODIFIED) and cross-check scenario completeness.
+- [x] 2.2 Add unit tests for OpenSpec import normalization (change folder fixture → `RequirementInput` records with `openspec_change` sources, scenario → `BusinessRule` mapping, `sha256:` revision).
+- [x] 2.3 Add unit tests for Spec Kit import normalization (feature folder fixture → `RequirementInput` records with `speckit_spec` sources).
+- [x] 2.4 Add unit tests for gate categories: `scenario-unverified`, `stale-import`, `source-missing`, `ambiguous-mapping`, including profile severity mapping and idempotent re-import.
+- [x] 2.4b Add unit tests for layered-config profile resolution: omitted profile resolves via `resolve_profile_config` (explicit flag wins); `id`, `title`, `acceptance`, and `trace_links` map to evidence fields; unsupported fields emit an advisory without making imported records incomplete.
+- [x] 2.5 Run targeted tests, capture failing-first output in `TDD_EVIDENCE.md`.
+- [x] 2.6 Add failing-first compatibility tests for default OpenSpec/Spec Kit
+  profiles, custom OpenSpec schemas, Spec Kit template customization roots,
+  and unknown Markdown markers; prove unsupported sources emit no partial
+  records.
 
 ## 3. Implementation (core)
 
-- [ ] 3.1 Add import normalizers in `src/specfact_cli/requirements/` that consume `adapters/openspec_parser.py` and `importers/speckit_scanner.py`/`speckit_converter.py` output and emit `RequirementInput` records with deterministic IDs and content-hash revisions.
-- [ ] 3.2 Extend `requirements/context.py` validation with the four gate categories and profile-driven severity; keep existing findings intact.
-- [ ] 3.2b Wire layered-config profile resolution: when no explicit profile is passed, resolve the effective profile via `resolve_profile_config` (profile defaults -> org baseline -> repo overlay -> developer local) and apply the profile's `requirements_schema.required_fields` to completeness findings.
-- [ ] 3.3 Guarantee read-only behavior toward upstream artifact directories (contract tests: no writes under source roots).
-- [ ] 3.4 Contract decorators (`@beartype`, `@require`, `@ensure`) on all new public APIs.
+- [x] 3.1 Add import normalizers in `src/specfact_cli/requirements/` that consume `adapters/openspec_parser.py` and `importers/speckit_scanner.py`/`speckit_converter.py` output and emit `RequirementInput` records with deterministic IDs and content-hash revisions.
+- [x] 3.2 Extend `requirements/context.py` validation with the four gate categories and profile-driven severity; keep existing findings intact.
+- [x] 3.2b Wire layered-config profile resolution: when no explicit profile is passed, resolve the effective profile via `resolve_profile_config` (profile defaults -> org baseline -> repo overlay -> developer local); apply the four supported required-field aliases to completeness findings and emit `unsupported-profile-field` advisories for all others.
+- [x] 3.3 Guarantee read-only behavior toward upstream artifact directories (contract tests: no writes under source roots).
+- [x] 3.4 Contract decorators (`@beartype`, `@require`, `@ensure`) on all new public APIs.
+- [x] 3.5 Add fail-closed compatibility preflight in the core import helpers:
+  support only fixture-backed default profiles and return
+  `unsupported-source-schema` for unknown/custom sources without emitting
+  partial records.
 
 ## 4. Implementation (modules repo, paired)
 
-- [ ] 4.1 Track runtime wiring in nold-ai/specfact-cli-modules#168: `requirements import --from-openspec [PATH] --from-speckit [PATH]` with auto-detection, plus validate/list/coverage surfacing of new gate findings.
+- [ ] 4.1 Track runtime wiring in nold-ai/specfact-cli-modules#168: `requirements import --from-openspec [PATH] --from-speckit [PATH]` with auto-detection, plus validate/list/coverage surfacing of new gate findings including `unsupported-source-schema`.
 - [ ] 4.2 Keep module runtime thin: parsing, hashing, and gate logic stay core-owned.
 
 ## 5. Validation and documentation
 
-- [ ] 5.1 Re-run tests and quality gates (`hatch run format`, `type-check`, `lint`, `contract-test`, `smart-test`) until green; record passing evidence in `TDD_EVIDENCE.md`.
-- [ ] 5.2 Update docs: requirements guide repositioned import-first (OpenSpec/Spec Kit as accountable authoring sources; `--from-file` as generic fallback); document gate categories and CI exit-code usage.
-- [ ] 5.3 Run `openspec validate openspec-01-intent-trace --strict` and resolve all issues.
+- [x] 5.1 Re-run tests and quality gates (`hatch run format`, `type-check`, `lint`, `contract-test`, `smart-test`) until green; record passing evidence in `TDD_EVIDENCE.md`.
+- [x] 5.2 Update docs: requirements guide repositioned import-first (OpenSpec/Spec Kit as accountable authoring sources; `--from-file` as generic fallback); document gate categories and CI exit-code usage.
+- [x] 5.3 Run `openspec validate openspec-01-intent-trace --strict` and resolve all issues.
 
 ## 6. Delivery
 
-- [ ] 6.1 Update `openspec/CHANGE_ORDER.md` if sequencing changed during implementation.
-- [ ] 6.2 Mirror material scope updates to `../specfact-cli-internal/wiki/sources/openspec-01-intent-trace.md` and rebuild the wiki graph.
-- [ ] 6.3 Open PR from `feature/openspec-01-intent-trace` to `dev` with spec/test/code/docs evidence.
-- [ ] 6.4 Sync GitHub issue #350 (and modules #168) title/body with the rescoped proposal.
+- [x] 6.1 Update `openspec/CHANGE_ORDER.md` if sequencing changed during implementation.
+- [x] 6.2 Mirror material scope updates to `../specfact-cli-internal/wiki/sources/openspec-01-intent-trace.md` and rebuild the wiki graph.
+- [x] 6.3 Sync GitHub issue #350 (and modules #168) title/body with the rescoped proposal.
+- [ ] 6.4 Open PR from `feature/openspec-01-intent-trace` to `dev` with spec/test/code/docs evidence.
+- [ ] 6.5 After the PR merges, remove the feature worktree with `scripts/worktree.sh remove feature/openspec-01-intent-trace`.

--- a/openspec/changes/openspec-01-intent-trace/tasks.md
+++ b/openspec/changes/openspec-01-intent-trace/tasks.md
@@ -26,6 +26,10 @@ code third. Record evidence in `TDD_EVIDENCE.md`.
   profiles, custom OpenSpec schemas, Spec Kit template customization roots,
   and unknown Markdown markers; prove unsupported sources emit no partial
   records.
+- [x] 2.7 Add review-regression tests for malformed schema declarations,
+  duplicate derived identities, explicit-profile isolation, resilient config
+  loading, and project-root-relative source locators; capture failing-first
+  evidence.
 
 ## 3. Implementation (core)
 
@@ -38,6 +42,8 @@ code third. Record evidence in `TDD_EVIDENCE.md`.
   support only fixture-backed default profiles and return
   `unsupported-source-schema` for unknown/custom sources without emitting
   partial records.
+- [x] 3.6 Remediate accepted PR review findings without widening the paired
+  module #168 runtime scope.
 
 ## 4. Implementation (modules repo, paired)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "specfact-cli"
-version = "0.52.0"
+version = "0.52.1"
 description = "AI-bloat defense CLI for Python teams. Run deterministic code review, cleanup forecasts, and spec/contract evidence for AI-assisted and brownfield delivery."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "specfact-cli"
-version = "0.52.1"
+version = "0.52.2"
 description = "AI-bloat defense CLI for Python teams. Run deterministic code review, cleanup forecasts, and spec/contract evidence for AI-assisted and brownfield delivery."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "specfact-cli"
-version = "0.51.2"
+version = "0.52.0"
 description = "AI-bloat defense CLI for Python teams. Run deterministic code review, cleanup forecasts, and spec/contract evidence for AI-assisted and brownfield delivery."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 if __name__ == "__main__":
     _setup = setup(
         name="specfact-cli",
-        version="0.52.1",
+        version="0.52.2",
         description=(
             "AI-bloat defense CLI for Python teams. Run deterministic code review, cleanup forecasts, "
             "and spec/contract evidence for AI-assisted and brownfield delivery."

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 if __name__ == "__main__":
     _setup = setup(
         name="specfact-cli",
-        version="0.51.2",
+        version="0.52.0",
         description=(
             "AI-bloat defense CLI for Python teams. Run deterministic code review, cleanup forecasts, "
             "and spec/contract evidence for AI-assisted and brownfield delivery."

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 if __name__ == "__main__":
     _setup = setup(
         name="specfact-cli",
-        version="0.52.0",
+        version="0.52.1",
         description=(
             "AI-bloat defense CLI for Python teams. Run deterministic code review, cleanup forecasts, "
             "and spec/contract evidence for AI-assisted and brownfield delivery."

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,4 +3,4 @@ SpecFact CLI - AI-bloat defense CLI for Python teams.
 """
 
 # Package version: keep in sync with pyproject.toml, setup.py, src/specfact_cli/__init__.py
-__version__ = "0.52.0"
+__version__ = "0.52.1"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,4 +3,4 @@ SpecFact CLI - AI-bloat defense CLI for Python teams.
 """
 
 # Package version: keep in sync with pyproject.toml, setup.py, src/specfact_cli/__init__.py
-__version__ = "0.51.2"
+__version__ = "0.52.0"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,4 +3,4 @@ SpecFact CLI - AI-bloat defense CLI for Python teams.
 """
 
 # Package version: keep in sync with pyproject.toml, setup.py, src/specfact_cli/__init__.py
-__version__ = "0.52.1"
+__version__ = "0.52.2"

--- a/src/specfact_cli/__init__.py
+++ b/src/specfact_cli/__init__.py
@@ -76,6 +76,6 @@ def _install_progressive_disclosure() -> None:
 # keeps missing-command and missing-parameter UX consistent outside the root CLI too.
 _install_progressive_disclosure()
 
-__version__ = "0.52.0"
+__version__ = "0.52.1"
 
 __all__ = ["__version__"]

--- a/src/specfact_cli/__init__.py
+++ b/src/specfact_cli/__init__.py
@@ -76,6 +76,6 @@ def _install_progressive_disclosure() -> None:
 # keeps missing-command and missing-parameter UX consistent outside the root CLI too.
 _install_progressive_disclosure()
 
-__version__ = "0.51.2"
+__version__ = "0.52.0"
 
 __all__ = ["__version__"]

--- a/src/specfact_cli/__init__.py
+++ b/src/specfact_cli/__init__.py
@@ -76,6 +76,6 @@ def _install_progressive_disclosure() -> None:
 # keeps missing-command and missing-parameter UX consistent outside the root CLI too.
 _install_progressive_disclosure()
 
-__version__ = "0.52.1"
+__version__ = "0.52.2"
 
 __all__ = ["__version__"]

--- a/src/specfact_cli/requirements/__init__.py
+++ b/src/specfact_cli/requirements/__init__.py
@@ -12,6 +12,7 @@ from specfact_cli.requirements.context import (
     normalize_requirement_records,
     validate_requirement_context,
 )
+from specfact_cli.requirements.importers import import_openspec_change, import_speckit_feature
 
 
 __all__ = [
@@ -21,6 +22,8 @@ __all__ = [
     "RequirementContextDiagnosticSeverity",
     "RequirementContextImportResult",
     "attach_requirements_to_bundle",
+    "import_openspec_change",
+    "import_speckit_feature",
     "inspect_requirement_context_coverage",
     "load_requirements_from_bundle",
     "normalize_requirement_records",

--- a/src/specfact_cli/requirements/context.py
+++ b/src/specfact_cli/requirements/context.py
@@ -162,10 +162,17 @@ def _project_root_supported(project_root: Path | None) -> bool:
 
 
 def _read_config_mapping(path: Path) -> dict[str, Any]:
-    if not path.is_file():
+    try:
+        if not path.is_file():
+            return {}
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
         return {}
-    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     return raw if isinstance(raw, dict) else {}
+
+
+def _without_profile_derived_values(layer: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in layer.items() if key not in {"profile", "requirements_schema"}}
 
 
 def _configured_profile(*layers: Mapping[str, object]) -> str:
@@ -195,6 +202,10 @@ def _resolve_requirement_profile(
     configured = _configured_profile(developer_local, repo_overlay, org_baseline)
     effective_profile = profile or configured
     resolver_profile = _PROFILE_RESOLUTION_ALIASES.get(effective_profile, effective_profile)
+    if profile is not None:
+        org_baseline = _without_profile_derived_values(org_baseline)
+        repo_overlay = _without_profile_derived_values(repo_overlay)
+        developer_local = _without_profile_derived_values(developer_local)
     resolved = resolve_profile_config(
         resolver_profile,
         org_baseline=org_baseline,
@@ -366,12 +377,19 @@ def _scenario_unverified_violation(requirement: RequirementInput, *, severity: s
     }
 
 
-def _source_integrity_violations(requirement: RequirementInput, *, severity: str) -> list[dict[str, str]]:
+def _source_integrity_violations(
+    requirement: RequirementInput,
+    *,
+    severity: str,
+    project_root: Path,
+) -> list[dict[str, str]]:
     violations: list[dict[str, str]] = []
     for source in requirement.sources:
         if source.source_type not in {RequirementSourceType.OPENSPEC_CHANGE, RequirementSourceType.SPECKIT_SPEC}:
             continue
         source_path = Path(source.locator)
+        if not source_path.is_absolute():
+            source_path = project_root / source_path
         if not source_path.is_file():
             violations.append(
                 {
@@ -409,7 +427,12 @@ def _ambiguous_mapping_violations(identities: Mapping[str, set[str]], *, severit
     ]
 
 
-def _import_gate_violations(requirements: Sequence[RequirementInput], *, severity: str) -> list[dict[str, str]]:
+def _import_gate_violations(
+    requirements: Sequence[RequirementInput],
+    *,
+    severity: str,
+    project_root: Path,
+) -> list[dict[str, str]]:
     violations: list[dict[str, str]] = []
     identities: dict[str, set[str]] = {}
     for requirement in requirements:
@@ -421,7 +444,13 @@ def _import_gate_violations(requirements: Sequence[RequirementInput], *, severit
         scenario_violation = _scenario_unverified_violation(requirement, severity=severity)
         if scenario_violation:
             violations.append(scenario_violation)
-        violations.extend(_source_integrity_violations(requirement, severity=severity))
+        violations.extend(
+            _source_integrity_violations(
+                requirement,
+                severity=severity,
+                project_root=project_root,
+            )
+        )
     violations.extend(_ambiguous_mapping_violations(identities, severity=severity))
     return violations
 
@@ -508,7 +537,13 @@ def validate_requirement_context(
     severity = _missing_evidence_severity(cast(RequirementContextValidationProfile, effective_profile))
     coverage = inspect_requirement_context_coverage(requirements)
     violations = _missing_evidence_violations(coverage, severity=severity)
-    violations.extend(_import_gate_violations(requirements, severity=severity))
+    violations.extend(
+        _import_gate_violations(
+            requirements,
+            severity=severity,
+            project_root=project_root or Path.cwd(),
+        )
+    )
     violations.extend(
         _required_field_violations(
             requirements,

--- a/src/specfact_cli/requirements/context.py
+++ b/src/specfact_cli/requirements/context.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Mapping, Sequence
 from enum import StrEnum
 from pathlib import Path
 from typing import Any, Literal, Protocol, cast, get_args
 
+import yaml
 from beartype import beartype
 from icontract import ensure, require
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
@@ -15,10 +17,12 @@ from specfact_cli.models.project import ProjectBundle
 from specfact_cli.models.requirements import (
     RequirementEvidenceLinkType,
     RequirementInput,
+    RequirementSourceType,
     load_requirements_input_extension,
     requirements_input_extension_payload,
 )
 from specfact_cli.models.validation import ValidationReport
+from specfact_cli.modules.init.src.first_run_selection import resolve_profile_config
 
 
 RequirementContextValidationProfile = Literal[
@@ -26,6 +30,7 @@ RequirementContextValidationProfile = Literal[
     "startup",
     "team",
     "enterprise",
+    "mid_size",
     "strict",
     "solo_developer",
     "api_first_team",
@@ -33,6 +38,19 @@ RequirementContextValidationProfile = Literal[
 ]
 KNOWN_REQUIREMENT_CONTEXT_PROFILES: frozenset[str] = frozenset(get_args(RequirementContextValidationProfile))
 STRICT_REQUIREMENT_CONTEXT_PROFILES: frozenset[str] = frozenset({"enterprise", "strict", "enterprise_full_stack"})
+_PROFILE_RESOLUTION_ALIASES: dict[str, str] = {
+    "api_first_team": "mid_size",
+    "enterprise_full_stack": "enterprise",
+    "solo_developer": "solo",
+    "strict": "enterprise",
+    "team": "mid_size",
+}
+_REQUIRED_FIELD_ALIASES: dict[str, str] = {
+    "id": "requirement_id",
+    "title": "title",
+    "acceptance": "business_rules",
+    "trace_links": "evidence_links",
+}
 
 
 class RequirementContextDiagnosticSeverity(StrEnum):
@@ -131,16 +149,66 @@ def _optional_text(value: str | None) -> str | None:
     return value
 
 
-def _profile_nonempty(profile: str) -> bool:
-    return profile.strip() != ""
-
-
-def _profile_supported(profile: str) -> bool:
-    return profile in KNOWN_REQUIREMENT_CONTEXT_PROFILES
-
-
 def _source_locator_supported(source_locator: str | None) -> bool:
     return source_locator is None or type(source_locator) is str
+
+
+def _optional_profile_supported(profile: str | None) -> bool:
+    return profile is None or (profile.strip() != "" and profile in KNOWN_REQUIREMENT_CONTEXT_PROFILES)
+
+
+def _project_root_supported(project_root: Path | None) -> bool:
+    return project_root is None or isinstance(project_root, Path)
+
+
+def _read_config_mapping(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _configured_profile(*layers: Mapping[str, object]) -> str:
+    for layer in layers:
+        profile = layer.get("profile")
+        if isinstance(profile, str) and profile in KNOWN_REQUIREMENT_CONTEXT_PROFILES:
+            return profile
+    return "startup"
+
+
+def _requirements_schema_fields(values: Mapping[str, Any]) -> list[str]:
+    schema = values.get("requirements_schema")
+    if not isinstance(schema, Mapping):
+        return []
+    fields = cast(Mapping[str, object], schema).get("required_fields")
+    return [field for field in fields if isinstance(field, str)] if isinstance(fields, list) else []
+
+
+def _resolve_requirement_profile(
+    profile: RequirementContextValidationProfile | None,
+    project_root: Path | None,
+) -> tuple[str, dict[str, Any]]:
+    root = project_root or Path.cwd()
+    org_baseline = _read_config_mapping(Path.home() / ".specfact" / "config.yaml")
+    repo_overlay = _read_config_mapping(root / ".specfact" / "config.yaml")
+    developer_local = _read_config_mapping(root / ".specfact" / "config.local.yaml")
+    configured = _configured_profile(developer_local, repo_overlay, org_baseline)
+    effective_profile = profile or configured
+    resolver_profile = _PROFILE_RESOLUTION_ALIASES.get(effective_profile, effective_profile)
+    resolved = resolve_profile_config(
+        resolver_profile,
+        org_baseline=org_baseline,
+        repo_overlay=repo_overlay,
+        developer_local=developer_local,
+    )
+    return effective_profile, resolved.values
+
+
+def _is_imported_requirement(requirement: RequirementInput) -> bool:
+    return any(
+        source.source_type in {RequirementSourceType.OPENSPEC_CHANGE, RequirementSourceType.SPECKIT_SPEC}
+        for source in requirement.sources
+    )
 
 
 def _coverage_summary_consistent(result: RequirementContextCoverageSummary) -> bool:
@@ -274,12 +342,125 @@ def _missing_evidence_violations(
 ) -> list[dict[str, str]]:
     return [
         {
+            "code": "missing-evidence",
             "severity": severity,
             "message": "Requirement input has no downstream evidence links.",
             "location": f"requirements.inputs[{requirement_id}].evidence_links",
         }
         for requirement_id in coverage.missing_evidence_requirement_ids
     ]
+
+
+def _scenario_unverified_violation(requirement: RequirementInput, *, severity: str) -> dict[str, str] | None:
+    if not requirement.business_rules or any(
+        link.link_type in {RequirementEvidenceLinkType.TEST, RequirementEvidenceLinkType.VALIDATION}
+        for link in requirement.evidence_links
+    ):
+        return None
+    rule_ids = ", ".join(rule.rule_id for rule in requirement.business_rules)
+    return {
+        "code": "scenario-unverified",
+        "severity": severity,
+        "message": f"Imported scenarios have no test or validation evidence links: {rule_ids}.",
+        "location": f"requirements.inputs[{requirement.requirement_id}].business_rules",
+    }
+
+
+def _source_integrity_violations(requirement: RequirementInput, *, severity: str) -> list[dict[str, str]]:
+    violations: list[dict[str, str]] = []
+    for source in requirement.sources:
+        if source.source_type not in {RequirementSourceType.OPENSPEC_CHANGE, RequirementSourceType.SPECKIT_SPEC}:
+            continue
+        source_path = Path(source.locator)
+        if not source_path.is_file():
+            violations.append(
+                {
+                    "code": "source-missing",
+                    "severity": severity,
+                    "message": "Imported source artifact no longer exists.",
+                    "location": source.locator,
+                }
+            )
+            continue
+        if source.revision and source.revision.startswith("sha256:"):
+            current_revision = f"sha256:{hashlib.sha256(source_path.read_bytes()).hexdigest()}"
+            if current_revision != source.revision:
+                violations.append(
+                    {
+                        "code": "stale-import",
+                        "severity": severity,
+                        "message": "Imported source artifact content changed after import.",
+                        "location": source.locator,
+                    }
+                )
+    return violations
+
+
+def _ambiguous_mapping_violations(identities: Mapping[str, set[str]], *, severity: str) -> list[dict[str, str]]:
+    return [
+        {
+            "code": "ambiguous-mapping",
+            "severity": severity,
+            "message": "Multiple imported sources claim the same requirement identity.",
+            "location": f"requirements.inputs[{requirement_id}]",
+        }
+        for requirement_id, locators in identities.items()
+        if len(locators) > 1
+    ]
+
+
+def _import_gate_violations(requirements: Sequence[RequirementInput], *, severity: str) -> list[dict[str, str]]:
+    violations: list[dict[str, str]] = []
+    identities: dict[str, set[str]] = {}
+    for requirement in requirements:
+        if not _is_imported_requirement(requirement):
+            continue
+        identities.setdefault(requirement.requirement_id, set()).update(
+            source.locator for source in requirement.sources
+        )
+        scenario_violation = _scenario_unverified_violation(requirement, severity=severity)
+        if scenario_violation:
+            violations.append(scenario_violation)
+        violations.extend(_source_integrity_violations(requirement, severity=severity))
+    violations.extend(_ambiguous_mapping_violations(identities, severity=severity))
+    return violations
+
+
+def _required_field_violations(
+    requirements: Sequence[RequirementInput],
+    required_fields: Sequence[str],
+    *,
+    severity: str,
+) -> list[dict[str, str]]:
+    imported_requirements = [requirement for requirement in requirements if _is_imported_requirement(requirement)]
+    if not imported_requirements:
+        return []
+
+    violations: list[dict[str, str]] = []
+    for field in required_fields:
+        attribute = _REQUIRED_FIELD_ALIASES.get(field)
+        if attribute is None:
+            violations.append(
+                {
+                    "code": "unsupported-profile-field",
+                    "severity": "info",
+                    "message": "Profile field is not represented by the import-first requirements evidence schema.",
+                    "location": f"requirements_schema.required_fields[{field}]",
+                }
+            )
+            continue
+        for requirement in imported_requirements:
+            value = getattr(requirement, attribute)
+            if not value:
+                violations.append(
+                    {
+                        "code": "required-field-missing",
+                        "severity": severity,
+                        "message": f"Required evidence field '{field}' is missing.",
+                        "location": f"requirements.inputs[{requirement.requirement_id}].{attribute}",
+                    }
+                )
+    return violations
 
 
 def _validation_status(failed: int, warnings: int) -> Literal["passed", "failed", "warnings"]:
@@ -307,21 +488,34 @@ def _validation_summary(
 
 @beartype
 @require(lambda bundle: isinstance(bundle, ProjectBundle), "bundle must be a ProjectBundle")
-@require(_profile_nonempty, "profile must not be empty")
-@require(_profile_supported, "profile must be a supported requirements context validation profile")
+@require(
+    _optional_profile_supported, "profile must be a supported requirements context validation profile when provided"
+)
+@require(_project_root_supported, "project_root must be a Path when provided")
 @ensure(lambda result: isinstance(result, ValidationReport))
 def validate_requirement_context(
     bundle: ProjectBundle,
     *,
-    profile: RequirementContextValidationProfile = "startup",
+    profile: RequirementContextValidationProfile | None = None,
+    project_root: Path | None = None,
 ) -> ValidationReport:
     """Validate requirements context evidence usefulness for a ProjectBundle."""
     requirements = load_requirements_from_bundle(bundle)
     if not requirements:
         return _empty_requirements_report()
 
+    effective_profile, resolved_config = _resolve_requirement_profile(profile, project_root)
+    severity = _missing_evidence_severity(cast(RequirementContextValidationProfile, effective_profile))
     coverage = inspect_requirement_context_coverage(requirements)
-    violations = _missing_evidence_violations(coverage, severity=_missing_evidence_severity(profile))
+    violations = _missing_evidence_violations(coverage, severity=severity)
+    violations.extend(_import_gate_violations(requirements, severity=severity))
+    violations.extend(
+        _required_field_violations(
+            requirements,
+            _requirements_schema_fields(resolved_config),
+            severity=severity,
+        )
+    )
     summary = _validation_summary(requirements, coverage, violations)
     return ValidationReport(
         status=_validation_status(summary["failed"], summary["warnings"]),

--- a/src/specfact_cli/requirements/importers.py
+++ b/src/specfact_cli/requirements/importers.py
@@ -42,6 +42,16 @@ def _slug(value: str) -> str:
     return re.sub(r"-+", "-", re.sub(r"[^a-z0-9]+", "-", value.lower())).strip("-") or "requirement"
 
 
+def _unique_requirement_id(base_id: str, seen_ids: set[str]) -> str:
+    candidate = base_id
+    ordinal = 2
+    while candidate in seen_ids:
+        candidate = f"{base_id}-{ordinal}"
+        ordinal += 1
+    seen_ids.add(candidate)
+    return candidate
+
+
 def _source_revision(path: Path) -> str:
     return f"sha256:{hashlib.sha256(path.read_bytes()).hexdigest()}"
 
@@ -97,7 +107,7 @@ def _missing_source_result(source: Path, source_type: RequirementSourceType) -> 
         diagnostics=[
             RequirementContextDiagnostic(
                 severity=RequirementContextDiagnosticSeverity.ERROR,
-                code="source_missing",
+                code="source-missing",
                 message=f"Required {source_type.value} source does not exist.",
                 source_locator=str(source),
             )
@@ -123,16 +133,16 @@ def _unsupported_source_result(
 
 
 def _load_schema_name(path: Path) -> str | None:
-    if not path.is_file():
-        return None
     try:
+        if not path.is_file():
+            return None
         data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    except yaml.YAMLError:
+    except (OSError, yaml.YAMLError):
         return "<invalid>"
     if not isinstance(data, dict):
         return "<invalid>"
     schema = cast(dict[str, object], data).get("schema")
-    return schema if isinstance(schema, str) else None
+    return "<invalid>" if "schema" in data and not isinstance(schema, str) else cast(str | None, schema)
 
 
 def _openspec_compatibility_error(change_dir: Path, spec_paths: list[Path]) -> RequirementContextImportResult | None:
@@ -195,9 +205,9 @@ def _import_result_has_requirements(result: RequirementContextImportResult) -> b
     return all(isinstance(record, RequirementInput) for record in result.requirements)
 
 
-@beartype
 @require(lambda change_dir: isinstance(change_dir, Path), "change_dir must be a Path")
 @ensure(_import_result_has_requirements)
+@beartype
 def import_openspec_change(change_dir: Path) -> RequirementContextImportResult:
     """Normalize one native OpenSpec change directory without modifying it."""
     if not change_dir.is_dir():
@@ -209,21 +219,16 @@ def import_openspec_change(change_dir: Path) -> RequirementContextImportResult:
         return compatibility_error
 
     parser = OpenSpecParser()
-    proposal_path = change_dir / "proposal.md"
-    tasks_path = change_dir / "tasks.md"
-    parser.parse_change_proposal(proposal_path)
-    if tasks_path.exists():
-        tasks_path.read_text(encoding="utf-8")
-
     requirements: list[RequirementInput] = []
     diagnostics: list[RequirementContextDiagnostic] = []
+    seen_requirement_ids: set[str] = set()
     for spec_path in spec_paths:
         parsed = parser.parse_change_spec_delta(spec_path)
         if parsed is None:
             diagnostics.append(
                 RequirementContextDiagnostic(
                     severity=RequirementContextDiagnosticSeverity.ERROR,
-                    code="source_missing",
+                    code="source-missing",
                     message="OpenSpec delta specification could not be read.",
                     source_locator=str(spec_path),
                 )
@@ -241,7 +246,10 @@ def import_openspec_change(change_dir: Path) -> RequirementContextImportResult:
             r"^### Requirement:\s*(.+?)\n(.*?)(?=^### Requirement:|\Z)", content, re.MULTILINE | re.DOTALL
         ):
             title = match.group(1).strip()
-            requirement_id = f"openspec:{change_dir.name}:{capability}:{_slug(title)}"
+            requirement_id = _unique_requirement_id(
+                f"openspec:{change_dir.name}:{capability}:{_slug(title)}",
+                seen_requirement_ids,
+            )
             body = match.group(2).strip()
             summary = body.split("#### Scenario:", maxsplit=1)[0].strip() or None
             requirements.append(
@@ -257,9 +265,9 @@ def import_openspec_change(change_dir: Path) -> RequirementContextImportResult:
     return RequirementContextImportResult(requirements=requirements, diagnostics=diagnostics)
 
 
-@beartype
 @require(lambda feature_dir: isinstance(feature_dir, Path), "feature_dir must be a Path")
 @ensure(_import_result_has_requirements)
+@beartype
 def import_speckit_feature(feature_dir: Path) -> RequirementContextImportResult:
     """Normalize one native Spec Kit feature directory without modifying it."""
     spec_path = feature_dir / "spec.md"
@@ -282,6 +290,7 @@ def import_speckit_feature(feature_dir: Path) -> RequirementContextImportResult:
         revision=_source_revision(spec_path),
     )
     requirements: list[RequirementInput] = []
+    seen_requirement_ids: set[str] = set()
     raw_requirements = cast(list[object], parsed.get("requirements", []))
     for raw_requirement in raw_requirements:
         if not isinstance(raw_requirement, dict):
@@ -290,7 +299,10 @@ def import_speckit_feature(feature_dir: Path) -> RequirementContextImportResult:
         summary = str(requirement_values.get("text", "")).strip()
         if not summary:
             continue
-        requirement_id = f"speckit:{feature_dir.name}:{_slug(summary)}"
+        requirement_id = _unique_requirement_id(
+            f"speckit:{feature_dir.name}:{_slug(summary)}",
+            seen_requirement_ids,
+        )
         requirements.append(
             RequirementInput(
                 schema_version="1",

--- a/src/specfact_cli/requirements/importers.py
+++ b/src/specfact_cli/requirements/importers.py
@@ -137,7 +137,7 @@ def _load_schema_name(path: Path) -> str | None:
         if not path.is_file():
             return None
         data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    except (OSError, yaml.YAMLError):
+    except (OSError, UnicodeDecodeError, yaml.YAMLError):
         return "<invalid>"
     if not isinstance(data, dict):
         return "<invalid>"

--- a/src/specfact_cli/requirements/importers.py
+++ b/src/specfact_cli/requirements/importers.py
@@ -1,0 +1,304 @@
+"""Read-only normalizers for native OpenSpec and Spec Kit requirement evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+from typing import cast
+
+import yaml
+from beartype import beartype
+from icontract import ensure, require
+
+from specfact_cli.adapters.openspec_parser import OpenSpecParser
+from specfact_cli.importers.speckit_scanner import SpecKitScanner
+from specfact_cli.models.requirements import (
+    BusinessRule,
+    RequirementInput,
+    RequirementSourceReference,
+    RequirementSourceType,
+)
+from specfact_cli.requirements.context import (
+    RequirementContextDiagnostic,
+    RequirementContextDiagnosticSeverity,
+    RequirementContextImportResult,
+)
+
+
+_DEFAULT_OPENSPEC_SCHEMA = "spec-driven"
+_OPENSPEC_REQUIREMENT_PATTERN = re.compile(r"^### Requirement:\s+.+$", re.MULTILINE)
+_OPENSPEC_SCENARIO_PATTERN = re.compile(r"^#### Scenario:\s+.+$", re.MULTILINE)
+_SPECKIT_TITLE_PATTERN = re.compile(r"^# Feature Specification:\s+.+$", re.MULTILINE)
+_SPECKIT_REQUIREMENT_PATTERN = re.compile(r"^\s*-?\s*\*\*FR-\d+\*\*:\s*System MUST\s+.+$", re.MULTILINE)
+_SPECKIT_CUSTOMIZATION_ROOTS = (
+    Path(".specify/templates/overrides"),
+    Path(".specify/presets"),
+    Path(".specify/extensions"),
+)
+
+
+def _slug(value: str) -> str:
+    return re.sub(r"-+", "-", re.sub(r"[^a-z0-9]+", "-", value.lower())).strip("-") or "requirement"
+
+
+def _source_revision(path: Path) -> str:
+    return f"sha256:{hashlib.sha256(path.read_bytes()).hexdigest()}"
+
+
+def _scenario_rules(requirement_id: str, content: str) -> list[BusinessRule]:
+    rules: list[BusinessRule] = []
+    scenario_pattern = re.compile(
+        r"^#### Scenario:\s*(.+?)\n(.*?)(?=^#### Scenario:|^### Requirement:|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    for match in scenario_pattern.finditer(content):
+        name = match.group(1).strip()
+        body = match.group(2)
+        clauses: dict[str, str] = {}
+        for clause in ("given", "when", "then"):
+            clause_match = re.search(rf"^- \*\*{clause.upper()}\*\*\s+(.+)$", body, re.MULTILINE | re.IGNORECASE)
+            if clause_match:
+                clauses[clause] = clause_match.group(1).strip()
+        if len(clauses) == 3:
+            rules.append(
+                BusinessRule(
+                    rule_id=f"{requirement_id}:{_slug(name)}",
+                    name=name,
+                    given=clauses["given"],
+                    when=clauses["when"],
+                    then=clauses["then"],
+                )
+            )
+    return rules
+
+
+def _speckit_rules(requirement_id: str, content: str) -> list[BusinessRule]:
+    rules: list[BusinessRule] = []
+    pattern = re.compile(
+        r"\*\*Given\*\*\s+(.+?),\s*\*\*When\*\*\s+(.+?),\s*\*\*Then\*\*\s+(.+?)(?=\n|$)",
+        re.IGNORECASE,
+    )
+    for index, match in enumerate(pattern.finditer(content), start=1):
+        rules.append(
+            BusinessRule(
+                rule_id=f"{requirement_id}:scenario-{index}",
+                name=f"Acceptance scenario {index}",
+                given=match.group(1).strip(),
+                when=match.group(2).strip(),
+                then=match.group(3).strip(),
+            )
+        )
+    return rules
+
+
+def _missing_source_result(source: Path, source_type: RequirementSourceType) -> RequirementContextImportResult:
+    return RequirementContextImportResult(
+        diagnostics=[
+            RequirementContextDiagnostic(
+                severity=RequirementContextDiagnosticSeverity.ERROR,
+                code="source_missing",
+                message=f"Required {source_type.value} source does not exist.",
+                source_locator=str(source),
+            )
+        ]
+    )
+
+
+def _unsupported_source_result(
+    source: Path,
+    source_type: RequirementSourceType,
+    message: str,
+) -> RequirementContextImportResult:
+    return RequirementContextImportResult(
+        diagnostics=[
+            RequirementContextDiagnostic(
+                severity=RequirementContextDiagnosticSeverity.ERROR,
+                code="unsupported-source-schema",
+                message=message,
+                source_locator=str(source),
+            )
+        ]
+    )
+
+
+def _load_schema_name(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError:
+        return "<invalid>"
+    if not isinstance(data, dict):
+        return "<invalid>"
+    schema = cast(dict[str, object], data).get("schema")
+    return schema if isinstance(schema, str) else None
+
+
+def _openspec_compatibility_error(change_dir: Path, spec_paths: list[Path]) -> RequirementContextImportResult | None:
+    config_paths = (change_dir.parent.parent / "config.yaml", change_dir / ".openspec.yaml")
+    for config_path in config_paths:
+        schema = _load_schema_name(config_path)
+        if schema is not None and schema != _DEFAULT_OPENSPEC_SCHEMA:
+            return _unsupported_source_result(
+                config_path,
+                RequirementSourceType.OPENSPEC_CHANGE,
+                "OpenSpec schema is not supported by the default evidence import profile.",
+            )
+    if not spec_paths:
+        return _unsupported_source_result(
+            change_dir,
+            RequirementSourceType.OPENSPEC_CHANGE,
+            "OpenSpec change has no default-profile spec.md artifact to import.",
+        )
+    for spec_path in spec_paths:
+        content = spec_path.read_text(encoding="utf-8")
+        if not (_OPENSPEC_REQUIREMENT_PATTERN.search(content) and _OPENSPEC_SCENARIO_PATTERN.search(content)):
+            return _unsupported_source_result(
+                spec_path,
+                RequirementSourceType.OPENSPEC_CHANGE,
+                "OpenSpec artifact does not match the supported default requirement/scenario Markdown profile.",
+            )
+    return None
+
+
+def _speckit_project_root(feature_dir: Path) -> Path | None:
+    for directory in (feature_dir.parent, *feature_dir.parents):
+        if (directory / ".specify").is_dir():
+            return directory
+    return None
+
+
+def _speckit_compatibility_error(
+    feature_dir: Path, spec_path: Path, content: str
+) -> RequirementContextImportResult | None:
+    project_root = _speckit_project_root(feature_dir)
+    if project_root:
+        for customization_root in _SPECKIT_CUSTOMIZATION_ROOTS:
+            path = project_root / customization_root
+            if path.exists():
+                return _unsupported_source_result(
+                    path,
+                    RequirementSourceType.SPECKIT_SPEC,
+                    "Spec Kit template customization is not supported by the default evidence import profile.",
+                )
+    if not (_SPECKIT_TITLE_PATTERN.search(content) and _SPECKIT_REQUIREMENT_PATTERN.search(content)):
+        return _unsupported_source_result(
+            spec_path,
+            RequirementSourceType.SPECKIT_SPEC,
+            "Spec Kit artifact does not match the supported default Markdown template profile.",
+        )
+    return None
+
+
+def _import_result_has_requirements(result: RequirementContextImportResult) -> bool:
+    return all(isinstance(record, RequirementInput) for record in result.requirements)
+
+
+@beartype
+@require(lambda change_dir: isinstance(change_dir, Path), "change_dir must be a Path")
+@ensure(_import_result_has_requirements)
+def import_openspec_change(change_dir: Path) -> RequirementContextImportResult:
+    """Normalize one native OpenSpec change directory without modifying it."""
+    if not change_dir.is_dir():
+        return _missing_source_result(change_dir, RequirementSourceType.OPENSPEC_CHANGE)
+
+    spec_paths = sorted((change_dir / "specs").glob("*/spec.md"))
+    compatibility_error = _openspec_compatibility_error(change_dir, spec_paths)
+    if compatibility_error:
+        return compatibility_error
+
+    parser = OpenSpecParser()
+    proposal_path = change_dir / "proposal.md"
+    tasks_path = change_dir / "tasks.md"
+    parser.parse_change_proposal(proposal_path)
+    if tasks_path.exists():
+        tasks_path.read_text(encoding="utf-8")
+
+    requirements: list[RequirementInput] = []
+    diagnostics: list[RequirementContextDiagnostic] = []
+    for spec_path in spec_paths:
+        parsed = parser.parse_change_spec_delta(spec_path)
+        if parsed is None:
+            diagnostics.append(
+                RequirementContextDiagnostic(
+                    severity=RequirementContextDiagnosticSeverity.ERROR,
+                    code="source_missing",
+                    message="OpenSpec delta specification could not be read.",
+                    source_locator=str(spec_path),
+                )
+            )
+            continue
+        content = str(parsed.get("raw_content", ""))
+        capability = spec_path.parent.name
+        source = RequirementSourceReference(
+            source_type=RequirementSourceType.OPENSPEC_CHANGE,
+            locator=str(spec_path),
+            title=capability,
+            revision=_source_revision(spec_path),
+        )
+        for match in re.finditer(
+            r"^### Requirement:\s*(.+?)\n(.*?)(?=^### Requirement:|\Z)", content, re.MULTILINE | re.DOTALL
+        ):
+            title = match.group(1).strip()
+            requirement_id = f"openspec:{change_dir.name}:{capability}:{_slug(title)}"
+            body = match.group(2).strip()
+            summary = body.split("#### Scenario:", maxsplit=1)[0].strip() or None
+            requirements.append(
+                RequirementInput(
+                    schema_version="1",
+                    requirement_id=requirement_id,
+                    title=title,
+                    summary=summary,
+                    sources=[source],
+                    business_rules=_scenario_rules(requirement_id, body),
+                )
+            )
+    return RequirementContextImportResult(requirements=requirements, diagnostics=diagnostics)
+
+
+@beartype
+@require(lambda feature_dir: isinstance(feature_dir, Path), "feature_dir must be a Path")
+@ensure(_import_result_has_requirements)
+def import_speckit_feature(feature_dir: Path) -> RequirementContextImportResult:
+    """Normalize one native Spec Kit feature directory without modifying it."""
+    spec_path = feature_dir / "spec.md"
+    if not feature_dir.is_dir() or not spec_path.is_file():
+        return _missing_source_result(feature_dir, RequirementSourceType.SPECKIT_SPEC)
+
+    content = spec_path.read_text(encoding="utf-8")
+    compatibility_error = _speckit_compatibility_error(feature_dir, spec_path, content)
+    if compatibility_error:
+        return compatibility_error
+
+    parsed = SpecKitScanner(feature_dir.parent).parse_spec_markdown(spec_path)
+    if parsed is None:
+        return _missing_source_result(spec_path, RequirementSourceType.SPECKIT_SPEC)
+
+    source = RequirementSourceReference(
+        source_type=RequirementSourceType.SPECKIT_SPEC,
+        locator=str(spec_path),
+        title=str(parsed.get("feature_title") or feature_dir.name),
+        revision=_source_revision(spec_path),
+    )
+    requirements: list[RequirementInput] = []
+    raw_requirements = cast(list[object], parsed.get("requirements", []))
+    for raw_requirement in raw_requirements:
+        if not isinstance(raw_requirement, dict):
+            continue
+        requirement_values = cast(dict[str, object], raw_requirement)
+        summary = str(requirement_values.get("text", "")).strip()
+        if not summary:
+            continue
+        requirement_id = f"speckit:{feature_dir.name}:{_slug(summary)}"
+        requirements.append(
+            RequirementInput(
+                schema_version="1",
+                requirement_id=requirement_id,
+                title=summary[:1].upper() + summary[1:],
+                summary=summary,
+                sources=[source],
+                business_rules=_speckit_rules(requirement_id, content),
+            )
+        )
+    return RequirementContextImportResult(requirements=requirements)

--- a/tests/unit/requirements/test_upstream_evidence_imports.py
+++ b/tests/unit/requirements/test_upstream_evidence_imports.py
@@ -1,0 +1,325 @@
+"""Tests for native OpenSpec and Spec Kit requirement evidence imports."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from specfact_cli.models.plan import Product
+from specfact_cli.models.project import BundleManifest, BundleVersions, ProjectBundle
+from specfact_cli.models.requirements import (
+    BusinessRule,
+    RequirementEvidenceLink,
+    RequirementEvidenceLinkType,
+    RequirementInput,
+    RequirementSourceReference,
+    RequirementSourceType,
+)
+from specfact_cli.requirements import (
+    attach_requirements_to_bundle,
+    import_openspec_change,
+    import_speckit_feature,
+    validate_requirement_context,
+)
+
+
+def _bundle() -> ProjectBundle:
+    """Return a minimal bundle that can carry requirements evidence."""
+    return ProjectBundle(
+        manifest=BundleManifest(
+            versions=BundleVersions(schema="1.0", project="0.1.0"),
+            schema_metadata=None,
+            project_metadata=None,
+        ),
+        bundle_name="test",
+        product=Product(themes=[], releases=[]),
+    )
+
+
+def _write_openspec_change(change_dir: Path) -> Path:
+    """Create one native OpenSpec change fixture."""
+    spec_file = change_dir / "specs" / "widgets" / "spec.md"
+    spec_file.parent.mkdir(parents=True)
+    (change_dir / "proposal.md").write_text("# Change: Widget evidence\n", encoding="utf-8")
+    (change_dir / "tasks.md").write_text("# Tasks: Widget evidence\n", encoding="utf-8")
+    spec_file.write_text(
+        """## ADDED Requirements
+
+### Requirement: Widget rendering
+
+The system SHALL render a widget.
+
+#### Scenario: Render a valid widget
+
+- **GIVEN** a valid widget request
+- **WHEN** rendering runs
+- **THEN** the widget is returned
+""",
+        encoding="utf-8",
+    )
+    return spec_file
+
+
+def _write_speckit_feature(feature_dir: Path) -> Path:
+    """Create one native Spec Kit feature fixture."""
+    spec_file = feature_dir / "spec.md"
+    feature_dir.mkdir(parents=True)
+    spec_file.write_text(
+        """# Feature Specification: Widget rendering
+
+## User Scenarios & Testing
+
+### User Story 1 - Render widgets (Priority: P1)
+
+As a user, I want widgets rendered so that I can see them.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid widget request, **When** rendering runs, **Then** the widget is returned
+
+## Requirements
+
+- **FR-001**: System MUST render a widget
+""",
+        encoding="utf-8",
+    )
+    return spec_file
+
+
+def test_import_openspec_change_normalizes_scenarios_hashes_and_preserves_source(tmp_path: Path) -> None:
+    """OpenSpec imports derive stable requirements without changing source artifacts."""
+    change_dir = tmp_path / "openspec" / "changes" / "widget-evidence"
+    spec_file = _write_openspec_change(change_dir)
+    before = spec_file.read_bytes()
+
+    result = import_openspec_change(change_dir)
+
+    assert result.diagnostics == []
+    assert [record.requirement_id for record in result.requirements] == [
+        "openspec:widget-evidence:widgets:widget-rendering"
+    ]
+    requirement = result.requirements[0]
+    assert requirement.sources[0].source_type == RequirementSourceType.OPENSPEC_CHANGE
+    assert requirement.sources[0].locator == str(spec_file)
+    assert requirement.sources[0].revision is not None
+    assert requirement.sources[0].revision.startswith("sha256:")
+    assert requirement.business_rules[0].model_dump() == {
+        "rule_id": "openspec:widget-evidence:widgets:widget-rendering:render-a-valid-widget",
+        "name": "Render a valid widget",
+        "given": "a valid widget request",
+        "when": "rendering runs",
+        "then": "the widget is returned",
+        "priority": None,
+    }
+    assert import_openspec_change(change_dir).model_dump() == result.model_dump()
+    assert spec_file.read_bytes() == before
+
+
+def test_import_speckit_feature_normalizes_requirement_and_scenario(tmp_path: Path) -> None:
+    """Spec Kit imports use the existing scanner while preserving G/W/T evidence."""
+    feature_dir = tmp_path / "specs" / "001-widget-rendering"
+    spec_file = _write_speckit_feature(feature_dir)
+
+    result = import_speckit_feature(feature_dir)
+
+    assert result.diagnostics == []
+    assert [record.requirement_id for record in result.requirements] == ["speckit:001-widget-rendering:render-a-widget"]
+    requirement = result.requirements[0]
+    assert requirement.sources[0].source_type == RequirementSourceType.SPECKIT_SPEC
+    assert requirement.sources[0].locator == str(spec_file)
+    assert requirement.sources[0].revision is not None
+    assert requirement.sources[0].revision.startswith("sha256:")
+    assert requirement.business_rules[0].given == "a valid widget request"
+    assert requirement.business_rules[0].when == "rendering runs"
+    assert requirement.business_rules[0].then == "the widget is returned"
+
+
+def test_import_openspec_change_rejects_custom_schema_without_partial_records(tmp_path: Path) -> None:
+    """Custom OpenSpec schemas fail closed until a core profile explicitly supports them."""
+    change_dir = tmp_path / "openspec" / "changes" / "widget-evidence"
+    _write_openspec_change(change_dir)
+    (change_dir.parent.parent / "config.yaml").write_text("schema: company-custom\n", encoding="utf-8")
+
+    result = import_openspec_change(change_dir)
+
+    assert result.requirements == []
+    assert [(diagnostic.code, diagnostic.severity) for diagnostic in result.diagnostics] == [
+        ("unsupported-source-schema", "error")
+    ]
+
+
+def test_import_openspec_change_rejects_change_local_custom_schema_without_partial_records(tmp_path: Path) -> None:
+    """A change-local OpenSpec schema declaration is as authoritative as project configuration."""
+    change_dir = tmp_path / "openspec" / "changes" / "widget-evidence"
+    _write_openspec_change(change_dir)
+    (change_dir / ".openspec.yaml").write_text("schema: company-custom\n", encoding="utf-8")
+
+    result = import_openspec_change(change_dir)
+
+    assert result.requirements == []
+    assert result.diagnostics[0].code == "unsupported-source-schema"
+
+
+@pytest.mark.parametrize(
+    "customization_root",
+    [
+        Path(".specify/templates/overrides"),
+        Path(".specify/presets"),
+        Path(".specify/extensions"),
+    ],
+)
+def test_import_speckit_feature_rejects_template_customization_without_partial_records(
+    tmp_path: Path,
+    customization_root: Path,
+) -> None:
+    """Spec Kit override roots fail closed rather than being parsed with default assumptions."""
+    feature_dir = tmp_path / "specs" / "001-widget-rendering"
+    _write_speckit_feature(feature_dir)
+    (tmp_path / customization_root).mkdir(parents=True)
+
+    result = import_speckit_feature(feature_dir)
+
+    assert result.requirements == []
+    assert [(diagnostic.code, diagnostic.severity) for diagnostic in result.diagnostics] == [
+        ("unsupported-source-schema", "error")
+    ]
+
+
+def test_imports_reject_unknown_default_profile_markers_without_partial_records(tmp_path: Path) -> None:
+    """Unrecognized Markdown markers cannot silently produce an empty or partial import."""
+    change_dir = tmp_path / "openspec" / "changes" / "widget-evidence"
+    open_spec_file = _write_openspec_change(change_dir)
+    open_spec_file.write_text("## ADDED Functional Requirements\n", encoding="utf-8")
+    feature_dir = tmp_path / "specs" / "001-widget-rendering"
+    speckit_file = _write_speckit_feature(feature_dir)
+    speckit_file.write_text("# Product Requirements\n\n- Render a widget\n", encoding="utf-8")
+
+    openspec_result = import_openspec_change(change_dir)
+    speckit_result = import_speckit_feature(feature_dir)
+
+    assert openspec_result.requirements == []
+    assert speckit_result.requirements == []
+    assert openspec_result.diagnostics[0].code == "unsupported-source-schema"
+    assert speckit_result.diagnostics[0].code == "unsupported-source-schema"
+
+
+def test_validation_reports_import_gates_and_profile_required_field_advisories(tmp_path: Path) -> None:
+    """Validation distinguishes import failures from unsupported profile metadata."""
+    source_file = tmp_path / "missing-after-import.md"
+    requirement = RequirementInput(
+        schema_version="1",
+        requirement_id="openspec:widget-evidence:widgets:widget-rendering",
+        title="Widget rendering",
+        sources=[
+            RequirementSourceReference(
+                source_type=RequirementSourceType.OPENSPEC_CHANGE,
+                locator=str(source_file),
+                revision="sha256:0123456789abcdef",
+            )
+        ],
+        business_rules=[
+            BusinessRule(
+                rule_id="rule-1",
+                name="Render a valid widget",
+                given="a valid widget request",
+                when="rendering runs",
+                then="the widget is returned",
+            )
+        ],
+        evidence_links=[
+            RequirementEvidenceLink(
+                link_type=RequirementEvidenceLinkType.TEST,
+                target="tests/unit/requirements/test_upstream_evidence_imports.py",
+            )
+        ],
+    )
+    bundle = attach_requirements_to_bundle(_bundle(), [requirement])
+
+    report = validate_requirement_context(bundle, profile="enterprise", project_root=tmp_path)
+
+    assert report.status == "failed"
+    assert {violation["code"] for violation in report.violations} >= {
+        "source-missing",
+        "unsupported-profile-field",
+    }
+    assert all(
+        violation["code"] != "required-field-missing" or violation["location"] != "requirements.inputs[0].owner"
+        for violation in report.violations
+    )
+
+
+def _imported_requirement(source_file: Path, *, revision: str, with_test_link: bool) -> RequirementInput:
+    """Return an imported requirement fixture with one G/W/T scenario."""
+    evidence_links = (
+        [
+            RequirementEvidenceLink(
+                link_type=RequirementEvidenceLinkType.TEST,
+                target="tests/unit/requirements/test_upstream_evidence_imports.py",
+            )
+        ]
+        if with_test_link
+        else []
+    )
+    return RequirementInput(
+        schema_version="1",
+        requirement_id="openspec:widget-evidence:widgets:widget-rendering",
+        title="Widget rendering",
+        sources=[
+            RequirementSourceReference(
+                source_type=RequirementSourceType.OPENSPEC_CHANGE,
+                locator=str(source_file),
+                revision=revision,
+            )
+        ],
+        business_rules=[
+            BusinessRule(
+                rule_id="rule-1",
+                name="Render a valid widget",
+                given="a valid widget request",
+                when="rendering runs",
+                then="the widget is returned",
+            )
+        ],
+        evidence_links=evidence_links,
+    )
+
+
+def test_validation_reports_scenario_stale_and_ambiguous_import_gates(tmp_path: Path) -> None:
+    """Every deterministic import gate is surfaced without heuristic matching."""
+    source_a = tmp_path / "source-a.md"
+    source_b = tmp_path / "source-b.md"
+    source_a.write_text("source A", encoding="utf-8")
+    source_b.write_text("source B", encoding="utf-8")
+    requirements = [
+        _imported_requirement(source_a, revision="sha256:outdated", with_test_link=False),
+        _imported_requirement(source_b, revision="sha256:outdated", with_test_link=True),
+    ]
+    bundle = attach_requirements_to_bundle(_bundle(), requirements)
+
+    report = validate_requirement_context(bundle, profile="solo", project_root=tmp_path)
+
+    assert {violation["code"] for violation in report.violations} >= {
+        "scenario-unverified",
+        "stale-import",
+        "ambiguous-mapping",
+    }
+
+
+def test_omitted_profile_uses_layered_configuration_and_explicit_profile_wins(tmp_path: Path) -> None:
+    """Profile resolution changes severity only when callers do not specify one."""
+    source_file = tmp_path / "source.md"
+    source_file.write_text("source", encoding="utf-8")
+    config_dir = tmp_path / ".specfact"
+    config_dir.mkdir()
+    (config_dir / "config.yaml").write_text("profile: enterprise\n", encoding="utf-8")
+    bundle = attach_requirements_to_bundle(
+        _bundle(),
+        [_imported_requirement(source_file, revision="sha256:outdated", with_test_link=False)],
+    )
+
+    configured_report = validate_requirement_context(bundle, project_root=tmp_path)
+    explicit_report = validate_requirement_context(bundle, profile="solo", project_root=tmp_path)
+
+    assert configured_report.status == "failed"
+    assert explicit_report.status == "warnings"

--- a/tests/unit/requirements/test_upstream_evidence_imports.py
+++ b/tests/unit/requirements/test_upstream_evidence_imports.py
@@ -178,6 +178,18 @@ def test_import_openspec_change_rejects_non_string_schema_without_partial_record
     assert result.diagnostics[0].code == "unsupported-source-schema"
 
 
+def test_import_openspec_change_rejects_invalid_utf8_schema_without_partial_records(tmp_path: Path) -> None:
+    """Unreadable schema configuration fails closed instead of crashing the import."""
+    change_dir = tmp_path / "openspec" / "changes" / "widget-evidence"
+    _write_openspec_change(change_dir)
+    (change_dir.parent.parent / "config.yaml").write_bytes(b"schema: \xff\n")
+
+    result = import_openspec_change(change_dir)
+
+    assert result.requirements == []
+    assert result.diagnostics[0].code == "unsupported-source-schema"
+
+
 @pytest.mark.parametrize(
     "customization_root",
     [

--- a/tests/unit/requirements/test_upstream_evidence_imports.py
+++ b/tests/unit/requirements/test_upstream_evidence_imports.py
@@ -264,32 +264,10 @@ The system SHALL render a fallback widget.
 def test_validation_reports_import_gates_and_profile_required_field_advisories(tmp_path: Path) -> None:
     """Validation distinguishes import failures from unsupported profile metadata."""
     source_file = tmp_path / "missing-after-import.md"
-    requirement = RequirementInput(
-        schema_version="1",
-        requirement_id="openspec:widget-evidence:widgets:widget-rendering",
-        title="Widget rendering",
-        sources=[
-            RequirementSourceReference(
-                source_type=RequirementSourceType.OPENSPEC_CHANGE,
-                locator=str(source_file),
-                revision="sha256:0123456789abcdef",
-            )
-        ],
-        business_rules=[
-            BusinessRule(
-                rule_id="rule-1",
-                name="Render a valid widget",
-                given="a valid widget request",
-                when="rendering runs",
-                then="the widget is returned",
-            )
-        ],
-        evidence_links=[
-            RequirementEvidenceLink(
-                link_type=RequirementEvidenceLinkType.TEST,
-                target="tests/unit/requirements/test_upstream_evidence_imports.py",
-            )
-        ],
+    requirement = _imported_requirement(
+        source_file,
+        revision="sha256:0123456789abcdef",
+        with_test_link=True,
     )
     bundle = attach_requirements_to_bundle(_bundle(), [requirement])
 

--- a/tests/unit/requirements/test_upstream_evidence_imports.py
+++ b/tests/unit/requirements/test_upstream_evidence_imports.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 
 import pytest
@@ -161,6 +162,22 @@ def test_import_openspec_change_rejects_change_local_custom_schema_without_parti
     assert result.diagnostics[0].code == "unsupported-source-schema"
 
 
+@pytest.mark.parametrize("schema_value", ["123", "true", "null", "{profile: default}"])
+def test_import_openspec_change_rejects_non_string_schema_without_partial_records(
+    tmp_path: Path,
+    schema_value: str,
+) -> None:
+    """Malformed schema declarations cannot fall through to the default profile."""
+    change_dir = tmp_path / "openspec" / "changes" / "widget-evidence"
+    _write_openspec_change(change_dir)
+    (change_dir.parent.parent / "config.yaml").write_text(f"schema: {schema_value}\n", encoding="utf-8")
+
+    result = import_openspec_change(change_dir)
+
+    assert result.requirements == []
+    assert result.diagnostics[0].code == "unsupported-source-schema"
+
+
 @pytest.mark.parametrize(
     "customization_root",
     [
@@ -204,6 +221,46 @@ def test_imports_reject_unknown_default_profile_markers_without_partial_records(
     assert speckit_result.diagnostics[0].code == "unsupported-source-schema"
 
 
+def test_importers_disambiguate_duplicate_derived_requirement_ids(tmp_path: Path) -> None:
+    """Repeated upstream titles and summaries retain distinct deterministic identities."""
+    change_dir = tmp_path / "openspec" / "changes" / "widget-evidence"
+    openspec_spec = _write_openspec_change(change_dir)
+    openspec_spec.write_text(
+        openspec_spec.read_text(encoding="utf-8")
+        + """
+
+### Requirement: Widget rendering
+
+The system SHALL render a fallback widget.
+
+#### Scenario: Render a fallback widget
+
+- **GIVEN** a fallback widget request
+- **WHEN** rendering runs
+- **THEN** the fallback widget is returned
+""",
+        encoding="utf-8",
+    )
+    feature_dir = tmp_path / "specs" / "001-widget-rendering"
+    speckit_spec = _write_speckit_feature(feature_dir)
+    speckit_spec.write_text(
+        speckit_spec.read_text(encoding="utf-8") + "\n- **FR-002**: System MUST render a widget\n",
+        encoding="utf-8",
+    )
+
+    openspec_result = import_openspec_change(change_dir)
+    speckit_result = import_speckit_feature(feature_dir)
+
+    assert [record.requirement_id for record in openspec_result.requirements] == [
+        "openspec:widget-evidence:widgets:widget-rendering",
+        "openspec:widget-evidence:widgets:widget-rendering-2",
+    ]
+    assert [record.requirement_id for record in speckit_result.requirements] == [
+        "speckit:001-widget-rendering:render-a-widget",
+        "speckit:001-widget-rendering:render-a-widget-2",
+    ]
+
+
 def test_validation_reports_import_gates_and_profile_required_field_advisories(tmp_path: Path) -> None:
     """Validation distinguishes import failures from unsupported profile metadata."""
     source_file = tmp_path / "missing-after-import.md"
@@ -244,7 +301,8 @@ def test_validation_reports_import_gates_and_profile_required_field_advisories(t
         "unsupported-profile-field",
     }
     assert all(
-        violation["code"] != "required-field-missing" or violation["location"] != "requirements.inputs[0].owner"
+        violation["code"] != "required-field-missing"
+        or violation["location"] != f"requirements.inputs[{requirement.requirement_id}].owner"
         for violation in report.violations
     )
 
@@ -306,13 +364,67 @@ def test_validation_reports_scenario_stale_and_ambiguous_import_gates(tmp_path: 
     }
 
 
+def test_validation_resolves_relative_source_locator_from_project_root(tmp_path: Path) -> None:
+    """Validation uses project_root rather than the process working directory for relative locators."""
+    source_file = tmp_path / "source.md"
+    source_file.write_text("source", encoding="utf-8")
+    requirement = _imported_requirement(
+        source_file,
+        revision=f"sha256:{hashlib.sha256(source_file.read_bytes()).hexdigest()}",
+        with_test_link=True,
+    ).model_copy(
+        update={
+            "sources": [
+                RequirementSourceReference(
+                    source_type=RequirementSourceType.OPENSPEC_CHANGE,
+                    locator="source.md",
+                    revision=f"sha256:{hashlib.sha256(source_file.read_bytes()).hexdigest()}",
+                )
+            ]
+        }
+    )
+
+    report = validate_requirement_context(
+        attach_requirements_to_bundle(_bundle(), [requirement]),
+        profile="solo",
+        project_root=tmp_path,
+    )
+
+    assert report.status == "passed"
+
+
+def test_validation_ignores_malformed_optional_config(tmp_path: Path) -> None:
+    """Unreadable optional configuration cannot prevent requirements validation."""
+    source_file = tmp_path / "source.md"
+    source_file.write_text("source", encoding="utf-8")
+    config_dir = tmp_path / ".specfact"
+    config_dir.mkdir()
+    (config_dir / "config.yaml").write_text("profile: [\n", encoding="utf-8")
+    requirement = _imported_requirement(
+        source_file,
+        revision=f"sha256:{hashlib.sha256(source_file.read_bytes()).hexdigest()}",
+        with_test_link=True,
+    )
+
+    report = validate_requirement_context(
+        attach_requirements_to_bundle(_bundle(), [requirement]),
+        profile="solo",
+        project_root=tmp_path,
+    )
+
+    assert report.status == "passed"
+
+
 def test_omitted_profile_uses_layered_configuration_and_explicit_profile_wins(tmp_path: Path) -> None:
     """Profile resolution changes severity only when callers do not specify one."""
     source_file = tmp_path / "source.md"
     source_file.write_text("source", encoding="utf-8")
     config_dir = tmp_path / ".specfact"
     config_dir.mkdir()
-    (config_dir / "config.yaml").write_text("profile: enterprise\n", encoding="utf-8")
+    (config_dir / "config.yaml").write_text(
+        "profile: enterprise\nrequirements_schema:\n  required_fields: [owner]\n",
+        encoding="utf-8",
+    )
     bundle = attach_requirements_to_bundle(
         _bundle(),
         [_imported_requirement(source_file, revision="sha256:outdated", with_test_link=False)],
@@ -323,3 +435,4 @@ def test_omitted_profile_uses_layered_configuration_and_explicit_profile_wins(tm
 
     assert configured_report.status == "failed"
     assert explicit_report.status == "warnings"
+    assert not any(violation["code"] == "required-field-missing" for violation in explicit_report.violations)


### PR DESCRIPTION
## Summary

- Import native OpenSpec and Spec Kit requirement evidence through core helpers.
- Validate source hashes, import gates, layered profile mappings, and required-field advisories.
- Fail closed for unsupported OpenSpec schemas and customized or unknown Spec Kit profiles.

## Why

Preserve upstream tools as authors while producing deterministic, auditable requirement evidence. Unrecognized formats produce an `unsupported-source-schema` diagnostic and no partial records.

## Validation

- `hatch run pytest tests/unit/requirements/test_upstream_evidence_imports.py tests/unit/requirements/test_context_adapter.py -q` (18 passed)
- `hatch run smart-test` (2,837 passed, 64.0% coverage)
- `hatch run contract-test`
- `hatch run specfact code review run --json --out .specfact/code-review.json` (no findings)
- Semgrep baseline and Bandit
- `openspec validate openspec-01-intent-trace --strict`

Closes #350
