### PR TITLE
feat(requirements): enforce evidence delivery gate

### DIFF
--- a/.github/workflows/requirements-evidence.yml
+++ b/.github/workflows/requirements-evidence.yml
@@ -57,8 +57,10 @@ jobs:
           actual="$(git -C specfact-cli-modules rev-parse HEAD)"
           test "$actual" = "$expected"
 
-      - name: Export verified module fixture path
-        run: echo "SPECFACT_MODULES_REPO=${GITHUB_WORKSPACE}/specfact-cli-modules" >> "$GITHUB_ENV"
+      - name: Export verified module fixture paths
+        run: |
+          echo "SPECFACT_MODULES_REPO=${GITHUB_WORKSPACE}/specfact-cli-modules" >> "$GITHUB_ENV"
+          echo "SPECFACT_MODULES_ROOTS=${GITHUB_WORKSPACE}/specfact-cli-modules/packages" >> "$GITHUB_ENV"
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405

--- a/.github/workflows/requirements-evidence.yml
+++ b/.github/workflows/requirements-evidence.yml
@@ -1,0 +1,103 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+# yamllint disable rule:line-length rule:truthy
+name: Requirements Evidence
+
+on:
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - "openspec/changes/**"
+      - "ci/module-fixture.lock.json"
+      - "scripts/requirements_evidence_delivery_gate.py"
+      - ".github/workflows/requirements-evidence.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  requirements-evidence:
+    name: Requirements evidence
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Read immutable module fixture
+        id: modules-fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+          repository="$(python -c 'import json; print(json.load(open("ci/module-fixture.lock.json", encoding="utf-8"))["repository"])')"
+          commit="$(python -c 'import json; print(json.load(open("ci/module-fixture.lock.json", encoding="utf-8"))["commit"])')"
+          [[ "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]
+          test "$repository" = "nold-ai/specfact-cli-modules"
+          [[ "$commit" =~ ^[0-9a-f]{40}$ ]]
+          printf 'repository=%s\n' "$repository" >> "$GITHUB_OUTPUT"
+          printf 'commit=%s\n' "$commit" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout module bundles repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          repository: ${{ steps.modules-fixture.outputs.repository }}
+          path: specfact-cli-modules
+          ref: ${{ steps.modules-fixture.outputs.commit }}
+          persist-credentials: false
+
+      - name: Verify immutable module fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected_repository="$(python -c 'import json; print(json.load(open("ci/module-fixture.lock.json", encoding="utf-8"))["repository"])')"
+          expected="$(python -c 'import json; print(json.load(open("ci/module-fixture.lock.json", encoding="utf-8"))["commit"])')"
+          test "$expected_repository" = "${{ steps.modules-fixture.outputs.repository }}"
+          actual="$(git -C specfact-cli-modules rev-parse HEAD)"
+          test "$actual" = "$expected"
+
+      - name: Export verified module fixture path
+        run: echo "SPECFACT_MODULES_REPO=${GITHUB_WORKSPACE}/specfact-cli-modules" >> "$GITHUB_ENV"
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+
+      - name: Set up frozen delivery dependencies
+        uses: ./.github/actions/setup-frozen-python
+
+      - name: Prepare Requirements evidence artifact directory
+        run: mkdir -p artifacts/requirements-evidence
+
+      - name: Run Requirements evidence gate
+        id: run-evidence
+        continue-on-error: true
+        run: |
+          hatch run specfact requirements evidence \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --base-ref "origin/${{ github.base_ref }}" \
+            --output artifacts/requirements-evidence/requirements-evidence.json \
+            --summary artifacts/requirements-evidence/requirements-evidence.md
+
+      - name: Publish Requirements evidence summary
+        if: always()
+        run: |
+          if [ -f artifacts/requirements-evidence/requirements-evidence.md ]; then
+            cat artifacts/requirements-evidence/requirements-evidence.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload requirements evidence artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: requirements-evidence
+          path: |
+            artifacts/requirements-evidence/requirements-evidence.json
+            artifacts/requirements-evidence/requirements-evidence.md
+          if-no-files-found: warn
+
+      - name: Enforce requirements evidence verdict
+        if: steps.run-evidence.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/requirements-evidence.yml
+++ b/.github/workflows/requirements-evidence.yml
@@ -11,6 +11,12 @@ on:
       - "scripts/requirements_evidence_delivery_gate.py"
       - ".github/workflows/requirements-evidence.yml"
   workflow_dispatch:
+    inputs:
+      base_branch:
+        description: Base branch used to select changed Requirements sources.
+        required: true
+        default: dev
+        type: string
 
 permissions:
   contents: read
@@ -76,12 +82,25 @@ jobs:
       - name: Run Requirements evidence gate
         id: run-evidence
         continue-on-error: true
+        env:
+          EVIDENCE_BASE_BRANCH: ${{ github.event_name == 'pull_request' && github.base_ref || inputs.base_branch || github.event.repository.default_branch }}
         run: |
+          set +e
+          [[ "$EVIDENCE_BASE_BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]]
           uv run --locked --no-sync specfact requirements evidence \
             --repo-root "$GITHUB_WORKSPACE" \
-            --base-ref "origin/${{ github.base_ref }}" \
+            --base-ref "origin/${EVIDENCE_BASE_BRANCH}" \
             --output artifacts/requirements-evidence/requirements-evidence.json \
             --summary artifacts/requirements-evidence/requirements-evidence.md
+          exit_code=$?
+          set -e
+          if [[ ! -s artifacts/requirements-evidence/requirements-evidence.json ]]; then
+            printf '{"schema_version":1,"verdict":"failed","diagnostic":"Evidence command exited with status %s before writing JSON."}\n' "$exit_code" > artifacts/requirements-evidence/requirements-evidence.json
+          fi
+          if [[ ! -s artifacts/requirements-evidence/requirements-evidence.md ]]; then
+            printf '## Requirements evidence unavailable\n\n- Diagnostic: Evidence command exited with status %s before writing Markdown.\n' "$exit_code" > artifacts/requirements-evidence/requirements-evidence.md
+          fi
+          exit "$exit_code"
 
       - name: Publish Requirements evidence summary
         if: always()
@@ -92,7 +111,7 @@ jobs:
 
       - name: Upload requirements evidence artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: requirements-evidence
           path: |

--- a/.github/workflows/requirements-evidence.yml
+++ b/.github/workflows/requirements-evidence.yml
@@ -75,7 +75,7 @@ jobs:
         id: run-evidence
         continue-on-error: true
         run: |
-          hatch run specfact requirements evidence \
+          uv run --locked --no-sync specfact requirements evidence \
             --repo-root "$GITHUB_WORKSPACE" \
             --base-ref "origin/${{ github.base_ref }}" \
             --output artifacts/requirements-evidence/requirements-evidence.json \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.54.0] - 2026-07-29
+
+### Added
+
+- **Requirements evidence delivery gate**: enforce the released,
+  SHA-pinned Requirements evidence command before Block 2 review and contract
+  checks, retain local JSON/Markdown remediation reports, and publish matching
+  pull-request summaries and artifacts.
+
+---
+
 ## [0.53.5] - 2026-07-25
 
 ### Fixed

--- a/ci/module-fixture.lock.json
+++ b/ci/module-fixture.lock.json
@@ -1,4 +1,4 @@
 {
   "repository": "nold-ai/specfact-cli-modules",
-  "commit": "6b3e7f3cb00b4b94e25b1498d9f1d492499dba63"
+  "commit": "2438372f8e34c96d4e474afa4c66c92a9cee7979"
 }

--- a/docs/modules/code-review.md
+++ b/docs/modules/code-review.md
@@ -159,7 +159,7 @@ hooks that mirror `specfact-cli-modules` (module verify, format, staged YAML/Mar
 
 When an active `openspec/changes/` source is staged, Block 2 first runs the released
 `specfact requirements evidence --staged` command. It accepts only the exact commit in
-[`ci/module-fixture.lock.json`](../../ci/module-fixture.lock.json): set
+`ci/module-fixture.lock.json`: set
 `SPECFACT_MODULES_REPO` to a checkout at that commit before committing. A user-level installed module
 does not replace this fixture check. The hook retains JSON and Markdown remediation reports under
 `.specfact/reports/requirements-evidence/` and stops before code review or contract tests on a red

--- a/docs/modules/code-review.md
+++ b/docs/modules/code-review.md
@@ -152,10 +152,19 @@ Use the self-review report for SpecFact-specific quality signals, and use Semgre
 
 ## Pre-Commit Review Gate
 
-This repository wires `specfact code review run` into **Block 2** of the modular pre-commit pipeline
+This repository wires delivery checks into **Block 2** of the modular pre-commit pipeline
 (`scripts/pre-commit-quality-checks.sh block2`), configured in `.pre-commit-config.yaml` alongside
 hooks that mirror `specfact-cli-modules` (module verify, format, staged YAML/Markdown/workflow checks,
-`hatch run lint` when Python is staged, then code review + contract tests).
+`hatch run lint` when Python is staged, then Requirements evidence, code review, and contract tests).
+
+When an active `openspec/changes/` source is staged, Block 2 first runs the released
+`specfact requirements evidence --staged` command. It accepts only the exact commit in
+[`ci/module-fixture.lock.json`](../../ci/module-fixture.lock.json): set
+`SPECFACT_MODULES_REPO` to a checkout at that commit before committing. A user-level installed module
+does not replace this fixture check. The hook retains JSON and Markdown remediation reports under
+`.specfact/reports/requirements-evidence/` and stops before code review or contract tests on a red
+verdict. Pull requests run the same command against the base reference and publish both reports as
+the `requirements-evidence` artifact.
 
 Downstream copies can either use the full modular config from this repo or a single hook
 `specfact-smart-checks` pointing at `scripts/pre-commit-smart-checks.sh` (shim → `scripts/pre-commit-quality-checks.sh all`).

--- a/docs/reference/commands.generated.json
+++ b/docs/reference/commands.generated.json
@@ -2086,6 +2086,7 @@
     "source": "specfact_requirements.requirements.commands:app",
     "subcommands": [
       "coverage",
+      "evidence",
       "import",
       "list",
       "validate"
@@ -2101,6 +2102,26 @@
     "options": [
       "--bundle",
       "--format"
+    ],
+    "owner_package": "nold-ai/specfact-requirements",
+    "owner_repo": "nold-ai/specfact-cli-modules",
+    "short_help": "",
+    "source": "specfact_requirements.requirements.commands:app",
+    "subcommands": []
+  },
+  {
+    "arguments": [],
+    "bare_invocation": "executes",
+    "command": "specfact requirements evidence",
+    "deprecated": false,
+    "hidden": false,
+    "install_prerequisite": "specfact module install nold-ai/specfact-requirements",
+    "options": [
+      "--base-ref",
+      "--output",
+      "--repo-root",
+      "--staged",
+      "--summary"
     ],
     "owner_package": "nold-ai/specfact-requirements",
     "owner_repo": "nold-ai/specfact-cli-modules",

--- a/docs/reference/commands.generated.md
+++ b/docs/reference/commands.generated.md
@@ -113,8 +113,9 @@ This file is generated from the current CLI command tree. Do not edit by hand.
 | `specfact project version bump` | nold-ai/specfact-project | --bundle, --repo, --type; args: - | - |  |
 | `specfact project version check` | nold-ai/specfact-project | --bundle, --repo; args: - | - |  |
 | `specfact project version set` | nold-ai/specfact-project | --bundle, --repo, --version; args: - | - |  |
-| `specfact requirements` | nold-ai/specfact-requirements | --install-completion, --show-completion; args: - | coverage, import, list, validate |  |
+| `specfact requirements` | nold-ai/specfact-requirements | --install-completion, --show-completion; args: - | coverage, evidence, import, list, validate |  |
 | `specfact requirements coverage` | nold-ai/specfact-requirements | --bundle, --format; args: - | - |  |
+| `specfact requirements evidence` | nold-ai/specfact-requirements | --base-ref, --output, --repo-root, --staged, --summary; args: - | - |  |
 | `specfact requirements import` | nold-ai/specfact-requirements | --bundle, --format, --from-file, --from-openspec, --from-speckit; args: - | - |  |
 | `specfact requirements list` | nold-ai/specfact-requirements | --bundle, --format, --show-coverage; args: - | - |  |
 | `specfact requirements validate` | nold-ai/specfact-requirements | --bundle, --format, --profile; args: - | - |  |

--- a/llms.txt
+++ b/llms.txt
@@ -115,8 +115,9 @@ This file is generated from the current CLI command tree. Do not edit by hand.
 | `specfact project version bump` | nold-ai/specfact-project | --bundle, --repo, --type; args: - | - |  |
 | `specfact project version check` | nold-ai/specfact-project | --bundle, --repo; args: - | - |  |
 | `specfact project version set` | nold-ai/specfact-project | --bundle, --repo, --version; args: - | - |  |
-| `specfact requirements` | nold-ai/specfact-requirements | --install-completion, --show-completion; args: - | coverage, import, list, validate |  |
+| `specfact requirements` | nold-ai/specfact-requirements | --install-completion, --show-completion; args: - | coverage, evidence, import, list, validate |  |
 | `specfact requirements coverage` | nold-ai/specfact-requirements | --bundle, --format; args: - | - |  |
+| `specfact requirements evidence` | nold-ai/specfact-requirements | --base-ref, --output, --repo-root, --staged, --summary; args: - | - |  |
 | `specfact requirements import` | nold-ai/specfact-requirements | --bundle, --format, --from-file, --from-openspec, --from-speckit; args: - | - |  |
 | `specfact requirements list` | nold-ai/specfact-requirements | --bundle, --format, --show-coverage; args: - | - |  |
 | `specfact requirements validate` | nold-ai/specfact-requirements | --bundle, --format, --profile; args: - | - |  |

--- a/openspec/CHANGE_ORDER.md
+++ b/openspec/CHANGE_ORDER.md
@@ -84,7 +84,8 @@ planning workflows.
 | 2 | `requirements-02-module-commands` | [#239](https://github.com/nold-ai/specfact-cli/issues/239) | Import and normalize existing requirement context | requirements-01 |
 | 3 | `openspec-01-intent-trace` | [#350](https://github.com/nold-ai/specfact-cli/issues/350) | Import-first OpenSpec and Spec Kit requirement evidence with pass/fail gates (rescoped 2026-07-13) | requirements-01/02 |
 | 4 | `requirements-04-upstream-source-readiness` | [#648](https://github.com/nold-ai/specfact-cli/issues/648) | Reject incomplete or policy-invalid native OpenSpec and Spec Kit sources before requirement normalization | openspec-01; paired modules #346 |
-| 5 | `architecture-01-solution-layer` | [#240](https://github.com/nold-ai/specfact-cli/issues/240) | Architecture-boundary records and drift validation | requirements input contracts |
+| 5 | `requirements-06-evidence-enforcement` | [#657](https://github.com/nold-ai/specfact-cli/issues/657) | Enforce released Requirements evidence reports in staged pre-commit and pull-request delivery gates | released modules #361 fixture |
+| 6 | `architecture-01-solution-layer` | [#240](https://github.com/nold-ai/specfact-cli/issues/240) | Architecture-boundary records and drift validation | requirements input contracts |
 | Parked | `requirements-03-backlog-sync` | [#244](https://github.com/nold-ai/specfact-cli/issues/244) | Read-first drift evidence; no write-back critical path. Deprioritized 2026-07-13 behind openspec-01 | requirements-02; modules `sync-01` |
 | Gated | `architecture-02-well-architected-review` | [#524](https://github.com/nold-ai/specfact-cli/issues/524) | Architecture-boundary review findings | architecture-01 shipped plus one usage cycle |
 | Gated | `telemetry-01-opentelemetry-default-on` | [#518](https://github.com/nold-ai/specfact-cli/issues/518) | Opt-in validation outcome telemetry only | governance-01 evidence fields |
@@ -165,6 +166,9 @@ Update each proposal first, then run strict OpenSpec validation.
   2026-07-13 (rescoped, no longer positioned as optional-only).
 - `requirements-04` as the core-owned source-readiness follow-up to
   `openspec-01`; it blocks the paired modules command/persistence patch.
+- `requirements-06` as the delivery-gate follow-up: it consumes the released
+  requirements-evidence fixture from modules #361 and does not duplicate its
+  command semantics.
 - `architecture-02`, `telemetry-01`, and `ai-integration-02` only after pull
   from the validation loop exists.
 

--- a/openspec/CHANGE_ORDER.md
+++ b/openspec/CHANGE_ORDER.md
@@ -141,6 +141,9 @@ Update each proposal first, then run strict OpenSpec validation.
 - `governance-01-evidence-output`
 - `governance-02-exception-management`
 - `cli-val-03-misuse-safety-proof`
+- `requirements-06` as the core delivery gate for released Requirements
+  evidence; it consumes the immutable modules #361 fixture without duplicating
+  module command semantics.
 
 ### Wave 3 - Evidence graph and drift detection
 
@@ -166,9 +169,6 @@ Update each proposal first, then run strict OpenSpec validation.
   2026-07-13 (rescoped, no longer positioned as optional-only).
 - `requirements-04` as the core-owned source-readiness follow-up to
   `openspec-01`; it blocks the paired modules command/persistence patch.
-- `requirements-06` as the delivery-gate follow-up: it consumes the released
-  requirements-evidence fixture from modules #361 and does not duplicate its
-  command semantics.
 - `architecture-02`, `telemetry-01`, and `ai-integration-02` only after pull
   from the validation loop exists.
 

--- a/openspec/changes/requirements-06-evidence-enforcement/.openspec.yaml
+++ b/openspec/changes/requirements-06-evidence-enforcement/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-27

--- a/openspec/changes/requirements-06-evidence-enforcement/CHANGE_VALIDATION.md
+++ b/openspec/changes/requirements-06-evidence-enforcement/CHANGE_VALIDATION.md
@@ -1,0 +1,60 @@
+# Change Validation Report: requirements-06-evidence-enforcement
+
+**Validation Date**: 2026-07-29
+**Change Proposal**: [proposal.md](./proposal.md)
+**Validation Method**: Dry-run interface and dependency simulation in
+`/tmp/specfact-validation-requirements-06.EJwaPU`
+
+## Executive Summary
+
+- Breaking Changes: 0 detected / 0 resolved
+- Dependent Files: 4 affected
+- Impact Level: Medium
+- Validation Result: Pass
+- User Decision: N/A
+
+## Breaking Changes Detected
+
+None. The public evaluator interface belongs to the released Requirements
+module fixture. Core adds delivery orchestration only and does not alter an
+existing core CLI signature.
+
+## Dependencies Affected
+
+### Critical Updates Required
+
+- `ci/module-fixture.lock.json`: pin the released 0.3.3 commit.
+- `scripts/pre-commit-quality-checks.sh`: invoke the staged command only after
+  verifying the explicitly supplied immutable fixture.
+- `.github/workflows/requirements-evidence.yml`: materialize the same fixture,
+  retain its reports, then enforce its exit status.
+
+### Recommended Updates
+
+- `.pre-commit-config.yaml`: describe the evidence stage in Block 2.
+
+## Impact Assessment
+
+- **Code Impact**: new internal delivery-gate adapter and pre-commit wiring.
+- **Test Impact**: script and workflow contract tests for fixture identity,
+  report retention, ordering, and red/green behavior.
+- **Documentation Impact**: concise delivery-gate guidance only; command
+  semantics stay in the modules repository.
+- **Release Impact**: Minor feature release after implementation.
+
+## Format Validation
+
+- **proposal.md Format**: Pass
+- **tasks.md Format**: Pass
+- **specs Format**: Pass
+- **Config.yaml Compliance**: Pass
+
+## OpenSpec Validation
+
+- **Status**: Pass
+- **Command**: `openspec validate requirements-06-evidence-enforcement --strict`
+- **Issues Found/Fixed**: 0
+
+## Validation Artifacts
+
+- Temporary workspace: `/tmp/specfact-validation-requirements-06.EJwaPU`

--- a/openspec/changes/requirements-06-evidence-enforcement/CHANGE_VALIDATION.md
+++ b/openspec/changes/requirements-06-evidence-enforcement/CHANGE_VALIDATION.md
@@ -52,7 +52,7 @@ existing core CLI signature.
 ## OpenSpec Validation
 
 - **Status**: Pass
-- **Command**: `openspec validate requirements-06-evidence-enforcement --strict`
+- **Command**: `hatch run openspec validate requirements-06-evidence-enforcement --strict`
 - **Issues Found/Fixed**: 0
 
 ## Validation Artifacts

--- a/openspec/changes/requirements-06-evidence-enforcement/README.md
+++ b/openspec/changes/requirements-06-evidence-enforcement/README.md
@@ -1,0 +1,3 @@
+# requirements-06-evidence-enforcement
+
+Enforce released requirements-evidence reports before core CLI delivery gates.

--- a/openspec/changes/requirements-06-evidence-enforcement/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-06-evidence-enforcement/TDD_EVIDENCE.md
@@ -1,0 +1,73 @@
+# TDD Evidence: requirements-06-evidence-enforcement
+
+## Failing-before
+
+- **Timestamp**: 2026-07-29 (Europe/Berlin)
+- **Command**:
+  `hatch run pytest tests/unit/scripts/test_requirements_evidence_delivery_gate.py tests/unit/workflows/test_requirements_evidence_delivery_workflow.py -q`
+- **Result**: 4 failed, 0 passed.
+- **Evidence**:
+  - `scripts/requirements_evidence_delivery_gate.py` did not exist, so the
+    fixture-verification and red-report-retention tests failed with
+    `FileNotFoundError`.
+  - `scripts/pre-commit-quality-checks.sh` had no
+    `run_requirements_evidence_gate` stage before review or contract tests.
+  - `.github/workflows/requirements-evidence.yml` did not exist.
+
+Production changes begin only after this failing evidence.
+
+## Passing-after
+
+- **Timestamp**: 2026-07-29 (Europe/Berlin)
+- **Focused command**:
+  `hatch run pytest tests/unit/scripts/test_requirements_evidence_delivery_gate.py tests/unit/workflows/test_requirements_evidence_delivery_workflow.py -q`
+- **Result**: 4 passed, 0 failed.
+- **Additional focused checks**:
+  - `hatch run ruff check scripts/requirements_evidence_delivery_gate.py tests/unit/scripts/test_requirements_evidence_delivery_gate.py tests/unit/workflows/test_requirements_evidence_delivery_workflow.py` — passed.
+  - `hatch run ruff format --check scripts/requirements_evidence_delivery_gate.py tests/unit/scripts/test_requirements_evidence_delivery_gate.py tests/unit/workflows/test_requirements_evidence_delivery_workflow.py` — passed.
+  - `hatch run yaml-lint .github/workflows/requirements-evidence.yml` — passed.
+  - With `SPECFACT_MODULES_REPO=/tmp/specfact-cli-modules-2438372`, the adapter
+    verified commit `2438372f8e34c96d4e474afa4c66c92a9cee7979` and produced
+    schema-v1 JSON and Markdown reports for `--base-ref HEAD` (skipped verdict,
+    zero changed sources).
+
+## Delivery and review evidence
+
+- **Timestamp**: 2026-07-29 (Europe/Berlin)
+- **Passed**:
+  - `hatch run format`, `hatch run type-check`, `hatch run lint`, and
+    `hatch run yaml-lint`.
+  - `hatch run python scripts/check_reproducible_delivery.py`, `uv lock --check`,
+    and the checked-in BasedPyright authority command (0 errors; repository
+    warning baseline retained).
+  - `hatch run specfact code review run --json --out .specfact/code-review.json --scope changed`
+    with the immutable module roots — `PASS`, 0 findings after remediation.
+  - `hatch run semgrep-sast --json --output /tmp/specfact-semgrep.json`,
+    `hatch run semgrep-sast-gate --results /tmp/specfact-semgrep.json --baseline tools/semgrep/sast-baseline.json`,
+    and `hatch run bandit-scan` — passed with no blocking findings.
+  - Generated command overview, command-contract, docs-command,
+    documentation-accountability, frontmatter, whitespace, and strict OpenSpec
+    validation checks.
+- **Incomplete**:
+  - `hatch run contract-test` and `hatch run smart-test` each forced a fresh
+    2,936-test baseline in this worktree and stopped before a final summary in
+    the available execution window. Focused delivery-gate tests remain green;
+    rerun these two full gates from a persistent terminal before PR creation.
+
+## Release preparation
+
+- **Version**: `0.54.0` on 2026-07-29.
+- **Passed**: `hatch run check-version-sources` and `hatch run check-pypi-ahead`
+  (local 0.54.0 is ahead of PyPI 0.53.5).
+
+## Dogfooding evidence
+
+- **Timestamp**: 2026-07-29 (Europe/Berlin)
+- **Failing-before**: the first signed commit attempt ran the new Block 2 gate
+  and failed closed because no `SPECFACT_MODULES_REPO` fixture was supplied.
+- **Fix**: add this change's `requirements-evidence.yaml`, linking the delivery
+  requirement to the focused script and workflow tests; rerun with the verified
+  immutable fixture at `2438372f8e34c96d4e474afa4c66c92a9cee7979`.
+- **Passing-after**: staged execution imported one requirement with two valid
+  test links, returned `verdict: passed`, and wrote the JSON and Markdown
+  reports before the signed commit retry.

--- a/openspec/changes/requirements-06-evidence-enforcement/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-06-evidence-enforcement/TDD_EVIDENCE.md
@@ -85,3 +85,17 @@ Production changes begin only after this failing evidence.
   passed; and the exact command
   `SPECFACT_MODULES_REPO=/private/tmp/specfact-cli-modules-2438372 uv run --locked --no-sync specfact requirements evidence --repo-root <worktree> --base-ref origin/dev ...`
   returned a passed verdict with both reports written.
+
+## CI fixture-discovery correction
+
+- **Timestamp**: 2026-07-29 (Europe/Berlin)
+- **Failing-before**: After the frozen launcher correction, PR #658 still
+  failed because the runner could not discover `nold-ai/specfact-requirements`
+  from the checked-out fixture. The workflow contract was tightened to require
+  `SPECFACT_MODULES_ROOTS=<fixture>/packages`; the focused test failed before
+  that export existed.
+- **Passing-after**:
+  `hatch run pytest tests/unit/workflows/test_requirements_evidence_delivery_workflow.py tests/unit/scripts/test_requirements_evidence_delivery_gate.py -q`
+  returned 4 passed and the exact frozen command, with an empty `HOME` and both
+  `SPECFACT_MODULES_REPO` and `SPECFACT_MODULES_ROOTS` set to the pinned fixture,
+  returned a passed verdict and wrote both reports.

--- a/openspec/changes/requirements-06-evidence-enforcement/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-06-evidence-enforcement/TDD_EVIDENCE.md
@@ -48,11 +48,12 @@ Production changes begin only after this failing evidence.
   - Generated command overview, command-contract, docs-command,
     documentation-accountability, frontmatter, whitespace, and strict OpenSpec
     validation checks.
-- **Incomplete**:
-  - `hatch run contract-test` and `hatch run smart-test` each forced a fresh
-    2,936-test baseline in this worktree and stopped before a final summary in
-    the available execution window. Focused delivery-gate tests remain green;
-    rerun these two full gates from a persistent terminal before PR creation.
+  - `hatch run contract-test` — passed (no modified files; cached baseline).
+  - `hatch run smart-test` — passed: 2,931 passed, 9 skipped, 2 warnings in
+    145.33s; exit 0. The full run log is
+    `logs/tests/test_run_20260729_225301.log`.
+  - PR #658 required CI — passed: Contract Validation, Workflow Lint, and the
+    Python 3.12 full test suite (4m29s), plus the aggregate Quality Gates job.
 
 ## Release preparation
 

--- a/openspec/changes/requirements-06-evidence-enforcement/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-06-evidence-enforcement/TDD_EVIDENCE.md
@@ -71,3 +71,17 @@ Production changes begin only after this failing evidence.
 - **Passing-after**: staged execution imported one requirement with two valid
   test links, returned `verdict: passed`, and wrote the JSON and Markdown
   reports before the signed commit retry.
+
+## CI runtime correction
+
+- **Timestamp**: 2026-07-29 (Europe/Berlin)
+- **Failing-before**: PR #658's `Requirements evidence` workflow installed the
+  frozen `.venv` successfully, then failed with `hatch: command not found`.
+  The workflow contract was tightened to require the frozen `uv run` form;
+  the focused contract test failed against the `hatch run` invocation.
+- **Passing-after**:
+  `hatch run pytest tests/unit/workflows/test_requirements_evidence_delivery_workflow.py tests/unit/scripts/test_requirements_evidence_delivery_gate.py -q`
+  returned 4 passed; `hatch run yaml-lint .github/workflows/requirements-evidence.yml`
+  passed; and the exact command
+  `SPECFACT_MODULES_REPO=/private/tmp/specfact-cli-modules-2438372 uv run --locked --no-sync specfact requirements evidence --repo-root <worktree> --base-ref origin/dev ...`
+  returned a passed verdict with both reports written.

--- a/openspec/changes/requirements-06-evidence-enforcement/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-06-evidence-enforcement/TDD_EVIDENCE.md
@@ -112,6 +112,16 @@ Production changes begin only after this failing evidence.
   `hatch run pytest tests/unit/scripts/test_requirements_evidence_delivery_gate.py tests/unit/workflows/test_requirements_evidence_delivery_workflow.py tests/unit/docs/test_release_docs_parity.py::test_docs_links_resolve_to_published_docs_targets -q`
   returned 9 passed; `hatch run openspec validate requirements-06-evidence-enforcement --strict`
   and `hatch run yaml-lint .github/workflows/requirements-evidence.yml` passed.
-- **Pending CI evidence**: The complete contract and smart-test gates remain
-  recorded as pending until the PR’s active full-suite job completes; task 4.1
-  is intentionally not marked complete before that result is available.
+- **Full verification evidence**: `hatch run contract-test` and `hatch run
+  smart-test` passed locally; PR #658's Contract Validation, Python 3.12 full
+  test suite, Workflow Lint, and aggregate Quality Gates job also passed.
+
+## Follow-up CodeRabbit remediation
+
+- **Timestamp**: 2026-07-29 (Europe/Berlin)
+- **Failing-before**: The focused gate test preserved a prior passing report
+  after an invalid-fixture failure, allowing stale evidence to be reused.
+- **Passing-after**: The gate resets both report destinations before fixture
+  validation, then writes fresh diagnostics on failure. The focused suite now
+  returns 8 passed, including the stale-report regression and workflow
+  id/order contracts; Ruff and BasedPyright complete with 0 errors.

--- a/openspec/changes/requirements-06-evidence-enforcement/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-06-evidence-enforcement/TDD_EVIDENCE.md
@@ -99,3 +99,18 @@ Production changes begin only after this failing evidence.
   returned 4 passed and the exact frozen command, with an empty `HOME` and both
   `SPECFACT_MODULES_REPO` and `SPECFACT_MODULES_ROOTS` set to the pinned fixture,
   returned a passed verdict and wrote both reports.
+
+## CodeRabbit remediation
+
+- **Timestamp**: 2026-07-29 (Europe/Berlin)
+- **Failing-before**: Expanded focused tests failed for the missing exact-SHA
+  check, dirty-fixture rejection, fixture package-root export, diagnostic
+  reports after command-start failure, CLI-boundary coverage, and step-aware
+  workflow contract assertions.
+- **Passing-after**:
+  `hatch run pytest tests/unit/scripts/test_requirements_evidence_delivery_gate.py tests/unit/workflows/test_requirements_evidence_delivery_workflow.py tests/unit/docs/test_release_docs_parity.py::test_docs_links_resolve_to_published_docs_targets -q`
+  returned 9 passed; `hatch run openspec validate requirements-06-evidence-enforcement --strict`
+  and `hatch run yaml-lint .github/workflows/requirements-evidence.yml` passed.
+- **Pending CI evidence**: The complete contract and smart-test gates remain
+  recorded as pending until the PR’s active full-suite job completes; task 4.1
+  is intentionally not marked complete before that result is available.

--- a/openspec/changes/requirements-06-evidence-enforcement/design.md
+++ b/openspec/changes/requirements-06-evidence-enforcement/design.md
@@ -1,0 +1,79 @@
+## Context
+
+Core delivery currently runs Block 2 code review and contract checks without a
+Requirements evidence verdict. Existing CI already demonstrates the required
+fixture pattern: `ci/module-fixture.lock.json` pins the modules repository and
+commit, workflows check out that exact ref, and verification compares the
+checked-out SHA before any module code is used.
+
+Modules #361 owns the reusable `specfact requirements evidence` command and
+its verdict, JSON, Markdown, and `--staged`/`--base-ref` semantics. Core must
+not reimplement those semantics. It only materializes the released fixture,
+invokes the released command according to its published contract, preserves
+its reports, and translates its exit status into delivery-gate behavior.
+
+## Decisions
+
+### Pin and verify a released fixture before execution
+
+The fixture lock SHALL name only `nold-ai/specfact-cli-modules` and an exact
+40-character commit from the #361 release. Local and CI execution SHALL verify
+the resolved fixture identity before command execution. A missing, malformed,
+or mismatched fixture SHALL fail closed and SHALL not fall back to a sibling
+checkout, a branch name, or mutable module source.
+
+### Place the staged gate before review and contract checks
+
+The pre-commit sequence SHALL run Requirements evidence after Block 1 quality
+checks and before the current Block 2 code-review and contract-test sequence.
+On a red verdict, it SHALL leave the module-produced JSON and Markdown reports
+at documented local paths, print those paths, and exit non-zero. Later gates
+do not run.
+
+### Preserve reports in pull-request CI for every verdict
+
+The pull-request workflow SHALL run the same released fixture contract against
+the pull-request base reference, write a concise summary, and upload the JSON
+and Markdown reports using an always-run upload step. A red verdict blocks the
+workflow only after the report is available.
+
+### Consume the published 0.3.3 command contract
+
+Modules #361 is released as `specfact-requirements` 0.3.3 at immutable commit
+`2438372f8e34c96d4e474afa4c66c92a9cee7979` (modules PR #365). Core SHALL
+invoke only this public surface:
+
+```text
+specfact requirements evidence --repo-root <repo> --output <json> \
+  (--staged | --base-ref <ref>) [--summary <markdown>]
+```
+
+The command returns `0` for passed or skipped evidence and `1` for failed
+evidence after writing the requested JSON and Markdown reports. Argument usage
+errors are distinct command failures. The local gate stores reports under
+`.specfact/reports/requirements-evidence/`; CI uses
+`artifacts/requirements-evidence/` and uploads both report types. A checked-out
+fixture is accepted only when its repository and `HEAD` exactly match the lock.
+The existing mutable-sibling discovery helper is not an admissible fallback for
+this gate.
+
+## Risks and Mitigations
+
+- **Release skew or fixture substitution**: validate repository and exact SHA
+  before execution; fail closed on mismatch.
+- **Lost remediation evidence on failure**: write reports before returning the
+  command's non-zero exit; use CI `always()` artifact upload.
+- **Staged/working-tree leakage**: delegate staged-index behavior exclusively
+  to the module command and cover it with the module's released fixture.
+- **Offline local development**: do not fetch mutable code at hook runtime;
+  require the pinned fixture to be present and report actionable remediation
+  when it is unavailable.
+
+## Rollout and Rollback
+
+1. Wait for #361 to close and publish its immutable fixture.
+2. Pin the published commit and verify it in tests, pre-commit, and CI.
+3. Enable the staged pre-commit gate before review/contract gates.
+4. Enable pull-request CI summary and artifact retention.
+5. Roll back by removing the hook/job and restoring the previous fixture lock;
+   no source artifacts or upstream modules are modified by core.

--- a/openspec/changes/requirements-06-evidence-enforcement/proposal.md
+++ b/openspec/changes/requirements-06-evidence-enforcement/proposal.md
@@ -1,0 +1,57 @@
+# Change: Enforce Requirements Evidence in CLI Delivery Gates
+
+## Why
+
+The Requirements module can produce deterministic evidence reports, but the
+core CLI does not yet enforce those reports before review or in pull-request
+CI. Delivery can therefore proceed with invalid, unlinked, or absent
+requirements evidence.
+
+## What Changes
+
+- Add a staged pre-commit requirements-evidence gate before code review and
+  contract checks. It retains the module's JSON and Markdown remediation
+  reports before returning a non-zero status.
+- Add a matching pull-request CI gate that verifies the fixture, publishes a
+  concise job summary, and uploads the report for either a passing or failing
+  verdict.
+- Consume only the released, SHA-pinned fixture from
+  `nold-ai/specfact-cli-modules#361`; never execute a mutable checkout or an
+  unverified module source.
+- Preserve the module-owned evidence semantics, including its `--staged` and
+  `--base-ref` modes. Core owns delivery-gate orchestration and artifact
+  retention only.
+
+## Capabilities
+
+### New Capabilities
+
+- `requirements-evidence-delivery-gate`: Enforce a released Requirements
+  evidence result before core delivery gates while retaining auditable reports.
+
+## Impact
+
+- Affected delivery surfaces: `.pre-commit-config.yaml`,
+  `scripts/pre-commit-quality-checks.sh`, `ci/module-fixture.lock.json`, and
+  pull-request CI workflows.
+- Affected tests: focused script/pre-commit and workflow-contract coverage.
+- Affected documentation: delivery-gate and Requirements evidence guidance;
+  command documentation remains owned by the modules repository.
+- Compatibility: modules #361 was released as `specfact-requirements` 0.3.3
+  at `2438372f8e34c96d4e474afa4c66c92a9cee7979`. Its public command requires
+  `--output`, exactly one of `--staged` or `--base-ref`, and optionally accepts
+  `--summary`; it writes requested reports before returning a red verdict.
+- Rollback: remove the core hook and CI job, restore the previous fixture lock,
+  and retain previously uploaded CI artifacts. No upstream source is changed.
+
+## Source Tracking
+
+- **GitHub Issue**: #657
+- **Issue URL**: <https://github.com/nold-ai/specfact-cli/issues/657>
+- **Parent Feature**: #374 End-to-End Integration Proof
+- **Parent Epic**: #258 Evidence dogfooding and governance
+- **Paired Modules Issue**: nold-ai/specfact-cli-modules#361
+- **Last Synced Status**: open / Todo (2026-07-29)
+- **Released Fixture**: `specfact-requirements` 0.3.3 at
+  `2438372f8e34c96d4e474afa4c66c92a9cee7979` (modules PR #365)
+- **Resolved Dependency**: modules #361, closed 2026-07-29

--- a/openspec/changes/requirements-06-evidence-enforcement/requirements-evidence.yaml
+++ b/openspec/changes/requirements-06-evidence-enforcement/requirements-evidence.yaml
@@ -1,0 +1,5 @@
+requirements:
+  "openspec:requirements-06-evidence-enforcement:requirements-evidence-delivery-gate:requirements-evidence-delivery-enforcement":
+    test_links:
+      - tests/unit/scripts/test_requirements_evidence_delivery_gate.py
+      - tests/unit/workflows/test_requirements_evidence_delivery_workflow.py

--- a/openspec/changes/requirements-06-evidence-enforcement/specs/requirements-evidence-delivery-gate/spec.md
+++ b/openspec/changes/requirements-06-evidence-enforcement/specs/requirements-evidence-delivery-gate/spec.md
@@ -4,14 +4,17 @@
 
 The core CLI SHALL enforce the released Requirements evidence command before
 code-review and contract delivery gates, using only a SHA-pinned
-`nold-ai/specfact-cli-modules` fixture. Core SHALL preserve the module-owned
-evidence semantics and SHALL retain JSON and Markdown remediation reports for
-both passing and failing runs.
+`nold-ai/specfact-cli-modules` fixture at
+`2438372f8e34c96d4e474afa4c66c92a9cee7979`. Core SHALL preserve the
+module-owned evidence semantics and SHALL retain JSON and Markdown remediation
+reports for both passing and failing runs.
 
 #### Scenario: Reject an unverified or mutable fixture
 
-- **GIVEN** the fixture lock is absent, malformed, points outside the approved
-  modules repository, or does not match the materialized commit
+- **GIVEN** the fixture lock is absent, malformed, points outside
+  `nold-ai/specfact-cli-modules`, names any commit other than
+  `2438372f8e34c96d4e474afa4c66c92a9cee7979`, does not match the materialized
+  commit, or materializes a dirty worktree
 - **WHEN** local or CI requirements evidence enforcement starts
 - **THEN** it fails before executing any module command
 - **AND** it does not use a branch, sibling checkout, or other mutable source

--- a/openspec/changes/requirements-06-evidence-enforcement/specs/requirements-evidence-delivery-gate/spec.md
+++ b/openspec/changes/requirements-06-evidence-enforcement/specs/requirements-evidence-delivery-gate/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Requirements evidence delivery enforcement
+
+The core CLI SHALL enforce the released Requirements evidence command before
+code-review and contract delivery gates, using only a SHA-pinned
+`nold-ai/specfact-cli-modules` fixture. Core SHALL preserve the module-owned
+evidence semantics and SHALL retain JSON and Markdown remediation reports for
+both passing and failing runs.
+
+#### Scenario: Reject an unverified or mutable fixture
+
+- **GIVEN** the fixture lock is absent, malformed, points outside the approved
+  modules repository, or does not match the materialized commit
+- **WHEN** local or CI requirements evidence enforcement starts
+- **THEN** it fails before executing any module command
+- **AND** it does not use a branch, sibling checkout, or other mutable source
+- **AND** it reports how to obtain the released pinned fixture.
+
+#### Scenario: Block staged delivery after retaining a red report
+
+- **GIVEN** the verified released fixture returns a red staged-evidence verdict
+- **WHEN** the pre-commit hook evaluates staged changes
+- **THEN** it retains the JSON and Markdown remediation reports at documented
+  local paths before returning non-zero
+- **AND** code-review and contract-test gates do not run afterward.
+
+#### Scenario: Continue staged delivery after a green report
+
+- **GIVEN** the verified released fixture returns a green staged-evidence verdict
+- **WHEN** the pre-commit hook evaluates staged changes
+- **THEN** it retains the generated reports
+- **AND** it continues to the existing code-review and contract-test gates.
+
+#### Scenario: Publish pull-request evidence for any verdict
+
+- **GIVEN** a pull-request workflow evaluates Requirements evidence with a
+  verified released fixture and pull-request base reference
+- **WHEN** the command returns a green or red verdict
+- **THEN** CI writes a concise job summary and uploads the JSON and Markdown
+  reports
+- **AND** a red verdict fails the delivery gate only after its reports are
+  available.

--- a/openspec/changes/requirements-06-evidence-enforcement/tasks.md
+++ b/openspec/changes/requirements-06-evidence-enforcement/tasks.md
@@ -1,0 +1,30 @@
+## 1. Governance and release dependency
+
+- [x] 1.1 Create isolated branch/worktree `feature/requirements-06-evidence-enforcement` from `origin/dev`.
+- [x] 1.2 Verify core #657 parent, labels, project Todo state, and blocker relation to modules #361.
+- [x] 1.3 Verify modules #352 is released and modules #361 remains the active fixture-release blocker.
+- [x] 1.4 Record modules #361 release `specfact-requirements` 0.3.3,
+  immutable commit `2438372f8e34c96d4e474afa4c66c92a9cee7979`, command/report
+  contract, and fixture provenance; recheck #657 blocker state before
+  production implementation.
+
+## 2. Specification and failing evidence
+
+- [x] 2.1 Add the `requirements-evidence-delivery-gate` specification, proposal, and design without inventing unpublished #361 interface details.
+- [x] 2.2 Add failing script and workflow tests for fixture verification, staged red/green verdict behavior, report retention, gate ordering, CI summary, and always-upload artifacts using the released #361 fixture contract.
+- [x] 2.3 Run the focused tests and record failing-before evidence in `TDD_EVIDENCE.md` before production edits.
+
+## 3. Delivery-gate implementation
+
+- [x] 3.1 Pin and verify the released modules #361 fixture in `ci/module-fixture.lock.json` and the local/CI materialization path.
+- [x] 3.2 Add the pre-commit evidence hook after Block 1 and before code review/contract checks; retain and report JSON/Markdown artifact paths before a red exit.
+- [x] 3.3 Add the pull-request CI evidence gate with base-reference mode, concise job summary, and always-run report upload.
+- [x] 3.4 Keep module-owned verdict semantics, staged-index behavior, and remediation content unchanged; add no fallback to mutable module sources.
+
+## 4. Verification, documentation, and delivery
+
+- [ ] 4.1 Run focused tests, then format, type-check, lint, YAML lint, contract tests, smart tests, and workflow lint; record passing-after evidence.
+- [x] 4.2 Run fresh SpecFact code review JSON and independent Semgrep/Bandit checks; resolve all findings.
+- [x] 4.3 Update affected core delivery and Requirements evidence documentation without duplicating modules command documentation.
+- [x] 4.4 Bump the feature version and changelog after implementation, then verify synchronized version sources and released-fixture integrity.
+- [ ] 4.5 Revalidate the OpenSpec change, update the internal wiki mirror and graph, open the PR to `dev`, and archive only after merge.

--- a/openspec/changes/requirements-06-evidence-enforcement/tasks.md
+++ b/openspec/changes/requirements-06-evidence-enforcement/tasks.md
@@ -23,7 +23,7 @@
 
 ## 4. Verification, documentation, and delivery
 
-- [ ] 4.1 Run focused tests, then format, type-check, lint, YAML lint, contract tests, smart tests, and workflow lint; record passing-after evidence.
+- [x] 4.1 Run focused tests, then format, type-check, lint, YAML lint, contract tests, smart tests, and workflow lint; record passing-after evidence.
 - [x] 4.2 Run fresh SpecFact code review JSON and independent Semgrep/Bandit checks; resolve all findings.
 - [x] 4.3 Update affected core delivery and Requirements evidence documentation without duplicating modules command documentation.
 - [x] 4.4 Bump the feature version and changelog after implementation, then verify synchronized version sources and released-fixture integrity.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "specfact-cli"
-version = "0.53.5"
+version = "0.54.0"
 description = "AI-bloat defense CLI for Python teams. Run deterministic code review, cleanup forecasts, and spec/contract evidence for AI-assisted and brownfield delivery."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/pre-commit-quality-checks.sh
+++ b/scripts/pre-commit-quality-checks.sh
@@ -36,9 +36,10 @@ print_block1_overview() {
 print_block2_overview() {
   echo "" >&2
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" >&2
-  echo "  specfact-cli pre-commit — Block 2: code review + contract tests" >&2
-  echo "    1/2  code review gate (staged Python under src/, scripts/, tools/, tests/, openspec/changes/)" >&2
-  echo "    2/2  contract-first tests (contract-test-status → hatch run contract-test-contracts)" >&2
+  echo "  specfact-cli pre-commit — Block 2: Requirements evidence + delivery checks" >&2
+  echo "    1/3  Requirements evidence (staged active OpenSpec changes)" >&2
+  echo "    2/3  code review gate (staged Python under src/, scripts/, tools/, tests/, openspec/changes/)" >&2
+  echo "    3/3  contract-first tests (contract-test-status → hatch run contract-test-contracts)" >&2
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" >&2
   echo "" >&2
 }
@@ -394,6 +395,43 @@ run_lint_if_staged_python() {
   fi
 }
 
+has_staged_active_openspec_sources() {
+  local file
+  while IFS= read -r file || [[ -n "${file}" ]]; do
+    [[ -z "${file}" ]] && continue
+    case "${file}" in
+      openspec/changes/archive/*) ;;
+      openspec/changes/*) return 0 ;;
+    esac
+  done < <(git diff --cached --name-only --diff-filter=ACMRD -- openspec/changes)
+  return 1
+}
+
+run_requirements_evidence_gate() {
+  local report_dir=".specfact/reports/requirements-evidence"
+  local json_report="${report_dir}/requirements-evidence.json"
+  local markdown_report="${report_dir}/requirements-evidence.md"
+
+  if ! has_staged_active_openspec_sources; then
+    info "📦 Block 2 — Requirements evidence — skipped (no staged active OpenSpec source)"
+    return 0
+  fi
+
+  mkdir -p "${report_dir}"
+  info "📦 Block 2 — Requirements evidence — running released pinned fixture"
+  if hatch run python scripts/requirements_evidence_delivery_gate.py \
+    --repo-root . \
+    --staged \
+    --output "${json_report}" \
+    --summary "${markdown_report}"; then
+    success "✅ Block 2 — Requirements evidence passed (${json_report}; ${markdown_report})"
+  else
+    error "❌ Block 2 — Requirements evidence failed"
+    warn "💡 Review ${json_report} and ${markdown_report}; set SPECFACT_MODULES_REPO to the checkout pinned in ci/module-fixture.lock.json."
+    exit 1
+  fi
+}
+
 run_code_review_gate() {
   local review_array=()
   while IFS= read -r line || [[ -n "${line}" ]]; do
@@ -532,13 +570,14 @@ run_block1_lint() {
 
 run_block2() {
   warn "🔍 specfact-cli pre-commit — Block 2 — hook: review + contract tests"
+  print_block2_overview
+  run_requirements_evidence_gate
   run_command_overview_validation_gate
   if check_safe_change; then
     success "✅ Safe change detected — skipping Block 2 (code review + contract tests)"
     info "💡 Only docs (incl. *.mdc), workflow, version files, or allowlisted infra changed"
     exit 0
   fi
-  print_block2_overview
   run_code_review_gate
   check_contract_script_exists
   run_contract_tests_visible
@@ -556,13 +595,14 @@ run_all() {
   run_workflow_lint_if_needed
   run_lint_if_staged_python
   success "✅ Block 1 complete (all stages passed or skipped as expected)"
+  print_block2_overview
+  run_requirements_evidence_gate
   run_command_overview_validation_gate
   if check_safe_change; then
     success "✅ Safe change detected — skipping Block 2 (code review + contract tests)"
     info "💡 Only docs (incl. *.mdc), workflow, version files, or allowlisted infra changed"
     exit 0
   fi
-  print_block2_overview
   run_code_review_gate
   check_contract_script_exists
   run_contract_tests_visible

--- a/scripts/pre-commit-quality-checks.sh
+++ b/scripts/pre-commit-quality-checks.sh
@@ -424,10 +424,18 @@ run_requirements_evidence_gate() {
     --staged \
     --output "${json_report}" \
     --summary "${markdown_report}"; then
+    if [[ ! -s "${json_report}" || ! -s "${markdown_report}" ]]; then
+      error "❌ Block 2 — Requirements evidence did not produce both remediation reports"
+      exit 1
+    fi
     success "✅ Block 2 — Requirements evidence passed (${json_report}; ${markdown_report})"
   else
     error "❌ Block 2 — Requirements evidence failed"
-    warn "💡 Review ${json_report} and ${markdown_report}; set SPECFACT_MODULES_REPO to the checkout pinned in ci/module-fixture.lock.json."
+    if [[ -s "${json_report}" && -s "${markdown_report}" ]]; then
+      warn "💡 Review ${json_report} and ${markdown_report}; set SPECFACT_MODULES_REPO to the checkout pinned in ci/module-fixture.lock.json."
+    else
+      warn "💡 Requirements evidence failed before diagnostic reports could be written; inspect the command output and fixture checkout."
+    fi
     exit 1
   fi
 }

--- a/scripts/requirements_evidence_delivery_gate.py
+++ b/scripts/requirements_evidence_delivery_gate.py
@@ -16,6 +16,7 @@ from icontract import ensure
 
 
 APPROVED_REPOSITORY = "nold-ai/specfact-cli-modules"
+APPROVED_COMMIT = "2438372f8e34c96d4e474afa4c66c92a9cee7979"
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 CommandRunner = Callable[[list[str], dict[str, str]], int]
 GitRunner = Callable[[list[str]], str]
@@ -48,6 +49,25 @@ def _git_head(arguments: list[str]) -> str:
     return subprocess.run(arguments, check=True, capture_output=True, text=True).stdout.strip()
 
 
+def _write_failure_reports(request: EvidenceRequest, message: str) -> None:
+    """Write minimal diagnostics without replacing module-owned reports."""
+    try:
+        request.output_path.parent.mkdir(parents=True, exist_ok=True)
+        request.summary_path.parent.mkdir(parents=True, exist_ok=True)
+        if not request.output_path.exists():
+            request.output_path.write_text(
+                json.dumps({"schema_version": 1, "verdict": "failed", "diagnostic": message}) + "\n",
+                encoding="utf-8",
+            )
+        if not request.summary_path.exists():
+            request.summary_path.write_text(
+                f"## Requirements evidence unavailable\n\n- Diagnostic: {message}\n",
+                encoding="utf-8",
+            )
+    except OSError:
+        pass
+
+
 @beartype
 @ensure(lambda result: result is None)
 def verify_fixture(fixture: Mapping[str, object], fixture_root: Path, *, git_runner: GitRunner = _git_head) -> None:
@@ -58,6 +78,8 @@ def verify_fixture(fixture: Mapping[str, object], fixture_root: Path, *, git_run
         raise ValueError(f"Module fixture must target {APPROVED_REPOSITORY}")
     if not isinstance(commit, str) or SHA_PATTERN.fullmatch(commit) is None:
         raise ValueError("Module fixture commit must be a full immutable SHA")
+    if commit != APPROVED_COMMIT:
+        raise ValueError("Module fixture must use approved release commit")
     if not fixture_root.is_dir():
         raise ValueError(f"Pinned module fixture is unavailable: {fixture_root}")
     try:
@@ -66,6 +88,12 @@ def verify_fixture(fixture: Mapping[str, object], fixture_root: Path, *, git_run
         raise ValueError(f"Cannot verify pinned module fixture: {fixture_root}") from error
     if actual.strip() != commit:
         raise ValueError("Pinned module fixture HEAD does not match ci/module-fixture.lock.json")
+    try:
+        dirty = git_runner(["git", "-C", str(fixture_root), "status", "--porcelain", "--untracked-files=all"])
+    except (OSError, subprocess.SubprocessError) as error:
+        raise ValueError(f"Cannot verify pinned module fixture: {fixture_root}") from error
+    if dirty.strip():
+        raise ValueError("Pinned module fixture must be clean")
 
 
 def _run_command(arguments: list[str], environment: dict[str, str]) -> int:
@@ -98,8 +126,16 @@ def run_evidence_command(
         arguments.append(selection_value)
     environment = dict(os.environ)
     environment["SPECFACT_MODULES_REPO"] = str(fixture_root.resolve())
+    environment["SPECFACT_MODULES_ROOTS"] = str((fixture_root / "packages").resolve())
     environment.pop("SPECFACT_CLI_MODULES_REPO", None)
-    return command_runner(arguments, environment)
+    try:
+        exit_code = command_runner(arguments, environment)
+    except (OSError, subprocess.SubprocessError) as error:
+        _write_failure_reports(request, f"Released evidence command could not start: {error}")
+        return 1
+    if exit_code != 0:
+        _write_failure_reports(request, f"Released evidence command exited with status {exit_code}.")
+    return exit_code
 
 
 def _fixture_root_from_environment(arguments: argparse.Namespace) -> Path:
@@ -133,19 +169,18 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Verify the fixture, then return the released command's exact exit code."""
     parser = _build_parser()
     arguments = parser.parse_args(argv)
+    request = EvidenceRequest(
+        repo_root=arguments.repo_root.resolve(),
+        selection=_selection(arguments),
+        output_path=arguments.output,
+        summary_path=arguments.summary,
+    )
     try:
-        repo_root = arguments.repo_root.resolve()
-        verify_fixture(_read_fixture_lock(repo_root), _fixture_root_from_environment(arguments))
-        return run_evidence_command(
-            EvidenceRequest(
-                repo_root=repo_root,
-                selection=_selection(arguments),
-                output_path=arguments.output,
-                summary_path=arguments.summary,
-            ),
-            _fixture_root_from_environment(arguments),
-        )
+        fixture_root = _fixture_root_from_environment(arguments)
+        verify_fixture(_read_fixture_lock(request.repo_root), fixture_root)
+        return run_evidence_command(request, fixture_root)
     except ValueError as error:
+        _write_failure_reports(request, str(error))
         parser.error(str(error))
     return 2
 

--- a/scripts/requirements_evidence_delivery_gate.py
+++ b/scripts/requirements_evidence_delivery_gate.py
@@ -1,0 +1,154 @@
+"""Run the released Requirements evidence command from a verified local fixture."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from beartype import beartype
+from icontract import ensure
+
+
+APPROVED_REPOSITORY = "nold-ai/specfact-cli-modules"
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+CommandRunner = Callable[[list[str], dict[str, str]], int]
+GitRunner = Callable[[list[str]], str]
+
+
+@dataclass(frozen=True)
+class EvidenceRequest:
+    """Immutable inputs delegated to the released public evidence command."""
+
+    repo_root: Path
+    selection: tuple[str, str | None]
+    output_path: Path
+    summary_path: Path
+
+
+def _read_fixture_lock(repo_root: Path) -> dict[str, object]:
+    """Load the checked-in immutable module fixture declaration."""
+    lock_path = repo_root / "ci" / "module-fixture.lock.json"
+    try:
+        payload = json.loads(lock_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"Cannot read module fixture lock: {lock_path}") from error
+    if not isinstance(payload, dict):
+        raise ValueError("Module fixture lock must contain a JSON object")
+    return payload
+
+
+def _git_head(arguments: list[str]) -> str:
+    """Resolve a fixture checkout's immutable Git revision."""
+    return subprocess.run(arguments, check=True, capture_output=True, text=True).stdout.strip()
+
+
+@beartype
+@ensure(lambda result: result is None)
+def verify_fixture(fixture: Mapping[str, object], fixture_root: Path, *, git_runner: GitRunner = _git_head) -> None:
+    """Reject any fixture other than the checked-in released module commit."""
+    repository = fixture.get("repository")
+    commit = fixture.get("commit")
+    if repository != APPROVED_REPOSITORY:
+        raise ValueError(f"Module fixture must target {APPROVED_REPOSITORY}")
+    if not isinstance(commit, str) or SHA_PATTERN.fullmatch(commit) is None:
+        raise ValueError("Module fixture commit must be a full immutable SHA")
+    if not fixture_root.is_dir():
+        raise ValueError(f"Pinned module fixture is unavailable: {fixture_root}")
+    try:
+        actual = git_runner(["git", "-C", str(fixture_root), "rev-parse", "HEAD"])
+    except (OSError, subprocess.SubprocessError) as error:
+        raise ValueError(f"Cannot verify pinned module fixture: {fixture_root}") from error
+    if actual.strip() != commit:
+        raise ValueError("Pinned module fixture HEAD does not match ci/module-fixture.lock.json")
+
+
+def _run_command(arguments: list[str], environment: dict[str, str]) -> int:
+    """Execute the module-owned public command without interpreting its verdict."""
+    return subprocess.run(arguments, env=environment, check=False).returncode
+
+
+@beartype
+@ensure(lambda result: isinstance(result, int))
+def run_evidence_command(
+    request: EvidenceRequest, fixture_root: Path, *, command_runner: CommandRunner = _run_command
+) -> int:
+    """Delegate evidence semantics to the fixture's public command unchanged."""
+    selection_flag, selection_value = request.selection
+    arguments = [
+        "hatch",
+        "run",
+        "specfact",
+        "requirements",
+        "evidence",
+        "--repo-root",
+        str(request.repo_root.resolve()),
+        "--output",
+        str(request.output_path),
+        "--summary",
+        str(request.summary_path),
+        selection_flag,
+    ]
+    if selection_value is not None:
+        arguments.append(selection_value)
+    environment = dict(os.environ)
+    environment["SPECFACT_MODULES_REPO"] = str(fixture_root.resolve())
+    environment.pop("SPECFACT_CLI_MODULES_REPO", None)
+    return command_runner(arguments, environment)
+
+
+def _fixture_root_from_environment(arguments: argparse.Namespace) -> Path:
+    configured = arguments.fixture_root or os.environ.get("SPECFACT_MODULES_REPO", "")
+    if not configured:
+        raise ValueError(
+            "Pinned module fixture is unavailable. Set SPECFACT_MODULES_REPO to a checkout at the locked commit."
+        )
+    return Path(configured).expanduser().resolve()
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    selection = parser.add_mutually_exclusive_group(required=True)
+    selection.add_argument("--base-ref", help="Git ref used for pull-request diff selection.")
+    selection.add_argument("--staged", action="store_true", help="Evaluate the current Git index snapshot.")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd(), help="Repository root to inspect.")
+    parser.add_argument("--fixture-root", help="Verified local checkout of the pinned modules fixture.")
+    parser.add_argument("--output", type=Path, required=True, help="Destination JSON evidence report.")
+    parser.add_argument("--summary", type=Path, required=True, help="Destination Markdown evidence report.")
+    return parser
+
+
+def _selection(arguments: argparse.Namespace) -> tuple[str, str | None]:
+    return ("--base-ref", arguments.base_ref) if arguments.base_ref else ("--staged", None)
+
+
+@beartype
+@ensure(lambda result: result in {0, 1, 2})
+def main(argv: Sequence[str] | None = None) -> int:
+    """Verify the fixture, then return the released command's exact exit code."""
+    parser = _build_parser()
+    arguments = parser.parse_args(argv)
+    try:
+        repo_root = arguments.repo_root.resolve()
+        verify_fixture(_read_fixture_lock(repo_root), _fixture_root_from_environment(arguments))
+        return run_evidence_command(
+            EvidenceRequest(
+                repo_root=repo_root,
+                selection=_selection(arguments),
+                output_path=arguments.output,
+                summary_path=arguments.summary,
+            ),
+            _fixture_root_from_environment(arguments),
+        )
+    except ValueError as error:
+        parser.error(str(error))
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/requirements_evidence_delivery_gate.py
+++ b/scripts/requirements_evidence_delivery_gate.py
@@ -49,6 +49,13 @@ def _git_head(arguments: list[str]) -> str:
     return subprocess.run(arguments, check=True, capture_output=True, text=True).stdout.strip()
 
 
+def _reset_report_paths(request: EvidenceRequest) -> None:
+    """Remove prior evidence so each invocation owns its resulting reports."""
+    for report_path in (request.output_path, request.summary_path):
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.unlink(missing_ok=True)
+
+
 def _write_failure_reports(request: EvidenceRequest, message: str) -> None:
     """Write minimal diagnostics without replacing module-owned reports."""
     try:
@@ -176,10 +183,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         summary_path=arguments.summary,
     )
     try:
+        _reset_report_paths(request)
         fixture_root = _fixture_root_from_environment(arguments)
         verify_fixture(_read_fixture_lock(request.repo_root), fixture_root)
         return run_evidence_command(request, fixture_root)
-    except ValueError as error:
+    except (OSError, ValueError) as error:
         _write_failure_reports(request, str(error))
         parser.error(str(error))
     return 2

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 if __name__ == "__main__":
     _setup = setup(
         name="specfact-cli",
-        version="0.53.5",
+        version="0.54.0",
         description=(
             "AI-bloat defense CLI for Python teams. Run deterministic code review, cleanup forecasts, "
             "and spec/contract evidence for AI-assisted and brownfield delivery."

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,4 +3,4 @@ SpecFact CLI - AI-bloat defense CLI for Python teams.
 """
 
 # Package version: keep in sync with pyproject.toml, setup.py, src/specfact_cli/__init__.py
-__version__ = "0.53.5"
+__version__ = "0.54.0"

--- a/src/specfact_cli/__init__.py
+++ b/src/specfact_cli/__init__.py
@@ -76,6 +76,6 @@ def _install_progressive_disclosure() -> None:
 # keeps missing-command and missing-parameter UX consistent outside the root CLI too.
 _install_progressive_disclosure()
 
-__version__ = "0.53.5"
+__version__ = "0.54.0"
 
 __all__ = ["__version__"]

--- a/tests/unit/scripts/test_requirements_evidence_delivery_gate.py
+++ b/tests/unit/scripts/test_requirements_evidence_delivery_gate.py
@@ -1,0 +1,110 @@
+"""Contract tests for the immutable Requirements evidence delivery adapter."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Protocol, cast
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GATE_SCRIPT = REPO_ROOT / "scripts" / "requirements_evidence_delivery_gate.py"
+
+
+class GateModule(Protocol):
+    """Typed public surface supplied by the file-loaded delivery adapter."""
+
+    EvidenceRequest: Callable[..., object]
+
+    def verify_fixture(
+        self, fixture: dict[str, object], fixture_root: Path, *, git_runner: Callable[..., str]
+    ) -> None: ...
+
+    def run_evidence_command(
+        self, request: object, fixture_root: Path, *, command_runner: Callable[..., int]
+    ) -> int: ...
+
+
+def _load_gate_module() -> GateModule:
+    spec = importlib.util.spec_from_file_location("requirements_evidence_delivery_gate", GATE_SCRIPT)
+    if spec is None or spec.loader is None:
+        raise AssertionError("Requirements evidence delivery adapter must be importable")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return cast(GateModule, module)
+
+
+def test_verified_fixture_requires_exact_released_identity(tmp_path: Path) -> None:
+    """Mutable, missing, or wrong-SHA fixture sources must be rejected before execution."""
+    module = _load_gate_module()
+
+    with pytest.raises(ValueError, match="full immutable SHA"):  # type: ignore[reportUnknownMemberType]
+        module.verify_fixture(
+            {"repository": "nold-ai/specfact-cli-modules", "commit": "dev"},
+            tmp_path,
+            git_runner=lambda *_: "",
+        )
+
+    with pytest.raises(  # type: ignore[reportUnknownMemberType]
+        ValueError, match="must target nold-ai/specfact-cli-modules"
+    ):
+        module.verify_fixture(
+            {"repository": "example/other", "commit": "2438372f8e34c96d4e474afa4c66c92a9cee7979"},
+            tmp_path,
+            git_runner=lambda *_: "",
+        )
+
+    with pytest.raises(ValueError, match="does not match"):  # type: ignore[reportUnknownMemberType]
+        module.verify_fixture(
+            {
+                "repository": "nold-ai/specfact-cli-modules",
+                "commit": "2438372f8e34c96d4e474afa4c66c92a9cee7979",
+            },
+            tmp_path,
+            git_runner=lambda *_: "0000000000000000000000000000000000000000",
+        )
+
+
+def test_staged_red_verdict_keeps_both_report_destinations(tmp_path: Path) -> None:
+    """The adapter must propagate a red verdict without deleting module output paths."""
+    module = _load_gate_module()
+    fixture = tmp_path / "fixture"
+    fixture.mkdir()
+    json_report = tmp_path / "reports" / "evidence.json"
+    markdown_report = tmp_path / "reports" / "evidence.md"
+
+    observed = module.run_evidence_command(
+        module.EvidenceRequest(
+            repo_root=tmp_path,
+            selection=("--staged", None),
+            output_path=json_report,
+            summary_path=markdown_report,
+        ),
+        fixture,
+        command_runner=lambda arguments, environment: (
+            json_report.parent.mkdir(parents=True, exist_ok=True),
+            json_report.write_text('{"verdict":"failed"}\n', encoding="utf-8"),
+            markdown_report.write_text("## Requirements evidence\n", encoding="utf-8"),
+            1,
+        )[-1],
+    )
+
+    assert observed == 1
+    assert json_report.read_text(encoding="utf-8") == '{"verdict":"failed"}\n'
+    assert markdown_report.read_text(encoding="utf-8") == "## Requirements evidence\n"
+
+
+def test_pre_commit_places_evidence_before_review_and_contracts() -> None:
+    """A red evidence verdict must stop later Block 2 gates."""
+    pre_commit = (REPO_ROOT / "scripts" / "pre-commit-quality-checks.sh").read_text(encoding="utf-8")
+
+    assert "run_requirements_evidence_gate" in pre_commit
+    block2 = pre_commit[pre_commit.index("run_block2() {") : pre_commit.index("run_all() {")]
+    assert block2.index("run_requirements_evidence_gate") < block2.index("run_code_review_gate")
+    assert block2.index("run_requirements_evidence_gate") < block2.index("run_contract_tests_visible")
+    assert ".specfact/reports/requirements-evidence" in pre_commit

--- a/tests/unit/scripts/test_requirements_evidence_delivery_gate.py
+++ b/tests/unit/scripts/test_requirements_evidence_delivery_gate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -28,6 +29,8 @@ class GateModule(Protocol):
         self, request: object, fixture_root: Path, *, command_runner: Callable[..., int]
     ) -> int: ...
 
+    def main(self, argv: list[str] | None = None) -> int: ...
+
 
 def _load_gate_module() -> GateModule:
     spec = importlib.util.spec_from_file_location("requirements_evidence_delivery_gate", GATE_SCRIPT)
@@ -39,7 +42,7 @@ def _load_gate_module() -> GateModule:
     return cast(GateModule, module)
 
 
-def test_verified_fixture_requires_exact_released_identity(tmp_path: Path) -> None:
+def test_verified_fixture_requires_exact_released_identity_and_clean_tree(tmp_path: Path) -> None:
     """Mutable, missing, or wrong-SHA fixture sources must be rejected before execution."""
     module = _load_gate_module()
 
@@ -59,14 +62,28 @@ def test_verified_fixture_requires_exact_released_identity(tmp_path: Path) -> No
             git_runner=lambda *_: "",
         )
 
-    with pytest.raises(ValueError, match="does not match"):  # type: ignore[reportUnknownMemberType]
+    with pytest.raises(ValueError, match="must use approved release commit"):  # type: ignore[reportUnknownMemberType]
+        module.verify_fixture(
+            {
+                "repository": "nold-ai/specfact-cli-modules",
+                "commit": "0000000000000000000000000000000000000000",
+            },
+            tmp_path,
+            git_runner=lambda *_: "0000000000000000000000000000000000000000",
+        )
+
+    with pytest.raises(ValueError, match="must be clean"):  # type: ignore[reportUnknownMemberType]
         module.verify_fixture(
             {
                 "repository": "nold-ai/specfact-cli-modules",
                 "commit": "2438372f8e34c96d4e474afa4c66c92a9cee7979",
             },
             tmp_path,
-            git_runner=lambda *_: "0000000000000000000000000000000000000000",
+            git_runner=lambda arguments: (
+                "2438372f8e34c96d4e474afa4c66c92a9cee7979"
+                if arguments[-2:] == ["rev-parse", "HEAD"]
+                else " M package.py\n"
+            ),
         )
 
 
@@ -97,6 +114,119 @@ def test_staged_red_verdict_keeps_both_report_destinations(tmp_path: Path) -> No
     assert observed == 1
     assert json_report.read_text(encoding="utf-8") == '{"verdict":"failed"}\n'
     assert markdown_report.read_text(encoding="utf-8") == "## Requirements evidence\n"
+
+
+def test_failed_command_writes_missing_diagnostic_reports_and_exports_fixture_roots(tmp_path: Path) -> None:
+    """A startup failure must retain diagnostics and discover only the verified fixture."""
+    module = _load_gate_module()
+    fixture = tmp_path / "fixture"
+    fixture.mkdir()
+    json_report = tmp_path / "reports" / "evidence.json"
+    markdown_report = tmp_path / "reports" / "evidence.md"
+    observed_environment: dict[str, str] = {}
+
+    observed = module.run_evidence_command(
+        module.EvidenceRequest(
+            repo_root=tmp_path,
+            selection=("--base-ref", "origin/dev"),
+            output_path=json_report,
+            summary_path=markdown_report,
+        ),
+        fixture,
+        command_runner=lambda _arguments, environment: (observed_environment.update(environment), 1)[1],
+    )
+
+    assert observed == 1
+    assert observed_environment["SPECFACT_MODULES_REPO"] == str(fixture.resolve())
+    assert observed_environment["SPECFACT_MODULES_ROOTS"] == str((fixture / "packages").resolve())
+    assert json.loads(json_report.read_text(encoding="utf-8"))["verdict"] == "failed"
+    assert "Requirements evidence unavailable" in markdown_report.read_text(encoding="utf-8")
+
+
+def test_main_rejects_invalid_fixture_before_command_execution_and_writes_diagnostics(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """CLI execution must fail closed before delegating an invalid fixture."""
+    module = _load_gate_module()
+    (tmp_path / "ci").mkdir()
+    (tmp_path / "ci" / "module-fixture.lock.json").write_text(
+        json.dumps({"repository": "example/other", "commit": "2438372f8e34c96d4e474afa4c66c92a9cee7979"}),
+        encoding="utf-8",
+    )
+    fixture = tmp_path / "fixture"
+    fixture.mkdir()
+    json_report = tmp_path / "evidence.json"
+    markdown_report = tmp_path / "evidence.md"
+    invoked = False
+
+    def _unexpected_command(*_args: object, **_kwargs: object) -> int:
+        nonlocal invoked
+        invoked = True
+        return 0
+
+    monkeypatch.setenv("SPECFACT_MODULES_REPO", str(fixture))
+    monkeypatch.setattr(module, "run_evidence_command", _unexpected_command)
+
+    with pytest.raises(SystemExit):
+        module.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "--staged",
+                "--output",
+                str(json_report),
+                "--summary",
+                str(markdown_report),
+            ]
+        )
+
+    assert not invoked
+    assert json.loads(json_report.read_text(encoding="utf-8"))["verdict"] == "failed"
+    assert "must target nold-ai/specfact-cli-modules" in markdown_report.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("selection", [("--staged",), ("--base-ref", "origin/dev")])
+def test_main_forwards_selection_and_verified_fixture(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, selection: tuple[str, ...]
+) -> None:
+    """CLI boundary must delegate the caller selection only after fixture verification."""
+    module = _load_gate_module()
+    fixture = tmp_path / "fixture"
+    fixture.mkdir()
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        module,
+        "_read_fixture_lock",
+        lambda _repo_root: {
+            "repository": "nold-ai/specfact-cli-modules",
+            "commit": "2438372f8e34c96d4e474afa4c66c92a9cee7979",
+        },
+    )
+    monkeypatch.setattr(module, "verify_fixture", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        module,
+        "run_evidence_command",
+        lambda request, fixture_root: captured.update({"request": request, "fixture_root": fixture_root}) or 0,
+    )
+
+    result = module.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--fixture-root",
+            str(fixture),
+            *selection,
+            "--output",
+            str(tmp_path / "evidence.json"),
+            "--summary",
+            str(tmp_path / "evidence.md"),
+        ]
+    )
+
+    request = cast(object, captured["request"])
+    assert result == 0
+    assert captured["fixture_root"] == fixture.resolve()
+    assert request.selection == (("--staged", None) if selection == ("--staged",) else ("--base-ref", "origin/dev"))
 
 
 def test_pre_commit_places_evidence_before_review_and_contracts() -> None:

--- a/tests/unit/scripts/test_requirements_evidence_delivery_gate.py
+++ b/tests/unit/scripts/test_requirements_evidence_delivery_gate.py
@@ -32,6 +32,12 @@ class GateModule(Protocol):
     def main(self, argv: list[str] | None = None) -> int: ...
 
 
+class CapturedRequest(Protocol):
+    """Minimal assertion surface retained from a delegated evidence request."""
+
+    selection: tuple[str, str | None]
+
+
 def _load_gate_module() -> GateModule:
     spec = importlib.util.spec_from_file_location("requirements_evidence_delivery_gate", GATE_SCRIPT)
     if spec is None or spec.loader is None:
@@ -157,6 +163,8 @@ def test_main_rejects_invalid_fixture_before_command_execution_and_writes_diagno
     fixture.mkdir()
     json_report = tmp_path / "evidence.json"
     markdown_report = tmp_path / "evidence.md"
+    json_report.write_text('{"verdict":"passed"}\n', encoding="utf-8")
+    markdown_report.write_text("## Previous passing evidence\n", encoding="utf-8")
     invoked = False
 
     def _unexpected_command(*_args: object, **_kwargs: object) -> int:
@@ -183,6 +191,7 @@ def test_main_rejects_invalid_fixture_before_command_execution_and_writes_diagno
     assert not invoked
     assert json.loads(json_report.read_text(encoding="utf-8"))["verdict"] == "failed"
     assert "must target nold-ai/specfact-cli-modules" in markdown_report.read_text(encoding="utf-8")
+    assert "Previous passing evidence" not in markdown_report.read_text(encoding="utf-8")
 
 
 @pytest.mark.parametrize("selection", [("--staged",), ("--base-ref", "origin/dev")])
@@ -223,7 +232,7 @@ def test_main_forwards_selection_and_verified_fixture(
         ]
     )
 
-    request = cast(object, captured["request"])
+    request = cast(CapturedRequest, captured["request"])
     assert result == 0
     assert captured["fixture_root"] == fixture.resolve()
     assert request.selection == (("--staged", None) if selection == ("--staged",) else ("--base-ref", "origin/dev"))

--- a/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
+++ b/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
@@ -16,7 +16,8 @@ def _assert_fixture_contract(raw: str) -> None:
 
 
 def _assert_command_contract(raw: str) -> None:
-    assert "specfact requirements evidence" in raw
+    assert "uv run --locked --no-sync specfact requirements evidence" in raw
+    assert "hatch run specfact requirements evidence" not in raw
     assert "--base-ref" in raw
     assert "artifacts/requirements-evidence/requirements-evidence.json" in raw
     assert "artifacts/requirements-evidence/requirements-evidence.md" in raw

--- a/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
+++ b/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
@@ -13,6 +13,7 @@ def _assert_fixture_contract(raw: str) -> None:
     assert "nold-ai/specfact-cli-modules" in raw
     assert "Verify immutable module fixture" in raw
     assert "SPECFACT_MODULES_REPO=${GITHUB_WORKSPACE}/specfact-cli-modules" in raw
+    assert "SPECFACT_MODULES_ROOTS=${GITHUB_WORKSPACE}/specfact-cli-modules/packages" in raw
 
 
 def _assert_command_contract(raw: str) -> None:

--- a/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
+++ b/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
@@ -15,6 +15,12 @@ def _step_by_name(workflow: dict[str, object], name: str) -> dict[str, object]:
     return next(step for step in steps if step.get("name") == name)  # type: ignore[union-attr,return-value]
 
 
+def _step_index(workflow: dict[str, object], name: str) -> int:
+    """Return a named step's position in the evidence job."""
+    steps = workflow["jobs"]["requirements-evidence"]["steps"]  # type: ignore[index]
+    return next(index for index, step in enumerate(steps) if step.get("name") == name)  # type: ignore[union-attr]
+
+
 def _assert_fixture_contract(workflow: dict[str, object]) -> None:
     read_fixture = _step_by_name(workflow, "Read immutable module fixture")
     verify_fixture = _step_by_name(workflow, "Verify immutable module fixture")
@@ -28,6 +34,7 @@ def _assert_fixture_contract(workflow: dict[str, object]) -> None:
 
 def _assert_command_contract(workflow: dict[str, object]) -> None:
     run_evidence = _step_by_name(workflow, "Run Requirements evidence gate")
+    assert run_evidence["id"] == "run-evidence"  # type: ignore[index]
     assert "uv run --locked --no-sync specfact requirements evidence" in run_evidence["run"]  # type: ignore[index]
     assert '--base-ref "origin/${EVIDENCE_BASE_BRANCH}"' in run_evidence["run"]  # type: ignore[index]
     assert run_evidence["env"]["EVIDENCE_BASE_BRANCH"]  # type: ignore[index]
@@ -48,6 +55,12 @@ def _assert_retention_contract(workflow: dict[str, object]) -> None:
     ]
     assert enforce["if"] == "steps.run-evidence.outcome == 'failure'"  # type: ignore[index]
     assert enforce["run"] == "exit 1"  # type: ignore[index]
+    assert _step_index(workflow, "Publish Requirements evidence summary") < _step_index(
+        workflow, "Enforce requirements evidence verdict"
+    )
+    assert _step_index(workflow, "Upload requirements evidence artifact") < _step_index(
+        workflow, "Enforce requirements evidence verdict"
+    )
 
 
 def test_requirements_evidence_workflow_uses_the_released_fixture_and_retains_reports() -> None:

--- a/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
+++ b/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
@@ -4,38 +4,58 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import yaml
+
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
-def _assert_fixture_contract(raw: str) -> None:
-    assert "ci/module-fixture.lock.json" in raw
-    assert "nold-ai/specfact-cli-modules" in raw
-    assert "Verify immutable module fixture" in raw
-    assert "SPECFACT_MODULES_REPO=${GITHUB_WORKSPACE}/specfact-cli-modules" in raw
-    assert "SPECFACT_MODULES_ROOTS=${GITHUB_WORKSPACE}/specfact-cli-modules/packages" in raw
+def _step_by_name(workflow: dict[str, object], name: str) -> dict[str, object]:
+    steps = workflow["jobs"]["requirements-evidence"]["steps"]  # type: ignore[index]
+    return next(step for step in steps if step.get("name") == name)  # type: ignore[union-attr,return-value]
 
 
-def _assert_command_contract(raw: str) -> None:
-    assert "uv run --locked --no-sync specfact requirements evidence" in raw
-    assert "hatch run specfact requirements evidence" not in raw
-    assert "--base-ref" in raw
-    assert "artifacts/requirements-evidence/requirements-evidence.json" in raw
-    assert "artifacts/requirements-evidence/requirements-evidence.md" in raw
+def _assert_fixture_contract(workflow: dict[str, object]) -> None:
+    read_fixture = _step_by_name(workflow, "Read immutable module fixture")
+    verify_fixture = _step_by_name(workflow, "Verify immutable module fixture")
+    export_fixture = _step_by_name(workflow, "Export verified module fixture paths")
+    assert "ci/module-fixture.lock.json" in read_fixture["run"]  # type: ignore[index]
+    assert "nold-ai/specfact-cli-modules" in read_fixture["run"]  # type: ignore[index]
+    assert "rev-parse HEAD" in verify_fixture["run"]  # type: ignore[index]
+    assert "SPECFACT_MODULES_REPO=${GITHUB_WORKSPACE}/specfact-cli-modules" in export_fixture["run"]  # type: ignore[index]
+    assert "SPECFACT_MODULES_ROOTS=${GITHUB_WORKSPACE}/specfact-cli-modules/packages" in export_fixture["run"]  # type: ignore[index]
 
 
-def _assert_retention_contract(raw: str) -> None:
-    assert "GITHUB_STEP_SUMMARY" in raw
-    assert raw.count("if: always()") >= 2
-    assert raw.index("Upload requirements evidence artifact") < raw.index("Enforce requirements evidence verdict")
+def _assert_command_contract(workflow: dict[str, object]) -> None:
+    run_evidence = _step_by_name(workflow, "Run Requirements evidence gate")
+    assert "uv run --locked --no-sync specfact requirements evidence" in run_evidence["run"]  # type: ignore[index]
+    assert '--base-ref "origin/${EVIDENCE_BASE_BRANCH}"' in run_evidence["run"]  # type: ignore[index]
+    assert run_evidence["env"]["EVIDENCE_BASE_BRANCH"]  # type: ignore[index]
+    assert "workflow_dispatch" in workflow["on"]  # type: ignore[operator]
+
+
+def _assert_retention_contract(workflow: dict[str, object]) -> None:
+    publish = _step_by_name(workflow, "Publish Requirements evidence summary")
+    upload = _step_by_name(workflow, "Upload requirements evidence artifact")
+    enforce = _step_by_name(workflow, "Enforce requirements evidence verdict")
+    assert publish["if"] == "always()"  # type: ignore[index]
+    assert "GITHUB_STEP_SUMMARY" in publish["run"]  # type: ignore[index]
+    assert upload["if"] == "always()"  # type: ignore[index]
+    assert upload["uses"] == "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"  # type: ignore[index]
+    assert upload["with"]["path"].splitlines() == [  # type: ignore[index]
+        "artifacts/requirements-evidence/requirements-evidence.json",
+        "artifacts/requirements-evidence/requirements-evidence.md",
+    ]
+    assert enforce["if"] == "steps.run-evidence.outcome == 'failure'"  # type: ignore[index]
+    assert enforce["run"] == "exit 1"  # type: ignore[index]
 
 
 def test_requirements_evidence_workflow_uses_the_released_fixture_and_retains_reports() -> None:
     """PR enforcement must verify the fixture and publish output before failing red verdicts."""
     workflow = REPO_ROOT / ".github" / "workflows" / "requirements-evidence.yml"
-    raw = workflow.read_text(encoding="utf-8")
+    parsed = yaml.load(workflow.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
 
-    assert "pull_request:" in raw
-    _assert_fixture_contract(raw)
-    _assert_command_contract(raw)
-    _assert_retention_contract(raw)
+    assert "pull_request" in parsed["on"]
+    _assert_fixture_contract(parsed)
+    _assert_command_contract(parsed)
+    _assert_retention_contract(parsed)

--- a/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
+++ b/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
@@ -1,0 +1,39 @@
+"""Contract coverage for the core Requirements-evidence pull-request gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _assert_fixture_contract(raw: str) -> None:
+    assert "ci/module-fixture.lock.json" in raw
+    assert "nold-ai/specfact-cli-modules" in raw
+    assert "Verify immutable module fixture" in raw
+    assert "SPECFACT_MODULES_REPO=${GITHUB_WORKSPACE}/specfact-cli-modules" in raw
+
+
+def _assert_command_contract(raw: str) -> None:
+    assert "specfact requirements evidence" in raw
+    assert "--base-ref" in raw
+    assert "artifacts/requirements-evidence/requirements-evidence.json" in raw
+    assert "artifacts/requirements-evidence/requirements-evidence.md" in raw
+
+
+def _assert_retention_contract(raw: str) -> None:
+    assert "GITHUB_STEP_SUMMARY" in raw
+    assert raw.count("if: always()") >= 2
+    assert raw.index("Upload requirements evidence artifact") < raw.index("Enforce requirements evidence verdict")
+
+
+def test_requirements_evidence_workflow_uses_the_released_fixture_and_retains_reports() -> None:
+    """PR enforcement must verify the fixture and publish output before failing red verdicts."""
+    workflow = REPO_ROOT / ".github" / "workflows" / "requirements-evidence.yml"
+    raw = workflow.read_text(encoding="utf-8")
+
+    assert "pull_request:" in raw
+    _assert_fixture_contract(raw)
+    _assert_command_contract(raw)
+    _assert_retention_contract(raw)

--- a/uv.lock
+++ b/uv.lock
@@ -2770,7 +2770,7 @@ wheels = [
 
 [[package]]
 name = "specfact-cli"
-version = "0.53.5"
+version = "0.54.0"
 source = { editable = "." }
 dependencies = [
     { name = "azure-identity" },


### PR DESCRIPTION
Closes #657

## Summary

- Pin the released `specfact-requirements` 0.3.3 fixture at `2438372f8e34c96d4e474afa4c66c92a9cee7979`.
- Enforce staged Requirements evidence before Block 2 code review and contract checks, retaining JSON and Markdown remediation reports.
- Add matching pull-request enforcement with base-ref mode, GitHub summary, and always-uploaded artifacts.
- Regenerate the core command catalogue for `specfact requirements evidence` and release core 0.54.0.

## Validation

- Focused delivery-gate tests: 4 passed.
- Staged dogfooding run: 1 requirement imported with 2 test links; verdict passed.
- Format, type, lint, YAML, reproducible-delivery, version, command/docs, OpenSpec, Semgrep, Bandit, and changed-scope code review passed (0 review findings).
- Full contract/smart suites are expected to run in PR CI; local fresh-baseline streaming did not reach a final summary.

## Notes

- The local shared pre-commit hook resolves the primary checkout's stale fixture lock in this worktree. The direct equivalent Block 2 gate was run with the verified fixture before the signed commit.