### PR TITLE
fix(ci): harden requirements evidence gate

### DIFF
--- a/.github/workflows/requirements-evidence.yml
+++ b/.github/workflows/requirements-evidence.yml
@@ -39,9 +39,11 @@ jobs:
           set -euo pipefail
           repository="$(python -c 'import json; print(json.load(open("ci/module-fixture.lock.json", encoding="utf-8"))["repository"])')"
           commit="$(python -c 'import json; print(json.load(open("ci/module-fixture.lock.json", encoding="utf-8"))["commit"])')"
+          approved_commit="2438372f8e34c96d4e474afa4c66c92a9cee7979"
           [[ "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]
           test "$repository" = "nold-ai/specfact-cli-modules"
           [[ "$commit" =~ ^[0-9a-f]{40}$ ]]
+          test "$commit" = "$approved_commit"
           printf 'repository=%s\n' "$repository" >> "$GITHUB_OUTPUT"
           printf 'commit=%s\n' "$commit" >> "$GITHUB_OUTPUT"
 
@@ -94,11 +96,17 @@ jobs:
             --summary artifacts/requirements-evidence/requirements-evidence.md
           exit_code=$?
           set -e
+          fallback_required=0
           if [[ ! -s artifacts/requirements-evidence/requirements-evidence.json ]]; then
             printf '{"schema_version":1,"verdict":"failed","diagnostic":"Evidence command exited with status %s before writing JSON."}\n' "$exit_code" > artifacts/requirements-evidence/requirements-evidence.json
+            fallback_required=1
           fi
           if [[ ! -s artifacts/requirements-evidence/requirements-evidence.md ]]; then
             printf '## Requirements evidence unavailable\n\n- Diagnostic: Evidence command exited with status %s before writing Markdown.\n' "$exit_code" > artifacts/requirements-evidence/requirements-evidence.md
+            fallback_required=1
+          fi
+          if [[ "$fallback_required" -eq 1 ]]; then
+            exit 1
           fi
           exit "$exit_code"
 

--- a/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
+++ b/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
@@ -8,6 +8,7 @@ import yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+APPROVED_MODULE_COMMIT = "2438372f8e34c96d4e474afa4c66c92a9cee7979"
 
 
 def _step_by_name(workflow: dict[str, object], name: str) -> dict[str, object]:
@@ -27,6 +28,8 @@ def _assert_fixture_contract(workflow: dict[str, object]) -> None:
     export_fixture = _step_by_name(workflow, "Export verified module fixture paths")
     assert "ci/module-fixture.lock.json" in read_fixture["run"]  # type: ignore[index]
     assert "nold-ai/specfact-cli-modules" in read_fixture["run"]  # type: ignore[index]
+    assert f'approved_commit="{APPROVED_MODULE_COMMIT}"' in read_fixture["run"]  # type: ignore[index]
+    assert 'test "$commit" = "$approved_commit"' in read_fixture["run"]  # type: ignore[index]
     assert "rev-parse HEAD" in verify_fixture["run"]  # type: ignore[index]
     assert "SPECFACT_MODULES_REPO=${GITHUB_WORKSPACE}/specfact-cli-modules" in export_fixture["run"]  # type: ignore[index]
     assert "SPECFACT_MODULES_ROOTS=${GITHUB_WORKSPACE}/specfact-cli-modules/packages" in export_fixture["run"]  # type: ignore[index]
@@ -39,6 +42,10 @@ def _assert_command_contract(workflow: dict[str, object]) -> None:
     assert '--base-ref "origin/${EVIDENCE_BASE_BRANCH}"' in run_evidence["run"]  # type: ignore[index]
     assert run_evidence["env"]["EVIDENCE_BASE_BRANCH"]  # type: ignore[index]
     assert "workflow_dispatch" in workflow["on"]  # type: ignore[operator]
+    assert "fallback_required=0" in run_evidence["run"]  # type: ignore[index]
+    assert "fallback_required=1" in run_evidence["run"]  # type: ignore[index]
+    assert 'if [[ "$fallback_required" -eq 1 ]]; then' in run_evidence["run"]  # type: ignore[index]
+    assert "exit 1" in run_evidence["run"]  # type: ignore[index]
 
 
 def _assert_retention_contract(workflow: dict[str, object]) -> None:


### PR DESCRIPTION
## Summary

Addresses the two active Codex review findings from release PR #659:

- reject any module fixture SHA other than the approved released commit before checkout;
- fail closed when the evidence command omits either required report.

## Verification

- Regression evidence: the workflow contract test failed before the implementation and passes after it.
- hatch run test tests/unit/workflows/test_requirements_evidence_delivery_workflow.py tests/unit/workflows/test_trustworthy_green_checks.py (48 passed)
- hatch run workflows-lint .github/workflows/requirements-evidence.yml
- manual code-review gate: 0 findings
- contract status: 0 violations

## Note

The local aggregate pre-commit block could not regenerate command artifacts because this checkout's module source lacks the checked-in evidence command. The generated artifacts were preserved unchanged; CI validates the authoritative pinned module environment.