### PR TITLE
fix: bind pytest plugins to red-proof provenance

### DIFF
--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1122,3 +1122,18 @@
 - **Internal wiki follow-up:** the sibling `specfact-cli-internal` checkout was
   unavailable. Update `wiki/sources/requirements-07-runtime-proof-delivery.md`
   and run `python3 scripts/wiki_rebuild_graph.py` from that repository root.
+
+## Codex follow-up pytest-plugin freshness remediation
+
+- **Recorded:** 2026-08-09 (UTC)
+- **Review finding:** PR #665 identified that static `pytest_plugins`
+  declarations in an applicable `conftest.py` were not traversed, allowing a
+  registered plugin to change after red without invalidating retained proof.
+- **Failing-before command:** `hatch run pytest tests/unit/scripts/test_requirements_proof_provenance.py::test_git_bound_red_proof_rejects_changed_pytest_plugin_registered_by_conftest -q`
+- **Failing result:** 1 test failed because changing the registered plugin
+  produced no provenance finding.
+- **Passing-after command:** `hatch run pytest tests/unit/scripts/test_requirements_proof_provenance.py -q`
+- **Passing result:** all 26 tests passed after resolving static
+  `pytest_plugins` module names and recursively traversing their local imports.
+- **Skipped:** 0 tests.
+- **Environment:** Linux, Python 3.12.13, pytest 9.1.1.

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -119,6 +119,25 @@ def _python_module_path(repo_root: Path, source_ref: str, module_parts: Sequence
     return None
 
 
+def _static_pytest_plugin_names(tree: ast.AST) -> list[str]:
+    """Return module names from static ``pytest_plugins`` declarations."""
+    names: list[str] = []
+    for node in ast.walk(tree):
+        value: ast.expr | None = None
+        if (
+            isinstance(node, ast.Assign)
+            and any(isinstance(target, ast.Name) and target.id == "pytest_plugins" for target in node.targets)
+        ) or (
+            isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.target.id == "pytest_plugins"
+        ):
+            value = node.value
+        if value is None:
+            continue
+        values = value.elts if isinstance(value, (ast.List, ast.Tuple, ast.Set)) else [value]
+        names.extend(item.value for item in values if isinstance(item, ast.Constant) and isinstance(item.value, str))
+    return names
+
+
 def _imported_python_paths(repo_root: Path, source_ref: str, source_paths: Sequence[str]) -> set[str]:
     """Return transitive repository-local Python imports used by pytest inputs."""
     pending = list(source_paths)
@@ -133,6 +152,12 @@ def _imported_python_paths(repo_root: Path, source_ref: str, source_paths: Seque
         if tree is None:
             continue
         current_package = list(PurePosixPath(current_path).parent.parts)
+        plugin_modules = (name.split(".") for name in _static_pytest_plugin_names(tree))
+        for module_parts in plugin_modules:
+            imported_path = _python_module_path(repo_root, source_ref, module_parts)
+            if imported_path is not None and imported_path not in imported_paths:
+                imported_paths.add(imported_path)
+                pending.append(imported_path)
         for node in ast.walk(tree):
             module_names: list[list[str]] = []
             if isinstance(node, ast.Import):

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -211,6 +211,35 @@ def test_git_bound_red_proof_rejects_changed_support_imported_by_conftest(tmp_pa
     ]
 
 
+def test_git_bound_red_proof_rejects_changed_pytest_plugin_registered_by_conftest(tmp_path: Path) -> None:
+    """A statically registered pytest plugin must remain bound to the red failure."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    plugin_path = tests_path / "pytest_support.py"
+    plugin_path.write_text("VALUE = False\n", encoding="utf-8")
+    (tests_path / "conftest.py").write_text(
+        'pytest_plugins = ("tests.pytest_support",)\n',
+        encoding="utf-8",
+    )
+    base_ref = _commit(tmp_path, "test: add pytest plugin")
+    test_path = tests_path / "test_proof.py"
+    test_path.write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    plugin_path.write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change registered pytest plugin")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
 def test_git_bound_red_proof_rejects_symlink_selector(tmp_path: Path) -> None:
     """A selector symlink must not hide mutable target bytes from provenance."""
     module = _load_provenance_module()


### PR DESCRIPTION
## Summary

- recognize static `pytest_plugins` declarations while traversing applicable pytest inputs
- recursively bind repository-local plugin modules and their imports to retained red proof
- add regression coverage and failing-before/passing-after TDD evidence

## Testing

- `hatch run pytest tests/unit/scripts/test_requirements_proof_provenance.py -q` (26 passed)
- `hatch run lint-changed scripts/requirements_proof_provenance.py tests/unit/scripts/test_requirements_proof_provenance.py`
- `hatch run type-check`
- `openspec validate requirements-07-runtime-proof-delivery --strict`

Follow-up remediation on top of #665.