### PR TITLE
fix: include conftest imports in proof freshness

### DIFF
--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1104,3 +1104,21 @@
 - **Internal wiki follow-up:** the sibling `specfact-cli-internal` checkout was
   unavailable. Update `wiki/sources/requirements-07-runtime-proof-delivery.md`
   and run `python3 scripts/wiki_rebuild_graph.py` from that repository root.
+
+## Codex follow-up conftest-import freshness remediation
+
+- **Recorded:** 2026-08-09 (UTC)
+- **Review finding:** PR #667 identified that import traversal started only at
+  selected tests, so a helper imported exclusively by an applicable
+  `conftest.py` could change after red without invalidating retained proof.
+- **Failing-before command:** `hatch run pytest tests/unit/scripts/test_requirements_proof_provenance.py::test_git_bound_red_proof_rejects_changed_support_imported_by_conftest -q`
+- **Failing result:** 1 test failed because the changed helper produced no
+  provenance finding.
+- **Passing-after command:** `hatch run pytest tests/unit/scripts/test_requirements_proof_provenance.py -q`
+- **Passing result:** all 25 tests passed after seeding recursive import
+  traversal with the selected test and every applicable `conftest.py` path.
+- **Skipped:** 0 tests.
+- **Environment:** Linux, Python 3.12.13, pytest 9.1.1.
+- **Internal wiki follow-up:** the sibling `specfact-cli-internal` checkout was
+  unavailable. Update `wiki/sources/requirements-07-runtime-proof-delivery.md`
+  and run `python3 scripts/wiki_rebuild_graph.py` from that repository root.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -53,9 +53,9 @@ maturity. The
 proof SHALL bind the commit/tree, merge base, mapping digest, selectors,
 test-file digests, JUnit digest, and toolchain identity. Core SHALL reject
 proof when governed production changed before the red commit, including a
-governed source renamed outside its prefix, or when selectors, their
-repository-local imported Python support modules, or test files changed after
-it. Before forwarding a prior-red report to the
+governed source renamed outside its prefix, or when selectors, applicable
+pytest `conftest.py` files, their repository-local imported Python support
+modules, or test files changed after it. Before forwarding a prior-red report to the
 released reconciliation command, core SHALL verify that its source commit is a
 strict ancestor of the final source, the current pull-request base is an
 ancestor of that source, and that the selected test files remain
@@ -84,8 +84,9 @@ SHALL NOT extend it to any other change.
 #### Scenario: Same-commit or stale red proof is rejected
 
 - **GIVEN** tests and production code first appear in the same commit, or a
-  mapped selector, its repository-local imported Python support module, or its
-  test file changes after the red proof
+  mapped selector, its applicable pytest `conftest.py`, a repository-local
+  Python support module imported by either input, or its test file changes after
+  the red proof
 - **WHEN** the gate evaluates a governed production diff
 - **THEN** it fails with `tdd-order-unproven` or `stale-red-proof`
 - **AND** retained-run discovery searches every completed-run page, skips

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -119,9 +119,9 @@ def _python_module_path(repo_root: Path, source_ref: str, module_parts: Sequence
     return None
 
 
-def _imported_python_paths(repo_root: Path, source_ref: str, test_path: str) -> set[str]:
-    """Return transitive repository-local Python imports used by a selected test."""
-    pending = [test_path]
+def _imported_python_paths(repo_root: Path, source_ref: str, source_paths: Sequence[str]) -> set[str]:
+    """Return transitive repository-local Python imports used by pytest inputs."""
+    pending = list(source_paths)
     imported_paths: set[str] = set()
     while pending:
         current_path = pending.pop()
@@ -372,10 +372,10 @@ def validate_prior_red_proof(red_proof_path: Path, repo_root: Path, *, base_ref:
             repo_root, source_ref, test_path
         ):
             return ["prior-red-proof-invalid"]
+        pytest_inputs = {test_path, *_applicable_conftest_paths(test_path)}
         proof_inputs = {
-            test_path,
-            *_applicable_conftest_paths(test_path),
-            *_imported_python_paths(repo_root, source_ref, test_path),
+            *pytest_inputs,
+            *_imported_python_paths(repo_root, source_ref, sorted(pytest_inputs)),
         }
         if not proof_inputs.isdisjoint(paths_after_red):
             return ["stale-red-proof"]

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -185,6 +185,32 @@ def test_git_bound_red_proof_rejects_changed_imported_test_support(tmp_path: Pat
     ]
 
 
+def test_git_bound_red_proof_rejects_changed_support_imported_by_conftest(tmp_path: Path) -> None:
+    """A helper reached through conftest must remain bound to the red failure."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    helper_path = tests_path / "support.py"
+    helper_path.write_text("VALUE = False\n", encoding="utf-8")
+    (tests_path / "conftest.py").write_text("from tests.support import VALUE\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add pytest support")
+    test_path = tests_path / "test_proof.py"
+    test_path.write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    helper_path.write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change conftest helper")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
 def test_git_bound_red_proof_rejects_symlink_selector(tmp_path: Path) -> None:
     """A selector symlink must not hide mutable target bytes from provenance."""
     module = _load_provenance_module()


### PR DESCRIPTION
## Summary

Follow-up to #667 for the remaining Codex P1 review finding.

- seed repository-local import traversal with selected tests and every applicable `conftest.py`
- invalidate retained red proof when a helper imported through pytest support changes after red
- add a focused failing-first regression and update the active OpenSpec contract/evidence

## Testing

- `hatch run pytest tests/unit/scripts/test_requirements_proof_provenance.py -q` (25 passed)
- `hatch run pytest tests/unit/scripts/test_requirements_proof_provenance.py tests/unit/workflows/test_requirements_evidence_delivery_workflow.py -q`
- `hatch run format`
- `hatch run type-check`
- `hatch run lint`
- `hatch run yaml-lint`
- `hatch run contract-test`
- `openspec validate requirements-07-runtime-proof-delivery --strict`

Targets `dev` (not `main`) as requested.
