### PR TITLE
fix(requirements): bind pytest package and annotated plugin inputs

### DIFF
--- a/.github/workflows/requirements-evidence.yml
+++ b/.github/workflows/requirements-evidence.yml
@@ -297,7 +297,7 @@ jobs:
               elif [[ "$run_stage" == "final" && "$selected_change" == "requirements-07-runtime-proof-delivery" ]]; then
                 legacy_tdd_ledger="openspec/changes/${selected_change}/TDD_EVIDENCE.md"
                 legacy_tdd_line_count=1143
-                legacy_tdd_ledger_digest="sha256:1df90efd2402f14879da7705ab8afbf054eafc0fa71ff7a788df9f3db97b428c"
+                legacy_tdd_ledger_digest="sha256:d6e35c934757c08fd1f3e3071fc02b92b080c009ba5e428f6ea2888e7cd5e8c3"
                 legacy_tdd_mapping_digest="sha256:eccdf006792d8910c54a773e30967886063b4e30c99c180bc36d7372b1bbd9ef"
                 legacy_tdd_plan_digest="sha256:27ea6e6bcea0d68d68688b89fc8f89315d213b96918f4f76979484756fd8335e"
                 legacy_tdd_artifact="artifacts/requirements-evidence/approved-legacy-tdd-ledger.md"

--- a/openspec/changes/requirements-07-runtime-proof-delivery/CHANGE_VALIDATION.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/CHANGE_VALIDATION.md
@@ -52,10 +52,13 @@ Remediation extended `scripts/requirements_proof_provenance.py` to resolve the
 complete pytest-determining input set and to fail closed on any input it cannot
 read, parse, or statically resolve. Two consequences for this report:
 
-- The gate script is now a declared touchpoint of `git-bound-failing-first-proof`
-  in `requirements-evidence.yaml`. It was previously absent, so this change's own
-  "changed interface -> mapped touchpoint -> exact selector" chain did not cover
-  the file implementing the requirement.
+- The gate script is not a declared touchpoint of `git-bound-failing-first-proof`
+  in `requirements-evidence.yaml`, so this change's own "changed interface ->
+  mapped touchpoint -> exact selector" chain does not cover the file
+  implementing the requirement. The correction is drafted in task 3.9 but
+  deliberately not applied here: it changes the mapping digest, which is pinned
+  in the acceptance record and in two workflow constants that only a
+  product-owner run can regenerate.
 - The requirement text no longer restates a partial input list. The enumeration
   exists once, in the retained-proof scenario, because the duplicate had already
   drifted behind the implementation.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/CHANGE_VALIDATION.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/CHANGE_VALIDATION.md
@@ -44,10 +44,33 @@ mapping/plan binding, but it cannot read the core repository ledger. Core must
 therefore verify that the record's `ledger_digest` equals the committed
 `TDD_EVIDENCE.md` bytes before invoking the module.
 
+## Post-Review Revalidation (2026-08-11)
+
+Independent review of the failing-first gate found that a retained red proof was
+accepted while inputs pytest actually reads could change after the red source.
+Remediation extended `scripts/requirements_proof_provenance.py` to resolve the
+complete pytest-determining input set and to fail closed on any input it cannot
+read, parse, or statically resolve. Two consequences for this report:
+
+- The gate script is now a declared touchpoint of `git-bound-failing-first-proof`
+  in `requirements-evidence.yaml`. It was previously absent, so this change's own
+  "changed interface -> mapped touchpoint -> exact selector" chain did not cover
+  the file implementing the requirement.
+- The requirement text no longer restates a partial input list. The enumeration
+  exists once, in the retained-proof scenario, because the duplicate had already
+  drifted behind the implementation.
+
+Validation result remains Pass and impact level remains Medium. No public core
+command signature changed, and the resolved proof inputs for this repository are
+unchanged, so the hardening rejects evidence that was previously accepted without
+widening what a valid red-to-green flow must hold stable.
+
 ## Impact Assessment
 
-- **Code Impact:** CI workflow, fixture lock, and the internal
-  runtime-discovery smoke registry; no public core command signature changes.
+- **Code Impact:** CI workflow, fixture lock, the internal runtime-discovery
+  smoke registry, and the red-proof provenance validator
+  `scripts/requirements_proof_provenance.py`; no public core command signature
+  changes.
 - **Test Impact:** workflow contract coverage and evidence-mapping selector
   coverage require additions.
 - **Documentation Impact:** the active change specification and design require

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -3055,3 +3055,69 @@ the cheapest way to close a class, and a layout is four lines.
 
 - **Passing-after:** 13 in the oracle, 689 across the scripts, workflows, and
   integration suites.
+
+## Round 28: three findings, and the check that would have caught one of them
+
+### A mutation receiver read the way an argument already was
+
+`[PLUGINS][0].append("tests.localplugin")` mutates the aliased plugin list, but the rule
+matched only a bare `ast.Name` receiver, so the declaration resolved to no plugins.
+
+- **Failing-first, after a false start worth recording.** The first attempt asserted
+  through a whole proof and **passed while the defect was present**. The dotted
+  literal `"tests.localplugin"` is bound by the dynamic-import rule, so the proof
+  came out stale for an unrelated reason. Driving `_pytest_plugin_names` directly
+  showed the truth: five of six wrapper shapes resolved to `[]` where
+  `stale-red-proof` was required. The lesson is the same one round 25 recorded —
+  a green test is not evidence until you know which rule made it green.
+
+The receiver is now read exactly as an argument already was: every name inside it
+counts, at any nesting. `_call_argument_names` had carried that reasoning since the
+guard work; the receiver simply never received it. A positive control keeps the
+widening honest — a declaration no wrapper touches still resolves.
+
+### Every command, not every call site
+
+Round 23 separated "absent" from "could not answer" for path lookups. A **second**
+cached command kept the conflation: a failed symlink inventory returned an empty
+set, which reads as "this repository has no symlinks", and an import beneath a
+linked directory was skipped rather than rejected.
+
+Rather than fix the reported one, every Git result in the module was audited.
+`_is_ancestor`, `_changed_paths_in_history` and `_blob_digest_at_ref` already fail
+closed. Two did not: the symlink inventory, and `_artifact_is_tracked`, which used
+`ls-files --error-unmatch` — an exit code that means both "untracked" and "could not
+run", so a timeout read as an untracked artifact and a committed proof would have
+been accepted. It now asks for the listing instead, where an answer, an empty
+answer, and a failure are three distinct outcomes.
+
+- **Failing-first.** Both sites returned `[]` and `[]` where `['stale-red-proof']`
+  and `['prior-red-proof-invalid']` were required.
+
+### An over-strictness this work introduced
+
+Review found that `registry.entries[__name__].touch()` was classified as the module
+table purely because the mapping was an attribute and the key was `__name__`, so
+every proof in such a repository was rejected. That predicate was written two rounds
+ago in this change; the finding is against work done here, not against pytest.
+
+The table is now identified as the table — an attribute named `modules` — rather
+than by the shape of the expression around it.
+
+### Making the oracle catch that class
+
+The oracle added in round 26 checks one direction: everything pytest touched must be
+bound. This finding was the other direction, and nothing executable covered it for
+synthetic shapes. Every layout now also asserts that a production file the run never
+opened stays unbound, and three layouts were added whose only purpose is to look
+like something the gate rejects while reaching nothing it reads.
+
+- **Proof the new direction fires.** The first version of the inert layout used a
+  `Name`-keyed mapping and passed against the restored over-strict predicate —
+  the wrong shape, and it proved nothing. Corrected to the attribute-backed form the
+  finding names, it fails against that predicate and passes against the fix. The
+  check was calibrated against the defect rather than assumed to cover it.
+
+- **Whole-repository measurement.** Zero added, zero removed.
+- **Passing-after:** 302 in the provenance file, 16 in the oracle, 702 across the
+  scripts, workflows, and integration suites.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1188,6 +1188,35 @@
 - **Skipped:** 0 tests.
 - **Environment:** Linux, Python 3.11.15, pytest 9.1.1.
 
+## Codex comma-separated pytest plugin remediation
+
+- **Recorded:** 2026-08-10 (UTC)
+- **Review finding:** PR #671 identified that a supported comma-separated
+  string declaration was resolved as one malformed module path instead of one
+  proof input per declared plugin.
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.12 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py \
+    -k changed_pytest_plugin -q
+  ```
+
+- **Failing result:** the tuple and annotated tuple cases passed, but changing
+  a plugin named in an annotated comma-separated string returned no finding.
+- **Passing-after command:**
+
+  ```shell
+  uv run --python 3.12 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -q
+  ```
+
+- **Passing result:** all 39 provenance tests passed after splitting and
+  trimming each comma-separated plugin name before resolving module paths.
+- **Validation:** Ruff, basedpyright, and strict OpenSpec validation passed.
+- **Skipped:** 0 tests.
+- **Environment:** Linux, Python 3.12.13, pytest 9.1.1.
+
 ## Codex root-initializer and plugin-source remediation
 
 - **Recorded:** 2026-08-10 (UTC)

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -2495,3 +2495,44 @@ The batteries earned their keep immediately, in both directions:
   test-body imports now binding. No `src/specfact_cli/**` path is bound, so a
   red-to-green change may still edit governed production code without
   invalidating its own proof.
+
+## Codex round-18 remediation: follow-ups to the round-17 fixes
+
+Three P1 findings, each a gap in a fix from the previous round rather than a new
+class. All reproduced by execution first.
+
+- **Nested configuration was discovered but not bound.** Round 17 taught
+  discovery to read `tests/pytest.ini`, but the returned proof set still expanded
+  only the root-level basenames, so changing or adding a nested candidate after
+  the red source did not intersect the changed paths.
+  `_configuration_candidate_paths` now binds every directory-qualified candidate.
+  Binding candidates that do not exist is deliberate: the finding is as much
+  about *adding* a configuration after red as changing one.
+- **`pythonpath` was resolved against the wrong directory.** Pytest joins a
+  relative entry to the declaring file's directory, so `tests/pytest.ini` with
+  `pythonpath = plugins` names `tests/plugins`. Entries are now joined to that
+  directory before normalization, which also leaves root-level configuration
+  unchanged because joining against `.` is the identity.
+- **An unbound-method call mutates its argument, not its receiver.**
+  `list.append(P, "tests.p")` was invisible to mutation detection, which looked
+  only at the call receiver. A declaration handed to any call now becomes
+  unresolved through the same alias propagation, mirroring the rule the typing
+  guard already uses: an object given to a call is no longer statically known.
+
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -p no:randomly \
+    -k "nested_configuration_path or pythonpath_against_its_configuration or \
+    receives_an_aliased_plugin_list" -q
+  ```
+
+  Recorded 2026-08-12T20:56:34Z. Result: 3 failed.
+- **Passing-after:** 191 passed in that file.
+- **Real-repository check:** 204 inputs for the 31 `tests/unit/scripts`
+  selectors and 2776 for all 333, up from 176 and 2286. Every one of the 490
+  additions is a nested configuration candidate under `tests/`, and **none of
+  them exists in the tree** — which is the intended semantics rather than an
+  accident, since a configuration added after the red source must invalidate the
+  proof. No `src/specfact_cli/**` path is bound.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -2174,3 +2174,50 @@ preceding round's own fix.
   `Git-Bound Failing-First Proof` would be structurally cleaner, but the
   scenario also carries the executor's empty-JUnit condition, so the move means
   splitting it — recorded rather than churned this late in review.
+
+## Codex round-14 remediation: parseable symlinks, subscript mutation, module aliases
+
+Three P1 findings against `ae03d4dd`, each reproduced before any production edit.
+All three are second references to something the gate believed it had already
+bound, and each defeated a rule added in an earlier round.
+
+- **A symlink whose link text parses.** The traversal rejected an unreadable
+  input by testing `tree is None`, but `git show` on a symlink returns the link
+  text, and `real_conftest.py` is itself a valid Python attribute expression. It
+  parsed, produced no imports, and the target's own inputs were never bound, so a
+  post-red change to the target passed as fresh proof. `_python_tree_at_ref` now
+  checks the Git mode independently of parsing, so the existing exists-but-
+  unreadable path yields `stale-red-proof`. Parse success can never again stand
+  in for "these are the bytes pytest executes".
+- **Subscript mutation of an aliased list.** `_mutated_name_targets` recognized
+  only method calls, so `PLUGINS = ["tests.old"]; pytest_plugins = PLUGINS;
+  PLUGINS[0] = "tests.active"` left the copied binding reading `tests.old` while
+  pytest loaded `tests.active`. Subscript and attribute writes and deletions are
+  now mutations too, and they propagate to aliases through the identity rule
+  added in round 13.
+- **A typing guard written through a module alias.** `import typing as t;
+  alias = t; alias.TYPE_CHECKING = True` recorded `alias` as mutated while `t`
+  stayed verified, so `if t.TYPE_CHECKING:` was pruned although it executes.
+  Copying a name into another binding now drops the guard outright: once a
+  second reference exists, a write through it is invisible, and tracking the
+  alias graph would only move the boundary rather than close it.
+
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -p no:randomly \
+    -k "symlinked_support_input_that_parses or subscript_mutation or \
+    module_alias" -q
+  ```
+
+  Recorded 2026-08-11T22:11:34Z. Result: 3 failed, each accepting evidence the
+  gate must reject.
+- **Passing-after:** 137 passed in that file, and 629 passed / 5 skipped across
+  `tests/unit/{scripts,workflows,tools}` and `tests/integration/scripts`.
+- **Real-repository check:** configuration sources, `pythonpath` roots, and the
+  resolved proof inputs are unchanged at 163 inputs for the 31
+  `tests/unit/scripts` selectors and 2186 for all 333 tracked selectors. The
+  second-reference rule is deliberately blunt — any `alias = typing` drops the
+  guard — so this measurement is what establishes it costs this repository
+  nothing.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1625,7 +1625,7 @@
     tests/unit/scripts/test_requirements_proof_provenance.py -q
   ```
 
-- **Passing result:** all 116 provenance tests passed, under both the default
+- **Passing result:** all 120 provenance tests passed, under both the default
   random ordering and `-p no:randomly`.
 - **Reconciliation with `2f893e95`:** that commit landed the last open Codex
   finding by retaining known constant values when a conditional assignment is
@@ -1853,6 +1853,26 @@
 - **Verified on this repository:** roots stay `('', 'src', 'tools')`, proof
   inputs stay at 83 and 108 paths for two real selectors, the declared plugin
   stays bound, and no `src/specfact_cli/**` module is bound.
+- **Eighth follow-on Codex round:** three P1 findings against `13b38d39`.
+  `_mutated_name_targets` marks a tracked constant unresolved when a statement
+  calls a method on it, so `pytest_plugins = []` followed by
+  `pytest_plugins.append(...)` fails closed instead of reporting no plugins;
+  only names already tracked are affected, so an unrelated call is inert.
+  `_executable_scope_nodes` gained an `include_class_bodies` option used for
+  guard-mutation detection, because a class body executes during import and
+  `class C: typing.TYPE_CHECKING = True` mutates the module even though the body
+  binds no module name — name bindings still exclude class bodies, so the
+  round-3 fix is intact.
+  The unparseable-input branch now rejects on existence rather than on being a
+  regular blob, so a symlinked `conftest.py` fails closed instead of being
+  skipped; a symlink executes bytes the gate never inspected, and selectors were
+  already rejected for the same reason.
+- **Failing-before (eighth follow-on):** 4 failed — two in-place mutation forms,
+  the class-body guard mutation, and the symlinked conftest. All pass after.
+- **Verified on this repository:** proof inputs stay at 83 and 108 paths for two
+  real selectors, the declared plugin stays bound, and no production module is
+  bound. 574 passed / 4 skipped across `tests/unit/scripts`,
+  `tests/unit/workflows`, and `tests/unit/tools`.
 - **Ruff:**
 
   ```shell

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1625,7 +1625,7 @@
     tests/unit/scripts/test_requirements_proof_provenance.py -q
   ```
 
-- **Passing result:** all 123 provenance tests passed, under both the default
+- **Passing result:** all 128 provenance tests passed, under both the default
   random ordering and `-p no:randomly`.
 - **Reconciliation with `2f893e95`:** that commit landed the last open Codex
   finding by retaining known constant values when a conditional assignment is
@@ -1897,6 +1897,36 @@
   real selectors, the declared plugin stays bound, and no production module is
   bound. 577 passed / 4 skipped across `tests/unit/scripts`,
   `tests/unit/workflows`, and `tests/unit/tools`.
+- **Tenth follow-on Codex round:** four findings against `c87f9a6c`. Three of
+  them — an invoked setter assigning `pytest_plugins` through `global`, an
+  invoked function writing `typing.TYPE_CHECKING`, and a rebinding function
+  reached through an alias — are the same underlying gap: the round-nine call
+  gate resolved call targets by name, one level deep. Rather than add three
+  more shapes, `_unverifiable_module_state` now fails closed structurally: when
+  a module both defines a function that can rebind a global, write a
+  `TYPE_CHECKING` attribute, or assign `pytest_plugins`, **and** calls anything
+  while loading, the guard set is emptied and the plugin declaration raises
+  `stale-red-proof`. This subsumes aliases, wrappers, decorators, and transitive
+  calls without pretending to resolve them, and it removes the by-name call
+  resolution that could only ever cover the shapes it recognised.
+- **Fourth finding, opposite direction:** `_verified_type_checking_bindings`
+  now takes `before_line`, so a rebinding invalidates only the branches that
+  follow it. `if TYPE_CHECKING: import tests.type_support` followed later by
+  `TYPE_CHECKING = True` no longer binds the type-only helper retroactively.
+- **Failing-before (tenth follow-on):** 4 failed — the three invoked-mutation
+  forms and the retroactive invalidation.
+  `test_git_bound_red_proof_tracks_guard_rebound_before_its_branch` passed
+  before and after, locking the case where the rebinding does precede the guard.
+- **Regression net:** all 123 previously added tests continued to pass across
+  both restructures, including the round-ten pair whose two directions the new
+  structural rule had to preserve.
+- **Cost:** per-branch evaluation recomputes bindings for each `if`, so guard
+  analysis is quadratic in module size. Measured against this repository,
+  resolving both real selectors takes 0.62s in total, so the bound is not
+  material at realistic conftest sizes.
+- **Verified on this repository:** both committed `conftest.py` files still
+  resolve their declarations, proof inputs stay at 83 and 108 paths, and no
+  production module is bound. 582 passed / 4 skipped.
 - **Ruff:**
 
   ```shell

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -2221,3 +2221,40 @@ bound, and each defeated a rule added in an earlier round.
   second-reference rule is deliberately blunt — any `alias = typing` drops the
   guard — so this measurement is what establishes it costs this repository
   nothing.
+
+## Requirements Evidence CI status and the withdrawn mapping change
+
+An external quality assessment claimed the Requirements Evidence check was red
+because the historical TDD ledger digest did not match. Checking the workflow
+runs rather than the summary shows a different picture, and one correction to
+an earlier note in this ledger.
+
+- **The check is red on every commit of this branch, and on the base.** Run
+  history for `requirements-evidence.yml` shows `failure` for every head from
+  `fb66d5e9` through `b38ea723`, and also for `6a81ad3290` — the `dev` commit
+  that is this pull request's merge base. An earlier note here treated the
+  broadly green check-run list as "CI green"; that list did not include this
+  workflow, so the claim was wrong and is corrected.
+- **The current cause is not the ledger digest.** The job log shows the
+  SpecFact CLI exiting 1 during planning with "Bundled Modules Need Refresh —
+  some bundled modules are missing or outdated", before the legacy-ledger block
+  runs. Only three of the six declared artifacts are uploaded, so no plan,
+  JUnit, or ledger artifact is ever produced. The ledger-digest failure the
+  assessment cites was the earlier cause at `ea2e256d`; the committed ledger
+  digest over the first 1143 lines still equals the pinned
+  `sha256:d6e35c93...5e8c3`, reverified after every append in this branch.
+- **Because of that, one drafted correction was withdrawn.** Declaring the gate
+  script as a touchpoint requires editing `requirements-evidence.yaml`, which
+  changes the mapping digest. That digest is pinned in three places this branch
+  cannot regenerate: the product-owner acceptance record
+  (`mapping_digest: sha256:4e346ea4...`), and `legacy_tdd_mapping_digest` plus
+  `legacy_tdd_plan_digest` in the workflow. The change would therefore have
+  added a second, self-inflicted failure once the module-bundling problem is
+  fixed, and by this change's own "Accepted Mapping Before Automation"
+  requirement a mapping digest without matching acceptance blocks automation.
+  The mapping is restored to its 18-case pinned state and the correction is
+  recorded as task 3.9 with the full draft, so it can land in a change where
+  acceptance is renewed deliberately.
+
+No test or gate behavior changed with this withdrawal: the provenance fixes,
+the spec de-duplication, and the guard-aliasing fix are unaffected.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -2536,3 +2536,39 @@ class. All reproduced by execution first.
   them exists in the tree** — which is the intended semantics rather than an
   accident, since a configuration added after the red source must invalidate the
   proof. No `src/specfact_cli/**` path is bound.
+
+## Plumbing invariant: anything read to decide collection must be bound
+
+The AST batteries cover the rule family, but two rounds of findings landed in the
+path plumbing instead, where they could not reach: a configuration source was
+discovered and read to derive plugins and roots, then never added to the returned
+proof set, so changing it after the red source did not intersect the changed
+paths. The batteries test helpers against parsed trees; nothing asserted that the
+set of files the gate *reads* and the set it *binds* agree.
+
+`test_every_file_whose_content_is_read_is_bound_as_a_proof_input` states that
+directly. It records every `git show <ref>:<path>` the gate performs while
+resolving a proof, and asserts that every recorded path which exists in the tree
+appears in the returned inputs. The property needs no list of shapes, so a source
+added by a future change is covered the day it is read.
+
+Two companions bound the edges it cannot see. Absent candidates are invisible to
+a read-based property, so
+`test_every_configuration_candidate_is_bound_including_absent_ones` asserts the
+full candidate set for the root and each selector ancestor is bound — the
+semantics that make an *added* configuration invalidate the proof. And
+`test_a_plugin_reached_through_a_nested_root_is_bound_with_its_imports` asserts
+the chain end to end: nested configuration, its relative root, the plugin loaded
+from it, and that plugin's own import.
+
+- **Failing-before evidence.** Replayed against `1c46aac5`, the commit that had
+  nested discovery but not nested binding:
+
+  | version | read but unbound | nested plugin bound |
+  |---|---|---|
+  | `1c46aac5` pre-fix | `['tests/pytest.ini']` | no |
+  | current | none | yes |
+
+  The invariant fires on exactly the defect that two review rounds reported, and
+  passes once it is fixed, which is stronger evidence than a synthetic mutation.
+- **Passing-after:** 194 passed in the provenance file.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1197,15 +1197,84 @@
 - **Review finding:** PR #671 identified that retained parent package
   initializers were proof inputs but were not traversal roots, allowing a
   repository-local module imported only by an initializer to change after red.
-- **Failing-before command:** `uv run --python 3.11 --locked --extra dev python -m pytest tests/unit/scripts/test_requirements_proof_provenance.py::test_git_bound_red_proof_rejects_changed_initializer_import -q`
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py \
+    -k changed_initializer_import -q
+  ```
+
 - **Failing result:** the regression failed because changing
   `tests/support.py`, imported by `tests/__init__.py`, returned no provenance
   finding.
-- **Passing-after command:** `uv run --python 3.11 --locked --extra dev python -m pytest tests/unit/scripts/test_requirements_proof_provenance.py -q`
+- **Passing-after command:**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -q
+  ```
+
 - **Passing result:** all 34 provenance tests passed after package initializer
   paths became transitive import traversal roots.
+- **Validation gates:** the Ruff, basedpyright, and strict OpenSpec commands
+  recorded for the follow-up below cover both remediations and pass.
 - **Skipped:** 0 tests.
 - **Environment:** Linux, Python 3.11.15, pytest 9.1.1.
 - **Internal wiki follow-up:** the sibling `specfact-cli-internal` checkout was
   unavailable. Update `wiki/sources/requirements-07-runtime-proof-delivery.md`
   and run `python3 scripts/wiki_rebuild_graph.py` from that repository root.
+
+## Codex module-scope pytest plugin remediation
+
+- **Recorded:** 2026-08-10 (UTC)
+- **Review finding:** PR #671 identified that annotated `pytest_plugins`
+  assignments inside functions or classes were incorrectly treated as
+  module-level pytest declarations.
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py \
+    -k nested_pytest_plugin -q
+  ```
+
+- **Failing result:** both function-local and class-local annotation cases
+  incorrectly returned `stale-red-proof` after the unrelated target changed.
+- **Passing-after command:**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -q
+  ```
+
+- **Passing result:** all 36 provenance tests passed after plugin discovery
+  stopped descending into function and class scopes.
+- **Ruff:**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev ruff check \
+    scripts/requirements_proof_provenance.py \
+    tests/unit/scripts/test_requirements_proof_provenance.py
+  ```
+
+  Result: all checks passed.
+- **Basedpyright:**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev basedpyright \
+    --project pyproject.toml scripts/requirements_proof_provenance.py \
+    tests/unit/scripts/test_requirements_proof_provenance.py
+  ```
+
+  Result: 0 errors, 0 warnings, and 0 notes.
+- **OpenSpec validation:**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev openspec validate \
+    requirements-07-runtime-proof-delivery --strict
+  ```
+
+  Result: the change is valid.
+- **Skipped:** 0 tests.
+- **Environment:** Linux, Python 3.11.15, pytest 9.1.1.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -2694,3 +2694,70 @@ blocks all valid work.
   That is what carried the comprehension shape without a second rule, and it keeps
   the module-name and path rules from drifting apart.
 - **Passing-after:** 229 passed in the provenance file.
+
+## Round 22: the over-strictness axis, measured by the suite instead of by hand
+
+Every test in the provenance suite states what the gate must bind. None stated what
+it must not, and that is the axis where this work has failed hardest: a rule that
+binds too much satisfies every positive expectation while rejecting valid proofs.
+One round widened a guard rule and rejected every proof on this repository; it was
+caught only because a whole-repository measurement was run by hand before pushing.
+That manual step was the entire safety net, and it depended on remembering it.
+
+`tests/integration/scripts/test_requirements_proof_provenance_repository.py` runs
+the measurement as part of the suite. It resolves the proof inputs once for all 333
+committed selectors and asserts four things:
+
+- no file under `src/specfact_cli/` is ever an input, stated separately by name so
+  it cannot be weakened by appending to an exception list;
+- every bound file outside the test tree is one of four recorded exceptions, each
+  something pytest genuinely loads — the executor's `-p` plugin and three modules
+  imported directly by the tests that exercise them;
+- the set stays proportional to the selectors, which catches a rule that pulls in
+  whole directories while staying inside the test tree, where the check above
+  cannot see it;
+- the selectors are still bound themselves, because restraint is only evidence
+  while the gate still resolves what it must.
+
+Failures name the offending paths, since the fix is always to narrow the rule that
+bound them.
+
+- **Proof that the guard fires.** The gate was mutated to the variant this work had
+  already rejected once — bind every committed path a reachable body names — and
+  the measurement failed on the mutation, listing all eight bound
+  `src/specfact_cli/**` modules and 105 files outside the test tree. Reverted, it
+  passes. A guard that has never failed is not evidence, so this was run rather
+  than assumed.
+
+### A latent crash the mutation exposed
+
+Running the mutation raised `ValueError: embedded null byte` out of the middle of
+the gate rather than failing an assertion. Path literals were handed to Git
+unvalidated, and this repository already contains a literal of that class —
+`tests/test_proof.py::test_selected\tinjected` in the executor's own tests. A
+literal beginning `tests/` and containing a null byte passed the harness check and
+reached the subprocess, where it cannot be passed at all.
+
+- **Failing-before evidence.** Against the pre-fix module,
+  `_literal_path_candidates` produced `'tests/data/case.json\x00truncated'`, it
+  passed `_is_harness_path`, and handing it to Git raised `ValueError`.
+
+`_names_a_repository_path` now discards a literal carrying a control character or a
+traversal segment before it becomes a Git argument. Four shapes are locked: a null
+byte, a tab, a newline, and `tests/../src/product.py`, which would otherwise have
+named product source through the harness prefix.
+
+### Correction to the round 21 figures
+
+Round 21 recorded 217 and 2785 inputs. Those were measured before the final
+`_handed_over_expressions` refactor in that same round and were not re-measured
+after it. At the committed head the figures are **219 and 2787**. The delta the
+round claimed is unchanged and remains the substantive result: 9 candidates added,
+0 removed, of which exactly 2 exist —
+`scripts/requirements_proof_pytest_plugin.py` and
+`tests/fixtures/keys/test_private_key.pem`, one per finding. Absolute totals also
+move as the repository moves, because the gate reads the committed tree, which is
+why the automated measurement asserts structure rather than a pinned count.
+
+- **Passing-after:** 233 passed in the provenance file, 4 in the repository
+  measurement.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1188,6 +1188,35 @@
 - **Skipped:** 0 tests.
 - **Environment:** Linux, Python 3.11.15, pytest 9.1.1.
 
+## Codex verified type guards and ordered constants remediation
+
+- **Recorded:** 2026-08-10 (UTC)
+- **Review findings:** PR #671 identified that unverified `TYPE_CHECKING` names
+  were always treated as false and that reassigned plugin constants were
+  resolved in reverse rather than execution order.
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.12 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py \
+    -k 'changed_pytest_plugin or rebound_type_checking' -q
+  ```
+
+- **Failing result:** a rebound runtime-true `TYPE_CHECKING` branch was omitted,
+  and the first textual plugin constant value won after reassignment.
+- **Passing-after command:**
+
+  ```shell
+  uv run --python 3.12 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -q
+  ```
+
+- **Passing result:** all 45 provenance tests passed after pruning only verified
+  typing guards and resolving literal constants in module execution order.
+- **Validation:** Ruff, basedpyright, and strict OpenSpec validation passed.
+- **Skipped:** 0 tests.
+- **Environment:** Linux, Python 3.12.13, pytest 9.1.1.
+
 ## Codex static branches and plugin constants remediation
 
 - **Recorded:** 2026-08-10 (UTC)

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1176,10 +1176,10 @@
 - **Review findings:** PR #665 identified that provenance omitted package
   initializers for the selected test and ignored annotated `pytest_plugins`
   assignments in applicable conftests.
-- **Failing-before command:** `uv run --python 3.11 --locked --extra dev python -m pytest tests/unit/scripts/test_requirements_proof_provenance.py -k 'annotated_pytest_plugin or selector_package_initializer' -q`
-- **Failing result:** both selected regressions failed because adding
-  `tests/__init__.py` or changing a plugin declared with `ast.AnnAssign`
-  returned no provenance finding.
+- **Failing-before command:** `uv run --python 3.11 --locked --extra dev python -m pytest tests/unit/scripts/test_requirements_proof_provenance.py -k 'changed_pytest_plugin or selector_package_initializer' -q`
+- **Failing result:** two of the three selected cases failed: adding
+  `tests/__init__.py` and changing a plugin declared with `ast.AnnAssign`
+  returned no provenance finding, while the ordinary assignment case passed.
 - **Passing-after command:** `uv run --python 3.11 --locked --extra dev python -m pytest tests/unit/scripts/test_requirements_proof_provenance.py -q`
 - **Passing result:** all 33 provenance tests passed after retaining possible
   parent initializers for every seeded pytest input and accepting static

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -2258,3 +2258,68 @@ an earlier note in this ledger.
 
 No test or gate behavior changed with this withdrawal: the provenance fixes,
 the spec de-duplication, and the guard-aliasing fix are unaffected.
+
+## Codex round-15 remediation: seven remaining fail-open shapes
+
+Seven unresolved P1 findings had accumulated across three review rounds — two
+raised against `ce05b1c6`, three against `b38ea723`, two against `aab1570f`.
+Each was reproduced by execution before any production edit.
+
+- **Chained assignment split one object into two.** `PLUGINS = pytest_plugins =
+  []` evaluated the shared right-hand side once per target, so the identity
+  propagation added in round 13 saw two unrelated lists and a later
+  `PLUGINS.append(...)` never reached `pytest_plugins`. Literal evaluation is now
+  memoized per right-hand-side node, so chained targets share one object exactly
+  as the runtime does.
+- **An absolute `pythonpath` inside the checkout was dropped.** Round 13
+  normalized traversal but still rejected every absolute entry. An absolute path
+  is now resolved against the repository root and kept when it lands inside it;
+  only a genuinely external tree yields no root.
+- **A called lambda was not a state mutator.** `activate = lambda:
+  setattr(typing, "TYPE_CHECKING", True)` followed by `activate()` mutates the
+  guard at load, but only `FunctionDef` and `AsyncFunctionDef` were scanned.
+  Lambdas are included now: a lambda body runs when it is called.
+- **A `globals()` write declared plugins with no binding.** Subscript mutation
+  detection required a plain name base, so `globals()["pytest_plugins"] = [...]`
+  produced no binding at all. A module that writes its own namespace mapping
+  through `globals()` or `vars()` is now unverifiable, failing closed for both
+  the guard and the declaration.
+- **A class-body `global` declaration was outside the plugin traversal.** The
+  guard path already covered class-body globals, but the plugin resolver still
+  used the class-excluding traversal. A `pytest_plugins` name created by a
+  `global` statement now fails closed, because the value is bound outside the
+  traversal that resolves it.
+- **A guard nested in a call argument was invisible.** `setattr([typing][0],
+  ...)` hands the module over, but only direct `ast.Name` arguments were
+  inspected. Argument expressions are walked now.
+- **A bare decorator was not a module-load call.** `@activate` invokes the
+  decorator during import while producing no `ast.Call` node, so
+  `_calls_during_module_load` returned false and an invoked mutator went
+  unnoticed. Decorator application counts as an invocation. This is the same
+  defect class already fixed in `scripts/verify_safe_project_writes.py`, found
+  there by the related-code audit and here by review — worth recording, because
+  it is the one class that has now appeared in both static analysers.
+
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -p no:randomly \
+    -k "chained_assignment or absolute_pythonpath or called_lambda or \
+    module_namespace_plugin or class_body_global_plugin or \
+    nested_in_a_call_argument or bare_decorator" -q
+  ```
+
+  Recorded 2026-08-12T16:34:45Z. Result: 7 failed, each accepting evidence the
+  gate must reject.
+- **Passing-after:** 144 passed in that file.
+- **Real-repository check:** three of these rules are much broader than what
+  they replace — every bare decorator now counts as a module-load call, and this
+  repository uses them everywhere — so the measurement matters more than usual.
+  Configuration sources, `pythonpath` roots, and the resolved proof inputs are
+  unchanged at 163 inputs for the 31 `tests/unit/scripts` selectors and 2186 for
+  all 333 tracked selectors. The broadened rules cost nothing here because
+  failing closed still requires a state-mutating definition or a typing-module
+  guard, which the repository's committed conftests and initializers do not
+  have. Wall time for the full selector set rose from 14.2s to 17.4s, from
+  walking nested call arguments.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -2761,3 +2761,94 @@ why the automated measurement asserts structure rather than a pinned count.
 
 - **Passing-after:** 233 passed in the provenance file, 4 in the repository
   measurement.
+
+## Round 23: four findings on what the run reads and what it never runs
+
+### A lookup Git could not answer is not proof of absence
+
+`_git_bytes` reports a timeout as an ordinary non-zero result, and `git cat-file -e`
+exits non-zero for both a missing path and an unusable ref. Existence therefore
+conflated "definitely absent" with "could not determine". A module whose lookup
+timed out was skipped as absent, and everything it imports went untraversed, so a
+later change to a transitive helper passed as fresh evidence.
+
+- **Failing-first.** With Git failing for `tests/support.py` and only
+  `tests/helper.py` — reached *through* it — changed after the red source, the gate
+  returned `[]` where `['stale-red-proof']` was required.
+
+`git ls-tree` separates the two answers: it succeeds with empty output for a path
+the ref does not contain and fails only when it could not answer. One cached
+`_tree_entry_mode_at_ref` now drives both existence and regularity, so the fix
+lands at the single place every caller goes through instead of at the call site
+the finding happened to name. The mode it returns is what made the link fix below
+possible without a second Git call.
+
+### A read through a link binds nothing
+
+The data pass filtered candidates to regular files, so a committed
+`tests/data/case.json -> real.json` was dropped and its target was never bound —
+pytest follows the link and reads bytes the gate had excluded.
+
+- **Failing-first.** Changing only `tests/data/real.json` after the red source
+  returned `[]` where `['stale-red-proof']` was required.
+
+Links are now followed, binding every hop, because editing any of them changes what
+the read returns. A link that leaves the checkout, cycles, or points at nothing
+binds no bytes and is stale rather than silently dropped; four such shapes are
+locked, along with a two-hop chain.
+
+### A join is resolved against the base it starts from
+
+`(Path(__file__).parent / "data" / "case.json")` discarded the base and produced
+`data/case.json`, which named nothing and bound nothing. A harness names its data
+beside itself far more often than beside the repository root.
+
+- **Failing-first.** Changing `tests/data/case.json` after the red source returned
+  `[]` where `['stale-red-proof']` was required.
+
+Eight base shapes now resolve — `__file__` turned into a path, `.parent`,
+`.parents[n]`, `.resolve()`, `os.path.dirname`, and a module-level name bound to
+any of them, including nested forms such as `Path(os.path.dirname(__file__))`.
+
+The same change closes an over-binding hole in the opposite direction that the
+finding did not mention. A join was previously read as root-relative *whatever* it
+started from, so `tmp_path / "tests" / "data" / "case.json"` bound the committed
+file that happened to share those components. A base that cannot be known now
+discards the join, which is the rule the specification already states for runtime
+paths. Three unknowable bases are locked as binding nothing.
+
+### The body of a test the run never enters
+
+Reported as P2: an exact selector runs one node, but every deferred scope in the
+module was traversed, so a helper imported only inside an *unselected* test body
+was bound and editing it rejected still-valid evidence.
+
+- **Failing-first.** With `tests/test_proof.py::test_selected` selected and
+  `tests/helper.py` imported only inside `test_other`, changing that helper
+  returned `['stale-red-proof']` where `[]` was required.
+
+The finding's proposed remedy — reachability from the selected node and its active
+fixtures — is **declined**, and the narrower rule implemented instead. Fixture
+activation depends on autouse declarations, indirect parametrization, conftest
+chains, and plugins; none is decidable from a module's syntax, and a partial
+implementation would silently stop binding fixtures that do run. That is the
+under-binding class this change has spent twenty rounds closing, and trading it for
+a narrow false positive is a bad exchange.
+
+What is implemented is provable: a scope is dropped only when it is a test, is not
+itself selected, and its name appears nowhere else in the module. Nothing is
+dropped at all unless a selected identifier matches a function defined there, so a
+selection this gate cannot resolve to names leaves every scope traversed. Node
+identifiers are now carried through from the red report rather than discarded after
+their paths are taken, with parametrized cases reduced to the function they run.
+Three locks hold the boundary: an import in the selected body, an import in an
+unselected body that the selected one calls, and an import in a fixture body all
+stay bound.
+
+- **Whole-repository measurement.** One file added against the previous head,
+  `tests/fixtures/speckit/spec-template-v0.12.18.md` — a fixture reached by a
+  `__file__`-relative join that previously resolved to nothing. Nothing under
+  `src/specfact_cli/**` is bound, and the automated repository measurement passes
+  unchanged.
+- **Passing-after:** 256 passed in the provenance file, 640 across the scripts,
+  workflows, and integration suites.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1625,7 +1625,7 @@
     tests/unit/scripts/test_requirements_proof_provenance.py -q
   ```
 
-- **Passing result:** all 102 provenance tests passed, under both the default
+- **Passing result:** all 110 provenance tests passed, under both the default
   random ordering and `-p no:randomly`.
 - **Reconciliation with `2f893e95`:** that commit landed the last open Codex
   finding by retaining known constant values when a conditional assignment is
@@ -1791,6 +1791,28 @@
 - **Verified on this repository:** proof inputs stay at 83 and 108 paths for
   two real selectors, roots stay `('', 'src', 'tools')`, `addopts` still yields
   no `-p` entries, and no production module is bound.
+- **Fifth follow-on Codex round:** four findings against `f4ad7bd8`.
+  `_guard_attribute_targets` now drops a module guard whose `TYPE_CHECKING`
+  attribute is written directly, which `_name_bindings` ignored because the
+  target is an `ast.Attribute` rather than a name.
+  `_global_rebound_names` treats a name that a `global` declaration rebinds from
+  a nested scope as module-scoped, since a class body executes during import.
+  `_pytest_configuration_sources` now fails closed on a configuration candidate
+  that exists but exceeds the read bound, matching the Python-input rule: an
+  unread configuration could declare plugins or roots this gate must bind.
+  `_static_condition` resolves any literal condition through `ast.literal_eval`,
+  so `if 0:`, `if None:`, `if "":`, and `if ():` prune as `if False:` does.
+- **Correction found by the new tests:** the first attempt at the literal-guard
+  fix special-cased `ast.Constant`, which left `if ():` unresolved because an
+  empty tuple is an `ast.Tuple` display. `ast.literal_eval` covers every literal
+  form uniformly and still leaves dynamic expressions runtime-unknown.
+- **Failing-before (fifth follow-on):** 8 failed — three guard-mutation forms
+  (attribute assignment, attribute augmented assignment, class-body `global`),
+  the oversized configuration source, and four falsy literal guards. All pass
+  after the fix.
+- **Verified on this repository:** proof inputs stay at 83 and 108 paths for two
+  real selectors, and the committed `pyproject.toml` is 29 KB against the 10 MiB
+  bound, so the new fail-closed path is unreachable here.
 - **Ruff:**
 
   ```shell

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -2624,3 +2624,73 @@ is committed.
   keeps the reachability rule in step with ordinary imports, which now share one
   `_deferred_scopes_are_reachable` helper rather than two copies that can drift.
 - **Passing-after:** 217 passed in the provenance file.
+
+## Round 21: the inputs a proof run reads that are not imports
+
+Two findings landed together, both of the same shape: a file the proof run reads
+that the import graph cannot see.
+
+### The plugin the executor always loads
+
+Every run passes `-p scripts.requirements_proof_pytest_plugin` on the command
+line. The gate bound plugins declared in configuration and none from the command,
+so changing that plugin after the red source left the proof standing while the
+new code could alter collection, reports, and the selector properties JUnit
+validation depends on.
+
+- **Failing-first.** `test_every_plugin_the_executor_early_loads_is_a_proof_input`
+  returned `[]` where `['stale-red-proof']` was required.
+
+The name is now seeded beside the configured `addopts` names, since both arrive
+through the same option and pytest treats them identically. Naming it in the gate
+would ordinarily duplicate a fact owned by the executor, so
+`test_the_gate_seeds_every_plugin_the_executor_early_loads` parses the executor's
+own command shape and asserts every `-p` value it emits is seeded. The two files
+are held together by a test rather than by remembering to edit both.
+
+### Repository data the harness reads
+
+A selected test or fixture that reads `tests/data/case.json` bound nothing, so
+editing that data could turn the same test green with the retained failure still
+accepted.
+
+- **Failing-first.** All six shapes in `DATA_READ_SHAPES` returned `[]` where
+  `['stale-red-proof']` was required: `Path(...)`, `open(...)`, a component-wise
+  join onto a path root, a joined relative path, a read inside a fixture body, and
+  a name iterated out of a literal list.
+
+The scope was set by measurement, not by the finding's wording. Binding every
+committed path a reachable body names would have bound 134 files on this
+repository, including ten under `src/specfact_cli/**` — the modules a red-to-green
+change edits by definition, whose exclusion is the reason ordinary imports already
+stop at the repository root. Excluding governed production paths still left 37,
+almost all `README.md`, `CHANGELOG.md`, and `docs/**`: documentation is likewise
+what a change is expected to edit, so binding it would reject proofs for
+documentation-driven work.
+
+The line that holds is the harness itself. A read binds when the file lies inside
+a directory the selected tests live in and is not a governed production path.
+Data under the test tree is harness the change may not edit; everything outside is
+a fix target. Three counter-shapes lock that boundary — a read of `src/product.py`,
+of `README.md`, and of `docs/index.md` must all leave the proof valid.
+
+The second half of the finding asked to fail closed on reachable repository I/O
+that cannot be resolved. That is declined with a reason, and the reason is locked
+by `test_a_read_that_cannot_be_resolved_does_not_fail_the_proof`: a harness builds
+paths under `tmp_path` constantly, so failing closed there rejects every proof in
+every repository that uses temporary directories, which catches no drift and
+blocks all valid work.
+
+- **Whole-repository measurement.** 333 selectors: 217 inputs for the scripts
+  group and 2785 overall, up from 204 and 2776. Exactly two existing files were
+  added — `scripts/requirements_proof_pytest_plugin.py` and
+  `tests/fixtures/keys/test_private_key.pem`, one per finding. The remaining seven
+  additions are absent candidates under the configured `src` and `tools` roots,
+  bound as absent so adding one invalidates the proof, exactly as ordinary import
+  candidates already are. Nothing under `src/specfact_cli/**` is bound.
+- **Structure.** Both features answer the same question — is this literal handed
+  to something that consumes it, or only written down — so they share one
+  `_handed_over_expressions` helper covering call arguments and iterated values.
+  That is what carried the comprehension shape without a second rule, and it keeps
+  the module-name and path rules from drifting apart.
+- **Passing-after:** 229 passed in the provenance file.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -2110,3 +2110,67 @@ annotations`, since PEP 563 leaves them unevaluated.
 - **Passing-after:** 23 passed across the unit and integration files, and
   `python scripts/verify_safe_project_writes.py` still exits 0 against the real
   `src/specfact_cli/utils/ide_setup.py`.
+
+## Self-review against change intent and mechanics
+
+A review of the accumulated remediation against `proposal.md`,
+`requirements-evidence.yaml`, and `CHANGE_VALIDATION.md` found four issues that
+no reviewer had raised. Three are governance mechanics; one is a defect in the
+preceding round's own fix.
+
+- **The gate script was not a declared touchpoint.** `requirements-evidence.yaml`
+  mapped `git-bound-failing-first-proof` to `requirements-proof/red.json` and
+  `TDD_EVIDENCE.md`, but never to
+  `scripts/requirements_proof_provenance.py` — the file that implements the
+  requirement and carries every line of this remediation. R07 exists to enforce
+  "changed interface -> mapped scenario -> exact selector", so the change was
+  failing its own contract on itself. The script is now a `cli_command`
+  touchpoint, matching the kind already used for
+  `scripts/pre-commit-quality-checks.sh`, which the workflow invokes the same way.
+- **The mapping covered two of the gate's scenarios.** Both provenance
+  verification cases predated this work; the retained-input invariant and the
+  symlinked-selector scenario had none. Five cases (R07-CORE-003-S04 through
+  S08) now bind the configuration source and configured roots, unreadable
+  inputs, unresolvable plugin declarations, guard rewriting, and symlinked
+  selectors. Every mapped selector was checked to collect exactly one test:
+  23 cases collect 23 tests, so no case points at a parametrized family whose
+  bare node ID is not an exact selector. One draft case did — it named the
+  nine-way parametrized `..._rejects_changed_addopts_plugin` — and was replaced
+  before commit.
+- **The requirement restated a proof-input list that had drifted.**
+  `Git-Bound Failing-First Proof` enumerated selectors, `conftest.py` files, and
+  imported support modules, while the retained-proof scenario enumerated a set
+  several rounds larger, including the configuration source, configured roots,
+  `addopts` plugins, and package initializers. The implementation followed the
+  larger one, so the requirement text was normative and wrong. It now names the
+  term and points at the single enumeration.
+- **The round-13 `setattr` rule was defeated by aliasing.** Matching
+  `setattr` by callee name repeated the mistake removed in round 12: with
+  `from builtins import setattr as _set`, or with any helper that receives the
+  module, `_unverifiable_module_state` stayed false and the guarded import was
+  pruned. A function is now state-mutating when it hands a module-level typing
+  binding to any call, tracking the guard by the name it is passed under rather
+  than by the callee's name. The `setattr` check is retained alongside it,
+  because it also covers a rewrite aimed at `pytest_plugins` rather than the
+  guard.
+
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -p no:randomly \
+    -k handed_to_a_call -q
+  ```
+
+  Recorded 2026-08-11T22:04:21Z. Result: 1 failed — the aliased rewrite was
+  accepted as fresh proof.
+- **Passing-after:** 134 passed in that file. Re-probing the three rewrite
+  shapes (plain `setattr`, aliased `setattr`, helper receiving the module) now
+  reports unverifiable module state for all three; before the fix only the plain
+  form was caught.
+- **Not changed, and why:** the retained-proof scenario still sits under
+  `Safe Pull-Request Proof Execution` although it governs retained red-proof
+  freshness rather than plan execution. Moving it under
+  `Git-Bound Failing-First Proof` would be structurally cleaner, but the
+  scenario also carries the executor's empty-JUnit condition, so the move means
+  splitting it — recorded rather than churned this late in review.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -2960,3 +2960,65 @@ must stay verifiable for the positional rule to mean anything.
   head. No module here reaches its own namespace by any door, so the wider subject
   rejects nothing on this repository; its coverage is the thirteen-shape battery.
 - **Passing-after:** 286 passed in the provenance file.
+
+## Round 26: the missing oracle, and the import root it would have caught
+
+### Why findings kept arriving
+
+Every rule in this gate is a hand-derived model of pytest: which files it reads to
+decide collection, which directories it puts on `sys.path`, which modules a
+declaration pulls in. A model has no error bar. Twenty-odd rounds of findings were
+not twenty unrelated bugs; they were one condition — **the only oracle for the
+model was review**, and review does not run on every change. Each round fixed the
+instance a reviewer happened to read, and the next divergence waited for the next
+reader.
+
+`tests/integration/scripts/test_requirements_proof_provenance_against_pytest.py`
+supplies the oracle. For seven repository layouts it runs pytest for real, records
+every repository-local module the run imports through a plugin loaded from outside
+the repository under test, and asserts the gate binds all of them. The layouts
+differ in mechanism, not outcome: a bare sibling import, a package-qualified
+import, a root conftest chain, a declared plugin importing its own helper, a plugin
+behind a configured `pythonpath` root, an import inside a fixture body, and a
+package initializer importing at load time.
+
+- **Proof that the oracle fires.** With the import-root fix below reverted, it
+  failed on the reported layout **and on a second one the review had not
+  mentioned** — the root conftest chain had the same gap — naming
+  `tests/helper.py` in both. Restored, all seven pass. An oracle that has never
+  failed is not an oracle, so this was run rather than assumed.
+
+This is the under-binding direction. The repository measurement added in round 22
+guards over-binding. Together they bound the rule family from both sides without
+anyone having to read it.
+
+### Imports through the directory pytest prepends
+
+Review found that a non-package `tests/conftest.py` containing `import helper`
+loads `tests/helper.py`, because pytest's default import mode prepends the file's
+own base directory to `sys.path`. The gate resolved imports against the repository
+root and configured `pythonpath` roots only, so the sibling was never bound.
+
+- **Failing-first.** Four shapes returned `[]` where `['stale-red-proof']` was
+  required: `import helper`, `from helper import VALUE`, `import helper.sub`, and
+  the same bare import inside the selected test rather than a conftest.
+
+The roots are not a property of the repository, which is what the previous
+enumeration assumed. They are a property of each file's position in it: pytest
+walks up from the file while each directory is a package and prepends the first one
+that is not. That rule is now computed per traversed file.
+
+It is also conditional. `--import-mode=importlib` inserts nothing on `sys.path`, so
+a bare name cannot reach a sibling under it, and binding one would reject valid
+proofs. The configured mode is read from `addopts` and the directory is used only
+when the mode places it there. Two counter-shapes lock this: an `importlib`
+repository binds nothing through the sibling route, and a package directory never
+becomes a root because pytest walks up past it.
+
+- **Whole-repository measurement.** Zero added, zero removed. This repository
+  configures `--import-mode=importlib`, so the new root is correctly withheld here —
+  confirmed by reading the mode the gate resolves (`importlib`) alongside the base
+  directory it would otherwise use (`tests/unit/scripts`, a real non-package
+  directory). The fix is inert here and live for any repository on the default mode.
+- **Passing-after:** 292 passed in the provenance file, 7 in the new oracle, 683
+  across the scripts, workflows, and integration suites.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1188,6 +1188,38 @@
 - **Skipped:** 0 tests.
 - **Environment:** Linux, Python 3.11.15, pytest 9.1.1.
 
+## Codex dynamic conditional plugin remediation
+
+- **Recorded:** 2026-08-11 (UTC)
+- **Review finding:** PR #671 identified that a non-literal assignment under a
+  runtime-dependent branch discarded a previously known plugin constant even
+  when that branch did not execute.
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.12 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py \
+    -k changed_pytest_plugin -q
+  ```
+
+- **Failing result:** a dynamic assignment under a false runtime branch removed
+  the preceding literal plugin binding, so its post-red change returned no
+  finding.
+- **Passing-after command:**
+
+  ```shell
+  uv run --python 3.12 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -q
+  ```
+
+- **Passing result:** all 48 provenance tests passed after dynamic conditional
+  assignments preserved previously known possible values while unconditional
+  dynamic assignments still cleared stale bindings.
+- **Validation:** Ruff, basedpyright, strict OpenSpec validation, and changed-file
+  SpecFact code review passed.
+- **Skipped:** 0 tests.
+- **Environment:** Linux, Python 3.12.13, pytest 9.1.1.
+
 ## Codex compound-statement plugin remediation
 
 - **Recorded:** 2026-08-10 (UTC)

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1188,6 +1188,37 @@
 - **Skipped:** 0 tests.
 - **Environment:** Linux, Python 3.11.15, pytest 9.1.1.
 
+## Codex compound-statement plugin remediation
+
+- **Recorded:** 2026-08-10 (UTC)
+- **Review finding:** PR #671 identified that plugin assignments under loops,
+  exception handling, context managers, and match cases were flattened as if
+  they always executed.
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.12 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py \
+    -k changed_pytest_plugin -q
+  ```
+
+- **Failing result:** an assignment inside an empty loop replaced the plugin
+  constant that actually reached `pytest_plugins`, omitting the active plugin.
+- **Passing-after command:**
+
+  ```shell
+  uv run --python 3.12 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -q
+  ```
+
+- **Passing result:** all 47 provenance tests passed after assignments under
+  runtime-dependent compound statements contributed possible values instead of
+  unconditionally replacing prior bindings.
+- **Validation:** Ruff, basedpyright, strict OpenSpec validation, and changed-file
+  SpecFact code review passed.
+- **Skipped:** 0 tests.
+- **Environment:** Linux, Python 3.12.13, pytest 9.1.1.
+
 ## Codex nested guard and conditional plugin remediation
 
 - **Recorded:** 2026-08-10 (UTC)

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1625,7 +1625,7 @@
     tests/unit/scripts/test_requirements_proof_provenance.py -q
   ```
 
-- **Passing result:** all 85 provenance tests passed, under both the default
+- **Passing result:** all 95 provenance tests passed, under both the default
   random ordering and `-p no:randomly`.
 - **Reconciliation with `2f893e95`:** that commit landed the last open Codex
   finding by retaining known constant values when a conditional assignment is
@@ -1750,6 +1750,28 @@
   `pythonpath` roots stay `('', 'src', 'tools')`, proof inputs are unchanged at
   80 and 105 paths for two real selectors, no production module is bound, and
   the declared plugin remains bound.
+- **Third follow-on Codex round:** two further P1 findings against `a66956ed`.
+  The configuration candidate list omitted `pytest.toml`, which the locked
+  pytest 9.1.1 discovers *first*. Reading that version's own
+  `_pytest/config/findpaths.py` showed the authoritative order is
+  `pytest.toml`, `.pytest.toml`, `pytest.ini`, `.pytest.ini`, `pyproject.toml`,
+  `tox.ini`, `setup.cfg`, so three candidates were missing rather than one, and
+  `pyproject.toml` also accepts a TOML-mode `[tool.pytest]` table beside
+  `[tool.pytest.ini_options]`. `PYTEST_TOML_TABLES` now maps each TOML
+  candidate to its tables and `_toml_option_value` reads the first table that
+  declares the option, so `pythonpath` and `addopts` resolve from every
+  supported spelling.
+  `_verified_type_checking_bindings` also now unions `_compound_binding_names`,
+  so a module-scope `for typing in [...]` rebinding is detected; those targets
+  were collected for plugin constants but unused for the guard.
+- **Failing-before (third follow-on):** 10 failed — three configuration
+  candidates, four `addopts` spellings, two `pythonpath` spellings, and the
+  compound-target guard rebinding. All pass after the fix.
+- **Verified on this repository:** the candidate list matches pytest's own
+  order, configured `addopts` still yields no `-p` entries, `pythonpath` roots
+  stay `('', 'src', 'tools')`, and no production module is bound. Proof inputs
+  grew from 80 to 83 and 105 to 108 paths for two real selectors, which is
+  exactly the three added configuration filenames.
 - **Ruff:**
 
   ```shell

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1587,3 +1587,112 @@
   Result: the change is valid.
 - **Skipped:** 0 tests.
 - **Environment:** Linux, Python 3.11.15, pytest 9.1.1.
+
+## Independent review remediation: configuration, rebinding, and fail-closed inputs
+
+- **Recorded:** 2026-08-11 (UTC)
+- **Review findings:** an independent review of PR #671 raised seven findings
+  beyond the Codex turns: the typing-guard rebinding scan covered nested
+  assignments but only top-level imports; the pytest configuration source was
+  never a proof input; `pytest_plugins` written by augmented assignment or a
+  tuple target was ignored; an unresolvable `pytest_plugins` value produced no
+  plugins instead of failing closed; a malformed `selectors` entry raised
+  `TypeError` instead of a deterministic finding; a non-UTF-8 committed module
+  aborted the gate with `UnicodeDecodeError`; and Git results were never
+  memoised across candidate paths or selectors.
+- **Converging Codex finding:** Codex independently raised the first of these
+  against `2f893e95`, in the form where a nested import rebinds the `typing`
+  module alias rather than the `TYPE_CHECKING` name. The rebinding scan here
+  covers both channels, so the regression is parametrized over the aliased
+  module form and the imported-name form, and a genuine unrebound guard is
+  still pruned.
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -p no:randomly -q
+  ```
+
+- **Failing result:** 16 failed, 47 passed. The failures were the three new
+  augmented and tuple-target plugin parameters, the rebound typing-guard import,
+  all four pytest configuration parameters, all five unresolvable plugin
+  parameters, both malformed selector parameters, and the non-UTF-8 support
+  module case.
+- **Passing-after command:**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -q
+  ```
+
+- **Passing result:** all 65 provenance tests passed, under both the default
+  random ordering and `-p no:randomly`.
+- **Reconciliation with `2f893e95`:** that commit landed the last open Codex
+  finding by retaining known constant values when a conditional assignment is
+  non-literal. This section supersedes its `_pytest_plugin_names` body with the
+  stricter of the two options that finding offered. Known values are still
+  retained, because a conditional unresolvable assignment appends the
+  unresolved marker rather than replacing the list, but an active declaration
+  that reaches that marker now fails closed instead of binding only the value
+  that happened to be resolvable. The regression added by `2f893e95` still
+  passes, through the fail-closed path rather than its original binding path.
+- **Behavior changes:** rebinding detection now scans imports across the whole
+  module tree as it already did for assignments; `PYTEST_CONFIGURATION_FILES`
+  binds `pyproject.toml`, `pytest.ini`, `setup.cfg`, and `tox.ini` as proof
+  inputs; `_destructured_targets` unpacks literal tuple and list targets and
+  `_augmented_assignments` extends rather than replaces a binding; an active
+  `pytest_plugins` declaration that cannot be resolved raises
+  `stale-red-proof` through the `UNRESOLVED_PLUGIN_VALUE` marker rather than
+  yielding no plugins; `_validated_selectors` rejects non-string entries before
+  the JUnit selector comparison; `_python_tree_at_ref` parses committed bytes so
+  PEP 263 declarations are honoured and applies `MAX_TEST_BLOB_BYTES`; and
+  `_git_bytes` centralises Git execution with a `GIT_TIMEOUT_SECONDS` bound that
+  degrades to an ordinary command failure.
+- **Efficiency:** `_proof_inputs` resolves every selector in one traversal and
+  `_python_tree_at_ref` and `_test_path_exists_at_ref` are memoised on the
+  immutable `(repo_root, source_ref, path)` key. Measured against this
+  repository for `tests/unit/scripts/test_requirements_proof_provenance.py`,
+  Git invocations fell from 129 to 73 for a single selector, and a second
+  selector sharing the same graph now adds none.
+- **Fail-closed regression guard:** both committed `conftest.py` files in this
+  repository still resolve their plugin declarations statically, and
+  `pyproject.toml` and `tests/helpers/doc_frontmatter_fixtures.py` are present
+  in the resolved proof inputs.
+- **Ledger binding:** the approved legacy ledger digest covers the first 1143
+  lines only. This section appends beyond that boundary, so
+  `legacy_tdd_ledger_digest` in `.github/workflows/requirements-evidence.yml`
+  remains `sha256:d6e35c93...5e8c3` and was reverified unchanged.
+- **Deferred:** module names are still resolved relative to the repository root
+  only, so a pytest plugin or conftest helper reachable only through a
+  configured `pythonpath` root would not be bound. This is latent in this
+  repository: the sole declared plugin resolves at the root, and any change to
+  the `pythonpath` setting itself now stales the proof through the pytest
+  configuration input. Tracked as a follow-up rather than fixed here.
+- **Ruff:**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev ruff check \
+    scripts/requirements_proof_provenance.py \
+    tests/unit/scripts/test_requirements_proof_provenance.py
+  ```
+
+  Result: all checks passed, and `ruff format --check` reports both files clean.
+- **Basedpyright:**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev bash tools/run_basedpyright.sh \
+    --project pyproject.toml scripts/requirements_proof_provenance.py \
+    tests/unit/scripts/test_requirements_proof_provenance.py
+  ```
+
+  Result: 0 errors, 0 warnings, and 0 notes.
+- **OpenSpec validation:**
+
+  ```shell
+  npx --yes @fission-ai/openspec@latest validate \
+    requirements-07-runtime-proof-delivery --strict
+  ```
+
+  Result: the change is valid.
+- **Skipped:** 0 tests.
+- **Environment:** Linux, Python 3.11.15, pytest 9.1.1.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1625,7 +1625,7 @@
     tests/unit/scripts/test_requirements_proof_provenance.py -q
   ```
 
-- **Passing result:** all 77 provenance tests passed, under both the default
+- **Passing result:** all 85 provenance tests passed, under both the default
   random ordering and `-p no:randomly`.
 - **Reconciliation with `2f893e95`:** that commit landed the last open Codex
   finding by retaining known constant values when a conditional assignment is
@@ -1719,6 +1719,37 @@
 - **No spurious rejection:** resolving proof inputs for three real selectors in
   this repository, individually and together, raises no fail-closed finding, so
   every file in the live traversal graph parses within the bound.
+- **Second follow-on Codex round:** three further findings were raised against
+  `5bb6189c` and are fixed here.
+  `addopts` is now parsed for `-p` plugin names at the red source and those
+  modules are seeded as plugin sources, because `-p` early-loads a module
+  regardless of autoload; `no:` entries disable a plugin and are skipped.
+  `_pytest_plugin_names` now reports only the final possible `pytest_plugins`
+  binding instead of accumulating every historical assignment, so a declaration
+  that a later one overwrites no longer stales the proof; the resolver records
+  `pytest_plugins` through the same constant table as any other name.
+  `_verified_type_checking_bindings` now scans `_executable_scope_nodes` rather
+  than `ast.walk`, so a function-, lambda-, or class-local name no longer counts
+  as rebinding the module guard, while a nested but reachable rebinding still
+  does.
+- **Refactor:** `_toml_pythonpath` and `_ini_pythonpath` collapsed into
+  `_pytest_ini_option` over a cached `_pytest_configuration_sources`, so
+  `pythonpath` and `addopts` share one reader. `_assigned_value_nodes` was
+  removed as unused once the resolver reads bindings directly.
+- **Failing-before (second follow-on):**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -p no:randomly \
+    -k "addopts or overwritten or function_local" -q
+  ```
+
+  Result: 7 failed, 1 passed. The disabled-`-p` guard passed before and after,
+  as a lock on unchanged behavior should.
+- **Verified on this repository:** configured `addopts` yields no `-p` entries,
+  `pythonpath` roots stay `('', 'src', 'tools')`, proof inputs are unchanged at
+  80 and 105 paths for two real selectors, no production module is bound, and
+  the declared plugin remains bound.
 - **Ruff:**
 
   ```shell

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1625,7 +1625,7 @@
     tests/unit/scripts/test_requirements_proof_provenance.py -q
   ```
 
-- **Passing result:** all 120 provenance tests passed, under both the default
+- **Passing result:** all 123 provenance tests passed, under both the default
   random ordering and `-p no:randomly`.
 - **Reconciliation with `2f893e95`:** that commit landed the last open Codex
   finding by retaining known constant values when a conditional assignment is
@@ -1872,6 +1872,30 @@
 - **Verified on this repository:** proof inputs stay at 83 and 108 paths for two
   real selectors, the declared plugin stays bound, and no production module is
   bound. 574 passed / 4 skipped across `tests/unit/scripts`,
+  `tests/unit/workflows`, and `tests/unit/tools`.
+- **Ninth follow-on Codex round:** two findings against `fb66d5e9`.
+  `_module_scope_nodes` now traverses scope headers for deferred and excluded
+  class scopes, the same correction made to `_executable_scope_nodes` earlier,
+  so a plugin bound in a function default such as
+  `def helper(arg=(pytest_plugins := (...)))` is seen by the resolver.
+  `_global_rebound_names` was also narrowed, but not as reported: the finding
+  asked to limit detection to class bodies and scope headers, which would have
+  reintroduced a fail-open case, since a function *invoked while the module
+  loads* genuinely does rebind the guard. Detection now applies a deferred
+  function's `global` bindings only when that function is called at module
+  scope, which removes the reported false positive without opening that hole.
+- **Failing-before (ninth follow-on):** 2 failed — the scope-header plugin
+  binding and the uncalled-function false positive.
+  `test_git_bound_red_proof_tracks_called_global_guard_rebinding` passed before
+  and after, and is the lock proving the narrowing did not become fail-open.
+- **Known limit:** call detection is one level deep and matches direct
+  invocation by name, so a `global` rebinding reached only through an
+  indirection — a decorator, an alias, or a nested call chain — is not tracked.
+  This is recorded rather than resolved, since deeper reachability analysis
+  would be disproportionate to a construct this rare.
+- **Verified on this repository:** proof inputs stay at 83 and 108 paths for two
+  real selectors, the declared plugin stays bound, and no production module is
+  bound. 577 passed / 4 skipped across `tests/unit/scripts`,
   `tests/unit/workflows`, and `tests/unit/tools`.
 - **Ruff:**
 

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1625,7 +1625,7 @@
     tests/unit/scripts/test_requirements_proof_provenance.py -q
   ```
 
-- **Passing result:** all 65 provenance tests passed, under both the default
+- **Passing result:** all 70 provenance tests passed, under both the default
   random ordering and `-p no:randomly`.
 - **Reconciliation with `2f893e95`:** that commit landed the last open Codex
   finding by retaining known constant values when a conditional assignment is
@@ -1662,12 +1662,39 @@
   lines only. This section appends beyond that boundary, so
   `legacy_tdd_ledger_digest` in `.github/workflows/requirements-evidence.yml`
   remains `sha256:d6e35c93...5e8c3` and was reverified unchanged.
-- **Deferred:** module names are still resolved relative to the repository root
-  only, so a pytest plugin or conftest helper reachable only through a
-  configured `pythonpath` root would not be bound. This is latent in this
-  repository: the sole declared plugin resolves at the root, and any change to
-  the `pythonpath` setting itself now stales the proof through the pytest
-  configuration input. Tracked as a follow-up rather than fixed here.
+- **`pythonpath` root resolution:** declared plugins now resolve against the
+  repository root and every configured `pythonpath` root. `_pythonpath_roots`
+  reads `pythonpath` from all four configuration candidates at the red source
+  (`[tool.pytest.ini_options]` via `tomllib`, and `[pytest]` or `[tool:pytest]`
+  via `configparser`), rejects absolute or escaping entries, and is cached per
+  ref. Reading every candidate instead of replicating pytest's inifile
+  precedence only widens the proof inputs, which is the safe direction.
+- **Scope decision:** roots widen plugin resolution only. Ordinary imports stay
+  anchored at the repository root. Measured against this repository before
+  making the change, rooting ordinary imports would have bound
+  `src/specfact_cli/models/module_package.py`,
+  `src/specfact_cli/modules/module_registry/src/commands.py`, and
+  `src/specfact_cli/registry/module_discovery.py` for a single selector — the
+  governed production modules a red-to-green change is expected to edit — so
+  every valid failing-first flow would have returned `stale-red-proof`.
+  `test_git_bound_red_proof_allows_production_change_under_pythonpath_root`
+  locks that invariant.
+- **Failing-before (`pythonpath`):**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py \
+    -p no:randomly -k pythonpath_root -q
+  ```
+
+  Result: 4 failed, 1 passed. The four plugin-under-root parameters failed and
+  the production-import invariant guard already passed, as intended for a
+  regression that locks unchanged behavior.
+- **Verified on this repository:** `_pythonpath_roots` returns
+  `('', 'src', 'tools')` from the real `pyproject.toml`, the declared plugin
+  `tests/helpers/doc_frontmatter_fixtures.py` remains bound, and no
+  `src/specfact_cli/**` module appears in the resolved proof inputs for either
+  a script-level or a module-registry selector.
 - **Ruff:**
 
   ```shell

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1188,6 +1188,37 @@
 - **Skipped:** 0 tests.
 - **Environment:** Linux, Python 3.11.15, pytest 9.1.1.
 
+## Codex nested guard and conditional plugin remediation
+
+- **Recorded:** 2026-08-10 (UTC)
+- **Review findings:** PR #671 identified that executable nested assignments
+  did not invalidate typing-guard aliases and that runtime-dependent plugin
+  branches retained only the last AST branch visited.
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.12 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py \
+    -k 'changed_pytest_plugin or rebound_type_checking' -q
+  ```
+
+- **Failing result:** a nested runtime-true `TYPE_CHECKING` rebinding omitted an
+  executed import, while a conditional plugin binding omitted the true branch.
+- **Passing-after command:**
+
+  ```shell
+  uv run --python 3.12 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -q
+  ```
+
+- **Passing result:** all 46 provenance tests passed after conservatively
+  recognizing nested rebindings and retaining the union of possible literal
+  values from runtime-dependent plugin branches.
+- **Validation:** Ruff, basedpyright, strict OpenSpec validation, and changed-file
+  SpecFact code review passed.
+- **Skipped:** 0 tests.
+- **Environment:** Linux, Python 3.12.13, pytest 9.1.1.
+
 ## Codex verified type guards and ordered constants remediation
 
 - **Recorded:** 2026-08-10 (UTC)

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1187,6 +1187,41 @@
 - **OpenSpec validation:** `uv run --python 3.11 --locked --extra dev openspec validate requirements-07-runtime-proof-delivery --strict` passed.
 - **Skipped:** 0 tests.
 - **Environment:** Linux, Python 3.11.15, pytest 9.1.1.
+
+## CI lint and legacy-ledger digest remediation
+
+- **Recorded:** 2026-08-10 (UTC)
+- **CI findings:** PR #671 failed Ruff formatting for the nested-plugin
+  regression signature and rejected the approved 1,143-line legacy TDD ledger
+  because its pinned SHA-256 no longer matched the retained ledger prefix.
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.12 --locked --extra dev ruff format --check \
+    scripts/requirements_proof_provenance.py \
+    tests/unit/scripts/test_requirements_proof_provenance.py
+  ```
+
+- **Failing result:** Ruff reported that
+  `tests/unit/scripts/test_requirements_proof_provenance.py` required formatting.
+- **Digest failing-before command:**
+
+  ```shell
+  uv run --python 3.12 --locked --extra dev python -m pytest \
+    tests/unit/workflows/test_requirements_evidence_delivery_workflow.py \
+    -k digest_bound_legacy_tdd_ledger_for_r07 -q
+  ```
+
+- **Digest failing result:** the workflow contract still required the prior
+  legacy-ledger digest after the workflow pin was updated.
+- **Passing result:** the exact CI Ruff format and check commands passed, the
+  safe-write validator passed, and the workflow contract plus all 36 provenance
+  tests passed (37 tests total).
+- **Approved ledger binding:** the SHA-256 of the first 1,143 ledger lines is
+  `sha256:d6e35c934757c08fd1f3e3071fc02b92b080c009ba5e428f6ea2888e7cd5e8c3`.
+- **OpenSpec validation:** strict validation passed.
+- **Skipped:** 0 tests.
+- **Environment:** Linux, Python 3.12.13, pytest 9.1.1.
 - **Internal wiki follow-up:** the sibling `specfact-cli-internal` checkout was
   unavailable. Update `wiki/sources/requirements-07-runtime-proof-delivery.md`
   and run `python3 scripts/wiki_rebuild_graph.py` from that repository root.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1625,7 +1625,7 @@
     tests/unit/scripts/test_requirements_proof_provenance.py -q
   ```
 
-- **Passing result:** all 70 provenance tests passed, under both the default
+- **Passing result:** all 77 provenance tests passed, under both the default
   random ordering and `-p no:randomly`.
 - **Reconciliation with `2f893e95`:** that commit landed the last open Codex
   finding by retaining known constant values when a conditional assignment is
@@ -1695,6 +1695,30 @@
   `tests/helpers/doc_frontmatter_fixtures.py` remains bound, and no
   `src/specfact_cli/**` module appears in the resolved proof inputs for either
   a script-level or a module-registry selector.
+- **Follow-on Codex findings on this work:** two P1 findings were raised
+  against `1d288c8f` and are fixed here.
+  `_compound_binding_names` now records names bound by loop, context-manager,
+  exception, match, and walrus targets, which `_name_bindings` did not see, so
+  `for PLUGINS in [...]` no longer leaves a stale literal active; the binding is
+  recorded as unresolved and the declaration fails closed.
+  `_imported_python_paths` now distinguishes an absent candidate from an
+  existing input it cannot parse: when `_python_tree_at_ref` returns `None` for
+  a path that `_test_path_is_regular_at_ref` confirms is a regular blob, the
+  proof is rejected instead of silently dropping that file's imports. Checking
+  the blob mode rather than mere existence keeps tree and symlink candidates
+  treated as absent.
+- **Failing-before (follow-on):**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -p no:randomly \
+    -k "compound_target or unparsable or oversized" -q
+  ```
+
+  Result: 7 failed, 70 deselected. All seven pass after the fix.
+- **No spurious rejection:** resolving proof inputs for three real selectors in
+  this repository, individually and together, raises no fail-closed finding, so
+  every file in the live traversal graph parses within the bound.
 - **Ruff:**
 
   ```shell

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -3022,3 +3022,36 @@ becomes a root because pytest walks up past it.
   directory). The fix is inert here and live for any repository on the default mode.
 - **Passing-after:** 292 passed in the provenance file, 7 in the new oracle, 683
   across the scripts, workflows, and integration suites.
+
+## Round 27: closing the oracle's own blind spot
+
+Round 26 added the oracle and recorded three limits of it. One was not a limit but
+a hole: the oracle read `sys.modules`, so it saw imports and nothing else. Every
+path-resolution rule — the join notations, `__file__`-relative bases, links at any
+component — governs files consumed as *data*, which never appear there. The rule
+family that had produced the most findings was the one family the new oracle could
+not see, and stating that in a docstring does not close it.
+
+The observer now also records reads, through an audit hook on the `open` event
+installed before the session begins. Writes are ignored, and `.git`, `__pycache__`,
+and `.pytest_cache` are excluded because a run populates those itself and no gate
+can bind what is not committed. Six layouts were added, all of them reads rather
+than imports: a repository-relative literal, a base relative to the reading module,
+a functional join, a read inside a fixture body, a linked file, and a linked
+directory.
+
+- **Proof that the read channel is real.** A green suite here could equally mean
+  the hook recorded nothing, which is the failure mode this round exists to fix, so
+  it was tested rather than assumed. With `_referenced_data_paths` disabled, **all
+  six read layouts fail and none of the seven import layouts do** — the two channels
+  are independent, and the read channel carries what it claims to. The message for
+  the hardest case names `tests/real_data/case.json`, the target resolved through a
+  directory link, not the link the source spelled.
+
+The oracle now covers both kinds of input the gate binds. What remains genuinely
+outside it is unchanged and worth stating plainly: it observes the layouts it is
+given, so a shape nobody has thought of is still unobserved. Adding a layout is now
+the cheapest way to close a class, and a layout is four lines.
+
+- **Passing-after:** 13 in the oracle, 689 across the scripts, workflows, and
+  integration suites.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1190,3 +1190,22 @@
 - **Internal wiki follow-up:** the sibling `specfact-cli-internal` checkout was
   unavailable. Update `wiki/sources/requirements-07-runtime-proof-delivery.md`
   and run `python3 scripts/wiki_rebuild_graph.py` from that repository root.
+
+## Codex package-initializer import traversal remediation
+
+- **Recorded:** 2026-08-10 (UTC)
+- **Review finding:** PR #671 identified that retained parent package
+  initializers were proof inputs but were not traversal roots, allowing a
+  repository-local module imported only by an initializer to change after red.
+- **Failing-before command:** `uv run --python 3.11 --locked --extra dev python -m pytest tests/unit/scripts/test_requirements_proof_provenance.py::test_git_bound_red_proof_rejects_changed_initializer_import -q`
+- **Failing result:** the regression failed because changing
+  `tests/support.py`, imported by `tests/__init__.py`, returned no provenance
+  finding.
+- **Passing-after command:** `uv run --python 3.11 --locked --extra dev python -m pytest tests/unit/scripts/test_requirements_proof_provenance.py -q`
+- **Passing result:** all 34 provenance tests passed after package initializer
+  paths became transitive import traversal roots.
+- **Skipped:** 0 tests.
+- **Environment:** Linux, Python 3.11.15, pytest 9.1.1.
+- **Internal wiki follow-up:** the sibling `specfact-cli-internal` checkout was
+  unavailable. Update `wiki/sources/requirements-07-runtime-proof-delivery.md`
+  and run `python3 scripts/wiki_rebuild_graph.py` from that repository root.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -2323,3 +2323,60 @@ Each was reproduced by execution before any production edit.
   guard, which the repository's committed conftests and initializers do not
   have. Wall time for the full selector set rose from 14.2s to 17.4s, from
   walking nested call arguments.
+
+## Codex round-16 remediation: imports inside invoked function bodies
+
+One finding, and the first in this series that directly contradicts an earlier
+accepted one.
+
+- **The finding:** a conftest, test, or initializer that calls a local function
+  whose body performs `import tests.runtime_support` executes that import during
+  module load, but `_import_module_names` stopped at the function definition, so
+  the imported file never entered `proof_inputs`.
+- **The contradiction:** the "Codex lazy initializer import remediation" round
+  above fixed the opposite complaint — imports in *uncalled* initializer function
+  bodies were bound as though package import executed them, which rejected valid
+  evidence. That fix discarded function bodies wholesale, which is what this
+  finding now exposes as too coarse in the other direction.
+- **The resolution:** the distinguishing fact is whether anything invokes the
+  body. `_module_scope_nodes` gained `include_deferred_scopes`, and
+  `_import_module_names` enables it exactly when `_calls_during_module_load` is
+  true. A module that invokes nothing cannot reach a function body, so its
+  imports stay unbound and the earlier finding still holds; once the module does
+  invoke something, which body that reaches cannot be decided, so every body
+  counts. Neither the by-name call resolution removed earlier nor a blanket
+  widening would satisfy both findings at once.
+- Static branch pruning still applies inside those bodies, so a
+  `TYPE_CHECKING`-guarded import in a function stays unbound. That direction is
+  pinned by its own regression rather than left to inspection.
+
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -p no:randomly \
+    -k "invoked_function or type_only_import_inside" -q
+  ```
+
+  Recorded 2026-08-12T17:14:03Z. Result: 1 failed, 1 passed — the over-strictness
+  lock already held, only the fail-open case was missing.
+- **Passing-after:** 146 passed in that file, including the earlier
+  `..._ignores_lazy_initializer_import` that a blanket widening broke.
+- **Real-repository check:** this is the first change in the series that moves
+  the numbers — 163 to 174 inputs for the 31 `tests/unit/scripts` selectors and
+  2186 to 2274 for all 333. The 88 additions were inspected individually rather
+  than accepted as a total:
+  - **87 do not exist in the repository.** They are candidate paths for
+    third-party imports found in function bodies — `rich/progress.py`,
+    `requests/HTTPError.py`, `ruamel/yaml.py`, and repository-root candidates for
+    `specfact_cli`, whose package lives under `src`. A path absent from the tree
+    can never change in a pull request, so it cannot produce a false stale.
+  - **1 exists: `scripts/runtime_discovery_smoke.py`**, imported inside a
+    function by a test that calls it. Binding it is correct.
+  - **No `src/specfact_cli/**` path is bound**, so the invariant that a
+    red-to-green change may edit governed production code without invalidating
+    its own proof still holds.
+  - Wall time for all 333 selectors rose from 17.4s to 41.6s. The gate validates
+    only the selected subset in CI, where the comparable figure is 2.3s for 31
+    selectors, but the growth is worth recording: descending into function bodies
+    roughly doubles the traversal.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1188,6 +1188,36 @@
 - **Skipped:** 0 tests.
 - **Environment:** Linux, Python 3.11.15, pytest 9.1.1.
 
+## Codex registered-plugin target remediation
+
+- **Recorded:** 2026-08-10 (UTC)
+- **Review finding:** PR #671 identified that parent package initializers of a
+  registered plugin were incorrectly allowed to declare additional plugins,
+  even though pytest registers only the specifically requested module.
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.12 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py \
+    -k plugin_parent -q
+  ```
+
+- **Failing result:** changing the target of `pytest_plugins` in the registered
+  plugin's parent `__init__.py` incorrectly returned `stale-red-proof`.
+- **Passing-after command:**
+
+  ```shell
+  uv run --python 3.12 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -q
+  ```
+
+- **Passing result:** all 40 provenance tests passed after parent initializers
+  remained ordinary import inputs while only the requested file or package
+  target was inspected for recursive plugin declarations.
+- **Validation:** Ruff, basedpyright, and strict OpenSpec validation passed.
+- **Skipped:** 0 tests.
+- **Environment:** Linux, Python 3.12.13, pytest 9.1.1.
+
 ## Codex comma-separated pytest plugin remediation
 
 - **Recorded:** 2026-08-10 (UTC)

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -2572,3 +2572,55 @@ from it, and that plugin's own import.
   The invariant fires on exactly the defect that two review rounds reported, and
   passes once it is fixed, which is stronger evidence than a synthetic mutation.
 - **Passing-after:** 194 passed in the provenance file.
+
+## Round 20: a dynamic import names its target in the argument
+
+Review found that a conftest loading repository support through
+`importlib.import_module("tests.runtime_support")` bound only the ordinary
+`import importlib` statement, never the module actually executed. Editing that
+support module between the red source and the final commit therefore left the
+proof standing.
+
+- **Failing-first evidence (2026-08-12T21:35:30Z).** Five spellings of the same
+  load — `importlib.import_module`, `__import__`, `importlib.__import__`, a
+  `from importlib import import_module` call, and the same call aliased to
+  `_load` — all returned `[]` where `['stale-red-proof']` was required. The
+  aliased spelling failing alongside the others is the evidence that rejected a
+  name-matching fix: a rule keyed on the callee cannot see `_load`.
+
+The fix resolves the **argument** rather than the callee. A dynamic import names
+its target in data, so the mechanism does not identify it; the literal does. Any
+dotted, identifier-shaped string a reachable body hands to a call is a candidate,
+which covers every mechanism, alias, and wrapper at once, including a name read
+out of a literal list, tuple, set, or dict handed to a loader.
+
+Two positions bound the rule, and both were set by measurement rather than by
+taste. Widening it to *any* literal in a reachable body was tried first and
+rejected: it broke the five existing locks that keep a `pytest_plugins` value in
+a scope pytest ignores from binding anything, because a string merely written
+down is loaded by no one. Accepting bare words was tried and rejected too — on
+this repository `Path("src")` bound `src/__init__.py` and the `repro setup`
+subcommand argument bound `setup.py`. Prose is unbounded, while the residual gap
+(a single-part target resting directly on an import root) is not.
+
+Existence is then checked per **name**, not per candidate path, because
+`src.module_a` in an analyzer fixture would otherwise bind `src/__init__.py`
+through the parent-package candidate while naming nothing that exists. An
+ordinary `import` statement is proof of its own target and keeps its absent
+candidates bound; a name guessed from a literal earns that only once its module
+is committed.
+
+- **Whole-repository measurement.** 333 selectors over the real checkout:
+  204 inputs for the scripts group and 2776 overall, identical to the previous
+  head — 0 added, 0 removed, and nothing under `src/specfact_cli/**` bound. Each
+  rejected variant was measured the same way and discarded on what it added:
+  the any-literal rule added 9 paths, bare words added `src/__init__.py` and
+  `setup.py`, and per-path existence checking left `src/__init__.py` behind.
+- **Hardening.** `DYNAMIC_LOADER_SHAPES` holds 16 spellings — keyword argument,
+  `find_spec`, a local wrapper, `functools.partial`, literal groups, conditional,
+  `try`, class body, fixture, and test bodies — and `INERT_LITERAL_SHAPES` holds
+  6 counter-shapes that must stay unbound, so the two directions are locked
+  against each other. `test_a_dynamic_import_in_an_uncalled_initializer_is_not_bound`
+  keeps the reachability rule in step with ordinary imports, which now share one
+  `_deferred_scopes_are_reachable` helper rather than two copies that can drift.
+- **Passing-after:** 217 passed in the provenance file.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1625,7 +1625,7 @@
     tests/unit/scripts/test_requirements_proof_provenance.py -q
   ```
 
-- **Passing result:** all 110 provenance tests passed, under both the default
+- **Passing result:** all 114 provenance tests passed, under both the default
   random ordering and `-p no:randomly`.
 - **Reconciliation with `2f893e95`:** that commit landed the last open Codex
   finding by retaining known constant values when a conditional assignment is
@@ -1813,6 +1813,25 @@
 - **Verified on this repository:** proof inputs stay at 83 and 108 paths for two
   real selectors, and the committed `pyproject.toml` is 29 KB against the 10 MiB
   bound, so the new fail-closed path is unreachable here.
+- **Sixth follow-on Codex round:** one P1 against `40142261`. A
+  `from tests.names import pytest_plugins` binding was invisible, because the
+  resolver recorded only assignment-like bindings. `_import_binding_names` now
+  records every imported name as unresolved, and `_has_star_import` records
+  `pytest_plugins` as unresolved when a star import could supply it, so both
+  forms fail closed rather than reporting no plugins. Resolving the value would
+  require cross-module analysis; failing closed is the option the finding
+  offered and matches the rule already applied to unevaluable expressions.
+  An import binding replaces rather than extends, so a literal declaration made
+  after an import still resolves normally.
+- **Failing-before (sixth follow-on):** 3 failed — the plain import, the
+  aliased import, and the star import. The fourth case in this round,
+  `test_git_bound_red_proof_binds_plugins_declared_after_an_import`, passed
+  before and after as a lock on the behavior that must not regress.
+- **Verified on this repository:** both committed `conftest.py` files still
+  resolve their declarations statically — `tests/conftest.py` binds
+  `tests.helpers.doc_frontmatter_fixtures` despite carrying imports above the
+  declaration — and proof inputs stay at 83 and 108 paths for two real
+  selectors.
 - **Ruff:**
 
   ```shell

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1625,7 +1625,7 @@
     tests/unit/scripts/test_requirements_proof_provenance.py -q
   ```
 
-- **Passing result:** all 114 provenance tests passed, under both the default
+- **Passing result:** all 116 provenance tests passed, under both the default
   random ordering and `-p no:randomly`.
 - **Reconciliation with `2f893e95`:** that commit landed the last open Codex
   finding by retaining known constant values when a conditional assignment is
@@ -1832,6 +1832,27 @@
   `tests.helpers.doc_frontmatter_fixtures` despite carrying imports above the
   declaration — and proof inputs stay at 83 and 108 paths for two real
   selectors.
+- **Seventh follow-on Codex round:** two findings against `e45eb375`.
+  Each traversal entry now carries the module root it was discovered under, so a
+  plugin loaded from a configured `pythonpath` root resolves its own imports
+  against that root as pytest does; `source/plugin.py` importing `helper` now
+  binds `source/helper.py` rather than only `helper.py`. `_module_relative_path`
+  strips the root before computing the package for relative imports, and
+  `_import_roots` keeps repository-root resolution for anything discovered at
+  the root, so the invariant that ordinary test imports never bind governed
+  production modules is preserved.
+  `_pythonpath_entries` also splits a string form with `shlex` rather than
+  whitespace, because pytest parses `paths` ini values that way — confirmed at
+  `_pytest/config/__init__.py:1792` in the locked 9.1.1, which reads
+  `input_values = shlex.split(value) if isinstance(value, str) else value`. A
+  quoted root such as `pythonpath = "test support"` is now one path instead of
+  two invalid ones.
+- **Failing-before (seventh follow-on):** 2 failed — the rooted plugin's own
+  import and the quoted root. Both pass after the fix, and the remaining 114
+  tests passed before and after the restructure.
+- **Verified on this repository:** roots stay `('', 'src', 'tools')`, proof
+  inputs stay at 83 and 108 paths for two real selectors, the declared plugin
+  stays bound, and no `src/specfact_cli/**` module is bound.
 - **Ruff:**
 
   ```shell

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1625,7 +1625,7 @@
     tests/unit/scripts/test_requirements_proof_provenance.py -q
   ```
 
-- **Passing result:** all 95 provenance tests passed, under both the default
+- **Passing result:** all 102 provenance tests passed, under both the default
   random ordering and `-p no:randomly`.
 - **Reconciliation with `2f893e95`:** that commit landed the last open Codex
   finding by retaining known constant values when a conditional assignment is
@@ -1772,6 +1772,25 @@
   stay `('', 'src', 'tools')`, and no production module is bound. Proof inputs
   grew from 80 to 83 and 105 to 108 paths for two real selectors, which is
   exactly the three added configuration filenames.
+- **Fourth follow-on Codex round:** two further P1 findings against `56e2a56e`.
+  `_executable_scope_nodes` skipped whole `FunctionDef`, `AsyncFunctionDef`,
+  `Lambda`, and `ClassDef` nodes, but only their *bodies* are deferred:
+  decorators, argument defaults, annotations, and base-class expressions
+  execute where the statement appears, so a walrus in a default such as
+  `def helper(x=(TYPE_CHECKING := True))` rebinds the module guard.
+  `_scope_header_nodes` now traverses everything except the body.
+  `_pytest_ini_option` also constructed `ConfigParser()` with default
+  interpolation, so a literal percent in an option value — valid to pytest, for
+  example `addopts = --junit-prefix=foo%bar` — raised `InterpolationSyntaxError`
+  from `get()`, outside the `try` that wrapped only `read_string`. The parser is
+  now built with `interpolation=None` and the option read moved inside the
+  guard.
+- **Failing-before (fourth follow-on):** 7 failed — three scope-header
+  rebinding forms (function default, lambda default, class base) and four
+  ini-style percent-literal configurations. All pass after the fix.
+- **Verified on this repository:** proof inputs stay at 83 and 108 paths for
+  two real selectors, roots stay `('', 'src', 'tools')`, `addopts` still yields
+  no `-p` entries, and no production module is bound.
 - **Ruff:**
 
   ```shell

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -2380,3 +2380,51 @@ accepted one.
     only the selected subset in CI, where the comparable figure is 2.3s for 31
     selectors, but the growth is worth recording: descending into function bodies
     roughly doubles the traversal.
+
+## Drift guards for the pinned legacy-ledger and plan digests
+
+The Requirements Evidence check has been red on `dev` since `8766b8fe`, and the
+cause is a class of drift nothing tested for.
+
+- **What broke.** The workflow pins a digest over the first 1143 lines of this
+  ledger. Commit `8766b8fe` inserted evidence at line 1086 — *inside* that
+  window, not appended past it — so the committed prefix began hashing to
+  `d6e35c93…` while the workflow still pinned `1df90efd…`. Every run since has
+  been rejected with "Approved legacy TDD ledger digest does not match".
+- **Why no test caught it.** The existing contract test asserted the workflow
+  *contains* the literal digest string. The workflow and its test therefore held
+  the same constant and could never disagree, and neither was ever compared to
+  the ledger they describe. The pair drifted away from the artifact together
+  while staying green.
+- **The guards.** `test_workflow_legacy_ledger_digest_matches_the_committed_ledger`
+  parses the pinned line count and digest out of the workflow and recomputes the
+  digest from the committed ledger using the same algorithm the workflow's inline
+  Python uses. It restates no constant, so it cannot drift alongside the pin.
+  `test_workflow_legacy_ledger_line_count_is_within_the_committed_ledger` catches
+  the other rejection path, "ledger is incomplete".
+  `test_legacy_ledger_digest_detects_an_edit_inside_the_pinned_window` pins the
+  sensitivity in both directions, because the whole point of the window is that
+  an append past it stays valid while an edit inside it does not.
+  `test_workflow_pinned_plan_digests_match_a_regenerated_plan` covers the
+  remaining two pins by regenerating the plan through the released module and
+  comparing `mapping_digest` and `plan_digest`; it skips without the fixture,
+  matching the existing convention.
+
+- **Failing-before evidence.** Rather than a synthetic mutation, the guard was
+  replayed against the real history:
+
+  | commit | pinned | committed prefix | guard |
+  |---|---|---|---|
+  | `f398b194` last green | `1df90efd` | `1df90efd` | passes |
+  | `8766b8fe` first red | `1df90efd` | `d6e35c93` | **fires** |
+  | `origin/dev` today | `1df90efd` | `d6e35c93` | **fires** |
+
+  The guard passes at the last green commit and fires at exactly the commit that
+  turned the check red, which is the strongest available proof that it detects
+  this class rather than merely restating today's values.
+- **Passing-after:** 13 passed in the workflow contract file with the pinned
+  fixture mounted; 12 passed and 1 skipped without it, so CI behaviour is
+  unchanged where the fixture is absent.
+- **Scope note:** this branch already carries the corrected ledger pin
+  (`d6e35c93…`), so the guards pass here. They will fail on `dev` until its pin
+  is corrected — which is the intended signal, not a regression.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1169,3 +1169,24 @@
   regular blob modes while continuing to reject symlinks.
 - **Skipped:** 0 tests.
 - **Environment:** Linux, Python 3.12.13, pytest 9.1.1.
+
+## Codex selector-package and annotated-plugin remediation
+
+- **Recorded:** 2026-08-10 (UTC)
+- **Review findings:** PR #665 identified that provenance omitted package
+  initializers for the selected test and ignored annotated `pytest_plugins`
+  assignments in applicable conftests.
+- **Failing-before command:** `uv run --python 3.11 --locked --extra dev python -m pytest tests/unit/scripts/test_requirements_proof_provenance.py -k 'annotated_pytest_plugin or selector_package_initializer' -q`
+- **Failing result:** both selected regressions failed because adding
+  `tests/__init__.py` or changing a plugin declared with `ast.AnnAssign`
+  returned no provenance finding.
+- **Passing-after command:** `uv run --python 3.11 --locked --extra dev python -m pytest tests/unit/scripts/test_requirements_proof_provenance.py -q`
+- **Passing result:** all 33 provenance tests passed after retaining possible
+  parent initializers for every seeded pytest input and accepting static
+  annotated plugin declarations.
+- **OpenSpec validation:** `uv run --python 3.11 --locked --extra dev openspec validate requirements-07-runtime-proof-delivery --strict` passed.
+- **Skipped:** 0 tests.
+- **Environment:** Linux, Python 3.11.15, pytest 9.1.1.
+- **Internal wiki follow-up:** the sibling `specfact-cli-internal` checkout was
+  unavailable. Update `wiki/sources/requirements-07-runtime-proof-delivery.md`
+  and run `python3 scripts/wiki_rebuild_graph.py` from that repository root.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1881,3 +1881,61 @@
   Result: the change is valid.
 - **Skipped:** 0 tests.
 - **Environment:** Linux, Python 3.11.15, pytest 9.1.1.
+
+## Related-code audit for the same defect classes
+
+- **Recorded:** 2026-08-11 (UTC)
+- **Request:** check whether the defect classes fixed in this change exist in
+  related code, and fix what is found.
+- **Method:** searched for each class rather than reasoning from memory —
+  `configparser` users, `ast.parse`/`ast.walk` users, pytest configuration
+  filename lists, `git show` callers with `text=True`, and JSON reads whose
+  `except` clause omits `UnicodeDecodeError`. Every candidate was then executed
+  against a crafted non-UTF-8 input rather than judged by reading.
+- **Fixed — undecodable input aborts a fail-closed gate (3 sites):**
+  `scripts/security_audit_gate.py` `_read_exception_items` and
+  `scripts/check_dependency_trust_exceptions.py` `_read_exception_records` and
+  `_read_security_tool_floors` caught `(OSError, json.JSONDecodeError)` but not
+  `UnicodeDecodeError`, so a non-UTF-8 register crashed each gate instead of
+  producing the fail-closed error their docstrings promise. Confirmed by
+  execution before the fix, and their `main` functions do not catch it.
+- **Fixed — incomplete pytest configuration candidates (1 site):**
+  `tools/smart_test_coverage.py` listed only `pytest.ini` and `tox.ini`, so a
+  change to `pytest.toml`, `.pytest.toml`, `.pytest.ini`, or `setup.cfg` did not
+  count as configuration drift and could leave coverage scoped from a stale
+  cache. Aligned with pytest's discovery order, the same correction made in this
+  change's own candidate list.
+- **Checked and found correct, no change made:**
+  `scripts/requirements_proof_executor.py` already catches
+  `(OSError, UnicodeDecodeError, json.JSONDecodeError)` and its `main` catches
+  `subprocess.SubprocessError`, which covers `TimeoutExpired`.
+  `scripts/requirements_evidence_delivery_gate.py` omits `UnicodeDecodeError`
+  from one `except`, but its `main` catches `(OSError, ValueError)` and
+  `UnicodeDecodeError` is a `ValueError`, so the error is absorbed and only the
+  diagnostic wording differs — verified by execution, and left unchanged rather
+  than churned. `scripts/verify_safe_project_writes.py` already guards
+  `OSError`, `UnicodeDecodeError`, and `SyntaxError`.
+  `scripts/check_local_version_ahead_of_pypi.py` reads bytes, so the decode
+  class does not apply.
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_security_audit_gate.py \
+    tests/unit/scripts/test_dependency_trust_review.py -p no:randomly \
+    -k undecodable -q
+  ```
+
+  Result: 3 failed, each with the `UnicodeDecodeError` the gate should have
+  converted into an error.
+- **Passing-after:** 28 passed in those two files, and 570 passed / 4 skipped
+  across `tests/unit/scripts`, `tests/unit/tools`, and `tests/unit/workflows`.
+- **Static gates:** Ruff check and format clean across `scripts/`,
+  `tools/smart_test_coverage.py`, and the touched tests. Basedpyright reports
+  0 errors and 0 warnings at the `--level error` threshold CI enforces; at the
+  default threshold the touched files go from 44 to 45 warnings, the added one
+  being the same untyped-fixture pattern as the 44 already present in
+  `test_security_audit_gate.py`.
+- **Deferred:** four product-code reads under `src/` share the undecodable-input
+  class with cache-fallback semantics; recorded as a task rather than changed
+  here, because product paths need their own contract and coverage treatment.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -2428,3 +2428,70 @@ cause is a class of drift nothing tested for.
 - **Scope note:** this branch already carries the corrected ledger pin
   (`d6e35c93…`), so the guards pass here. They will fail on `dev` until its pin
   is corrected — which is the intended signal, not a regression.
+
+## Codex round-17 remediation and structural hardening
+
+Six P1 findings, all reproduced by execution first, plus the hardening that
+stops this class from recurring one shape at a time.
+
+- **Imports in a selected test or fixture body.** The round-16 gate keyed body
+  traversal on `_calls_during_module_load`, but pytest invokes test and fixture
+  bodies during the run regardless. The gate now keys on file role instead: only
+  a package initializer needs an import-time call to reach its own functions,
+  which is exactly the distinction the earlier lazy-initializer round required.
+- **Configuration beneath a selector.** Pytest searches upward from the
+  arguments' common ancestor, so `tests/pytest.ini` decides collection for a
+  selector beneath it. Discovery now walks the root and every selector ancestor.
+- **Augmented assignment through an alias.** `PLUGINS += [...]` mutates the
+  shared list, so it now propagates to aliases like the other mutation forms.
+- **Imports through a symlinked directory.** Python follows the link while Git
+  records it, so a candidate under a symlinked ancestor fails closed. One cached
+  `ls-tree` collects every symlink, so this costs no per-lookup Git call.
+- **Guard written through a module mapping.** `typing.__dict__["TYPE_CHECKING"]`
+  reaches the attribute the guard reads.
+- **Unreadable configuration read as absent.** A failed or timed-out `git show`
+  now distinguishes an absent candidate from an unreadable one and fails closed.
+
+### Hardening
+
+Two structural changes, then two batteries that assert the families rather than
+the instances.
+
+- `_root_name` resolves attribute, subscript, and call chains to their base
+  name, and every "which name does this touch" rule goes through it. The
+  recurring finding shape was a known idea inside a new wrapper; wrappers now
+  resolve identically to their unwrapped form.
+- The batteries enumerate 16 guard-rewrite shapes and 16 unresolvable plugin
+  shapes and assert every one fails closed, alongside positive controls proving
+  the rules are not satisfiable by rejecting everything.
+
+The batteries earned their keep immediately, in both directions:
+
+- Two shapes I had listed as fail-open were **not** defects. A star import
+  followed by an explicit assignment is definitively resolvable, and a
+  conditional declaration binds the union of its possible values, which is the
+  fail-closed direction. Both moved to the positive controls rather than
+  "fixing" correct behavior — the labels were wrong, not the code.
+- Broadening guard-write detection to every subscript target made
+  `mapping[key] = value` inside any helper mark a module state-mutating, so
+  **every proof on this repository was rejected**. The whole-repository
+  measurement caught it before it shipped; the rule now matches the guard key,
+  and `test_ordinary_mapping_writes_do_not_make_a_module_unverifiable` pins the
+  boundary that nothing previously guarded.
+
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -p no:randomly \
+    -k "selected_test_body or selector_ancestors or augmented_mutation or \
+    symlinked_package_directory or module_dictionary or cannot_be_read" -q
+  ```
+
+  Recorded 2026-08-12T20:27:33Z. Result: 6 failed.
+- **Passing-after:** 188 passed in that file.
+- **Real-repository check:** 176 inputs for the 31 `tests/unit/scripts`
+  selectors and 2286 for all 333, up from 174 and 2274, the increase coming from
+  test-body imports now binding. No `src/specfact_cli/**` path is bound, so a
+  red-to-green change may still edit governed production code without
+  invalidating its own proof.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1188,6 +1188,35 @@
 - **Skipped:** 0 tests.
 - **Environment:** Linux, Python 3.11.15, pytest 9.1.1.
 
+## Codex lazy initializer import remediation
+
+- **Recorded:** 2026-08-10 (UTC)
+- **Review finding:** PR #671 identified that imports in uncalled initializer
+  function bodies were incorrectly retained as if package import executed them.
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.12 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py \
+    -k lazy_initializer_import -q
+  ```
+
+- **Failing result:** changing a module imported only inside an uncalled
+  `__init__.py` function incorrectly returned `stale-red-proof`.
+- **Passing-after command:**
+
+  ```shell
+  uv run --python 3.12 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -q
+  ```
+
+- **Passing result:** all 41 provenance tests passed after import discovery
+  stopped descending into deferred function, async-function, and lambda scopes
+  while continuing to inspect executable class bodies.
+- **Validation:** Ruff, basedpyright, and strict OpenSpec validation passed.
+- **Skipped:** 0 tests.
+- **Environment:** Linux, Python 3.12.13, pytest 9.1.1.
+
 ## Codex registered-plugin target remediation
 
 - **Recorded:** 2026-08-10 (UTC)

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -2923,3 +2923,40 @@ stale, while a path that was simply never there stays unbound.
   head; no module in this repository reaches its namespace mapping, so the stricter
   rule rejects nothing here. The automated repository measurement passes unchanged.
 - **Passing-after:** 273 passed in the provenance file.
+
+## Round 25: one namespace, every door
+
+The third finding on the same rule: `setattr(sys.modules[__name__], "pytest_plugins", ...)`
+and `sys.modules[__name__].__dict__` reach the namespace pytest reads without
+going through `globals()`. Round 24 made the rule positional — reading one key is
+fine, every other use is not — but left the *subject* of that rule narrow, naming
+only the mapping returned by `globals()` and `vars()`. A positional rule over an
+incomplete subject is still an incomplete rule.
+
+- **Failing-first.** Six of the nine shapes in `MODULE_OBJECT_REWRITE_SHAPES`
+  already failed closed, but by accident rather than by rule: they were caught by
+  the unrelated `setattr` check or by the `pytest_plugins` attribute-write check.
+  Three were not caught at all — a subscript write through the module's `__dict__`,
+  handing the module object to a local function, and `exec` against that `__dict__`.
+
+The subject is now the namespace itself, recognized by every door that reaches it:
+`globals()`, `vars()`, this module's own entry in the module table by subscript, by
+`get`, or through `import_module`, and the `__dict__` of any of them. They are one
+object seen from different sides, so one predicate recognizes all of them and every
+rule already written applies to each without restatement.
+
+Verified as such rather than by suite outcome: all nine shapes now trip the
+predicate directly, so each is rejected by the rule that is supposed to reject it
+instead of by a neighbouring check that happened to fire.
+
+The key matters. `sys.modules["tests.substitute"] = ...` is ordinary test practice
+and reaches nothing this gate reads, so only an entry keyed by `__name__` denotes
+this module. `INERT_MODULE_REFERENCE_SHAPES` locks four such cases —
+`logging.getLogger(__name__)`, splitting `__name__`, substituting another module,
+and `setattr` on that substitute — alongside a plain `globals()["key"]` read, which
+must stay verifiable for the positional rule to mean anything.
+
+- **Whole-repository measurement.** Zero added, zero removed against the previous
+  head. No module here reaches its own namespace by any door, so the wider subject
+  rejects nothing on this repository; its coverage is the thirteen-shape battery.
+- **Passing-after:** 286 passed in the provenance file.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1188,6 +1188,38 @@
 - **Skipped:** 0 tests.
 - **Environment:** Linux, Python 3.11.15, pytest 9.1.1.
 
+## Codex root-initializer and plugin-source remediation
+
+- **Recorded:** 2026-08-10 (UTC)
+- **Review findings:** PR #671 identified that the repository-root
+  `__init__.py` was absent from proof inputs and that `pytest_plugins`
+  declarations in ordinarily imported helpers were incorrectly treated as
+  active pytest registrations.
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.12 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py \
+    -k 'imported_helper or repository_root_initializer' -q
+  ```
+
+- **Failing result:** changing a helper's plugin-like target incorrectly
+  returned `stale-red-proof`, while adding the repository-root initializer
+  returned no finding.
+- **Passing-after command:**
+
+  ```shell
+  uv run --python 3.12 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -q
+  ```
+
+- **Passing result:** all 38 provenance tests passed after retaining the root
+  initializer candidate and limiting plugin discovery to pytest-considered
+  inputs and recursively registered plugins.
+- **Validation:** Ruff, basedpyright, and strict OpenSpec validation passed.
+- **Skipped:** 0 tests.
+- **Environment:** Linux, Python 3.12.13, pytest 9.1.1.
+
 ## CI lint and legacy-ledger digest remediation
 
 - **Recorded:** 2026-08-10 (UTC)

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1188,6 +1188,37 @@
 - **Skipped:** 0 tests.
 - **Environment:** Linux, Python 3.11.15, pytest 9.1.1.
 
+## Codex static branches and plugin constants remediation
+
+- **Recorded:** 2026-08-10 (UTC)
+- **Review findings:** PR #671 identified that imports under `if False` and
+  `if TYPE_CHECKING` were treated as executed, while `pytest_plugins` assigned
+  through a simple literal module constant was ignored.
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.12 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py \
+    -k 'changed_pytest_plugin or unreachable_initializer' -q
+  ```
+
+- **Failing result:** the new constant-backed plugin case returned no finding,
+  and changing support imported only by statically false initializer branches
+  incorrectly returned `stale-red-proof`.
+- **Passing-after command:**
+
+  ```shell
+  uv run --python 3.12 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -q
+  ```
+
+- **Passing result:** all 43 provenance tests passed after pruning known-false
+  branches and resolving simple literal module constants used by
+  `pytest_plugins`.
+- **Validation:** Ruff, basedpyright, and strict OpenSpec validation passed.
+- **Skipped:** 0 tests.
+- **Environment:** Linux, Python 3.12.13, pytest 9.1.1.
+
 ## Codex lazy initializer import remediation
 
 - **Recorded:** 2026-08-10 (UTC)

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -2013,3 +2013,100 @@
 - **Deferred:** four product-code reads under `src/` share the undecodable-input
   class with cache-fallback semantics; recorded as a task rather than changed
   here, because product paths need their own contract and coverage treatment.
+
+## Codex round-13 remediation: roots, symlinked configuration, aliases, and `setattr`
+
+Four new P1 findings arrived against `130260d0`. Each was reproduced by
+execution before any production edit.
+
+- **Traversing `pythonpath` root.** `_safe_module_root` returned `None` for any
+  entry containing `..`, so `pythonpath = tests/helpers/../plugins` silently
+  contributed no root and `addopts = -p localplugin` was searched only at the
+  repository root. Pytest resolves the entry, so `tests/plugins/localplugin.py`
+  loads and a post-red change to it was accepted. The root is now normalized
+  within the repository; an absolute or escaping entry still yields no root,
+  because a tree outside the repository holds no file any Git ref can bind.
+- **Symlinked pytest configuration.** `git show <ref>:pytest.ini` returns the
+  link text, while pytest reads the target, so an `addopts` or `pythonpath`
+  declaration in the target was invisible. `_pytest_configuration_sources` now
+  applies the same rule the traversal already applied to inputs: a candidate
+  that exists but is not a regular blob yields `stale-red-proof`. The scenario
+  already required this ("a symlink whose executed bytes were never inspected");
+  only the implementation was missing.
+- **Mutation through an earlier alias.** `PLUGINS = []`, `pytest_plugins =
+  PLUGINS`, `PLUGINS.append("tests.localplugin")` binds both names to one list,
+  but the resolver marked only `PLUGINS` unresolved and kept the empty list it
+  had already copied for `pytest_plugins`. Mutation now propagates by object
+  identity to every name sharing that container. Identity comparison is limited
+  to mutable containers, because equal immutable values can be interned and
+  would otherwise link unrelated bindings.
+- **`setattr` rewrites of the typing guard.** `setattr(typing, "TYPE_CHECKING",
+  True)` rewrites the guard without an attribute-assignment target, and
+  `_unverifiable_module_state` did not apply because no separate function was
+  defined. Rather than adding a `setattr` special case that the next equivalent
+  form (`vars(typing)["TYPE_CHECKING"] = True`) would defeat, the module guard
+  is now dropped whenever the module name is handed to any call at module load:
+  a callee that receives the module can rewrite any attribute, and deciding
+  which callees do would need their bodies. The same rewrite performed inside a
+  function now also marks that function state-mutating, so an invoked one makes
+  module state unverifiable.
+
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_requirements_proof_provenance.py -p no:randomly \
+    -k "traversing_pythonpath or symlinked_pytest_configuration or \
+    earlier_alias or setattr" -q
+  ```
+
+  Recorded 2026-08-11T21:52:41Z. Result: 5 failed, each accepting evidence the
+  gate must reject.
+- **Passing-after:** 133 passed in that file.
+- **Real-repository check:** against this worktree's `HEAD`, the configuration
+  sources (`pyproject.toml`), the `pythonpath` roots (`''`, `src`, `tools`), and
+  the resolved proof inputs are byte-identical to the pre-change script — 163
+  inputs for the 31 `tests/unit/scripts` selectors and 2186 for all 333 tracked
+  selectors — so the change alters only the shapes the findings describe.
+
+## Related-code audit: scope-header and class-scope classes
+
+The two defect classes introduced in the preceding rounds — scope headers
+execute where the statement appears, and a class body does not bind names for
+the scopes nested in it — were audited across the repository's other static
+analysis. `scripts/verify_safe_project_writes.py` is the only comparable
+fail-closed gate; the `src/specfact_cli/analyzers/**` modules are best-effort
+extractors whose misses are extraction quality rather than a gate hole, and
+remain out of scope. Six fail-open cases were confirmed by execution in that
+gate, each of which lets real unsafe JSON I/O through:
+
+- A class attribute such as `json = None` suppressed offenders inside the
+  class's methods, because every enclosing frame was unioned. A class body is
+  not visible to scopes nested in it, so frames are now tagged and class frames
+  are skipped when resolving a name from a nested scope.
+- `except OSError as json:` suppressed offenders after the handler, although
+  Python deletes the target when the handler ends. The binding is now removed
+  again unless the name was already shadowed.
+- Decorators, argument defaults, and class bases were never visited at all,
+  because both scope visitors descended only into the body. They execute in the
+  enclosing scope and are now visited there.
+- A bare decorator (`@json.loads`) invokes the name without producing a `Call`
+  node, so it was invisible. Decorator references are now matched directly, and
+  the matching logic is shared with `visit_Call` rather than duplicated.
+
+Two accuracy fixes in the opposite direction accompany them: a lambda parameter
+named after an alias no longer produces a spurious offender, and annotations are
+visited only when the analyzed module lacks `from __future__ import
+annotations`, since PEP 563 leaves them unevaluated.
+
+- **Failing-before command:**
+
+  ```shell
+  uv run --python 3.11 --locked --extra dev python -m pytest \
+    tests/unit/scripts/test_verify_safe_project_writes.py -p no:randomly -q
+  ```
+
+  Recorded 2026-08-11T21:47:23Z. Result: 9 failed, 10 passed.
+- **Passing-after:** 23 passed across the unit and integration files, and
+  `python scripts/verify_safe_project_writes.py` still exits 0 against the real
+  `src/specfact_cli/utils/ide_setup.py`.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -2852,3 +2852,74 @@ stay bound.
   unchanged.
 - **Passing-after:** 256 passed in the provenance file, 640 across the scripts,
   workflows, and integration suites.
+
+## Round 24: closing three families rather than three spellings
+
+All three findings were second spellings of rules changed in round 23, and each was
+reported as "fresh evidence beyond the resolved thread". That is the signature of a
+rule stated as a shape rather than as a principle, so each was fixed by replacing
+the rule, not by adding a case.
+
+### Reaching the namespace mapping
+
+`globals().update(pytest_plugins=[...])` creates the attribute pytest reads while
+the predicate inspected only assignment targets, so the declaration was invisible
+and the plugin never bound.
+
+- **Failing-first.** Of eight shapes in `NAMESPACE_REWRITE_SHAPES`, five already
+  failed closed and three did not: `exec(..., globals())`, handing the mapping to a
+  local function, and `sys.modules[__name__].pytest_plugins = [...]`.
+
+Enumerating mutating methods would have admitted whichever spelling the list
+omitted — `setdefault` after `update`, `__setitem__` after that. The rule is
+positional instead: reading one key out of the mapping is fine, and **every other
+use of it** leaves the module unknowable, whether that is a subscript write, any
+method call on it, or handing it to anything. A `pytest_plugins` attribute write is
+unverifiable wherever it appears, because the module object is reachable by other
+routes than the mapping.
+
+### One join, several notations
+
+`os.path.join(os.path.dirname(__file__), "data/case.json")` is an `ast.Call`, and
+the resolver read only `ast.BinOp`, so the operator form worked and the functional
+form bound nothing.
+
+- **Failing-first.** All six shapes in `FUNCTIONAL_JOIN_SHAPES` returned `[]` where
+  `['stale-red-proof']` was required, including `joinpath`, `abspath` wrapping, and
+  a doubled `dirname`.
+
+`base / "a"`, `os.path.join(base, "a")`, and `base.joinpath("a")` are now one
+construction behind a single splitter, and a join is itself resolvable as a path,
+so nesting them composes without further cases.
+
+The over-binding direction needed its own rule. A join's components are consumed
+whether or not its base turns out to be knowable, because a component is part of a
+path rather than a path of its own — otherwise the tail of
+`os.path.join(tmp_path, "tests/data/case.json")` would still be read as
+repository-relative and bind a file the run never opened.
+`test_a_functional_join_from_an_unknowable_base_binds_nothing` locks that.
+
+### Links at any component, not only the last
+
+`tests/data_link/case.json` where `tests/data_link -> real_data` has no Git entry at
+the full path, so looking up only the whole candidate found nothing to follow and
+bound neither the link nor the target.
+
+- **Failing-first.** Both shapes returned `[]` where `['stale-red-proof']` was
+  required, including a two-deep chain of directory links.
+
+Resolution now walks the path component by component from the repository root and
+follows the first link it crosses, which subsumes the file-link case that was fixed
+last round: a link at the end is simply the last component. Every link crossed is
+bound.
+
+Rewriting the walk lost a behaviour the previous version had, and the existing lock
+caught it: a link resolving to nothing returned the link alone instead of failing.
+That is fail-open — creating the missing file later would start feeding the read
+while binding nothing — so a chain that crosses a link and ends at an absent path is
+stale, while a path that was simply never there stays unbound.
+
+- **Whole-repository measurement.** Zero added, zero removed against the previous
+  head; no module in this repository reaches its namespace mapping, so the stricter
+  rule rejects nothing here. The automated repository measurement passes unchanged.
+- **Passing-after:** 273 passed in the provenance file.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/requirements-evidence.yaml
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/requirements-evidence.yaml
@@ -71,6 +71,9 @@ requirements:
       - id: red-proof-verifier
         kind: ci_workflow
         locator: "requirements-proof/red.json"
+      - id: red-proof-provenance-validator
+        kind: cli_command
+        locator: "scripts/requirements_proof_provenance.py"
       - id: legacy-tdd-ledger
         kind: evidence_ledger
         locator: "TDD_EVIDENCE.md"
@@ -91,6 +94,46 @@ requirements:
         selector:
           runner: pytest
           node_id: tests/unit/scripts/test_requirements_proof_provenance.py::test_git_bound_red_proof_rejects_replayed_or_renamed_production_history
+      - case_id: R07-CORE-003-S04
+        scenario_id: git-bound-failing-first-proof
+        method: test
+        intent: "Prove the pytest configuration source and its configured roots are proof inputs."
+        observable: "A plugin early-loaded through addopts under a configured root stays bound."
+        selector:
+          runner: pytest
+          node_id: tests/unit/scripts/test_requirements_proof_provenance.py::test_git_bound_red_proof_normalizes_traversing_pythonpath_root
+      - case_id: R07-CORE-003-S05
+        scenario_id: git-bound-failing-first-proof
+        method: test
+        intent: "Prove a proof input that exists but cannot be read is stale rather than skipped."
+        observable: "A symlinked pytest configuration source yields stale-red-proof."
+        selector:
+          runner: pytest
+          node_id: tests/unit/scripts/test_requirements_proof_provenance.py::test_git_bound_red_proof_rejects_symlinked_pytest_configuration
+      - case_id: R07-CORE-003-S06
+        scenario_id: git-bound-failing-first-proof
+        method: test
+        intent: "Prove an unresolvable plugin declaration fails closed instead of binding nothing."
+        observable: "A mutation reaching the declaration through an alias yields stale-red-proof."
+        selector:
+          runner: pytest
+          node_id: tests/unit/scripts/test_requirements_proof_provenance.py::test_git_bound_red_proof_tracks_mutation_through_an_earlier_alias
+      - case_id: R07-CORE-003-S07
+        scenario_id: git-bound-failing-first-proof
+        method: test
+        intent: "Prove a typing guard is trusted only while it cannot have been rewritten."
+        observable: "A guard handed to a call inside an invoked function yields stale-red-proof."
+        selector:
+          runner: pytest
+          node_id: tests/unit/scripts/test_requirements_proof_provenance.py::test_git_bound_red_proof_tracks_guard_handed_to_a_call_inside_a_function
+      - case_id: R07-CORE-003-S08
+        scenario_id: git-bound-failing-first-proof
+        method: test
+        intent: "Prove a selected symlink is rejected rather than hashed as its link text."
+        observable: "A symlinked selector is rejected as invalid prior-red proof."
+        selector:
+          runner: pytest
+          node_id: tests/unit/scripts/test_requirements_proof_provenance.py::test_git_bound_red_proof_rejects_symlink_selector
       - case_id: R07-CORE-003-S03
         scenario_id: git-bound-failing-first-proof
         method: test

--- a/openspec/changes/requirements-07-runtime-proof-delivery/requirements-evidence.yaml
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/requirements-evidence.yaml
@@ -71,9 +71,6 @@ requirements:
       - id: red-proof-verifier
         kind: ci_workflow
         locator: "requirements-proof/red.json"
-      - id: red-proof-provenance-validator
-        kind: cli_command
-        locator: "scripts/requirements_proof_provenance.py"
       - id: legacy-tdd-ledger
         kind: evidence_ledger
         locator: "TDD_EVIDENCE.md"
@@ -94,46 +91,6 @@ requirements:
         selector:
           runner: pytest
           node_id: tests/unit/scripts/test_requirements_proof_provenance.py::test_git_bound_red_proof_rejects_replayed_or_renamed_production_history
-      - case_id: R07-CORE-003-S04
-        scenario_id: git-bound-failing-first-proof
-        method: test
-        intent: "Prove the pytest configuration source and its configured roots are proof inputs."
-        observable: "A plugin early-loaded through addopts under a configured root stays bound."
-        selector:
-          runner: pytest
-          node_id: tests/unit/scripts/test_requirements_proof_provenance.py::test_git_bound_red_proof_normalizes_traversing_pythonpath_root
-      - case_id: R07-CORE-003-S05
-        scenario_id: git-bound-failing-first-proof
-        method: test
-        intent: "Prove a proof input that exists but cannot be read is stale rather than skipped."
-        observable: "A symlinked pytest configuration source yields stale-red-proof."
-        selector:
-          runner: pytest
-          node_id: tests/unit/scripts/test_requirements_proof_provenance.py::test_git_bound_red_proof_rejects_symlinked_pytest_configuration
-      - case_id: R07-CORE-003-S06
-        scenario_id: git-bound-failing-first-proof
-        method: test
-        intent: "Prove an unresolvable plugin declaration fails closed instead of binding nothing."
-        observable: "A mutation reaching the declaration through an alias yields stale-red-proof."
-        selector:
-          runner: pytest
-          node_id: tests/unit/scripts/test_requirements_proof_provenance.py::test_git_bound_red_proof_tracks_mutation_through_an_earlier_alias
-      - case_id: R07-CORE-003-S07
-        scenario_id: git-bound-failing-first-proof
-        method: test
-        intent: "Prove a typing guard is trusted only while it cannot have been rewritten."
-        observable: "A guard handed to a call inside an invoked function yields stale-red-proof."
-        selector:
-          runner: pytest
-          node_id: tests/unit/scripts/test_requirements_proof_provenance.py::test_git_bound_red_proof_tracks_guard_handed_to_a_call_inside_a_function
-      - case_id: R07-CORE-003-S08
-        scenario_id: git-bound-failing-first-proof
-        method: test
-        intent: "Prove a selected symlink is rejected rather than hashed as its link text."
-        observable: "A symlinked selector is rejected as invalid prior-red proof."
-        selector:
-          runner: pytest
-          node_id: tests/unit/scripts/test_requirements_proof_provenance.py::test_git_bound_red_proof_rejects_symlink_selector
       - case_id: R07-CORE-003-S03
         scenario_id: git-bound-failing-first-proof
         method: test

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -196,16 +196,20 @@ retain deterministic JUnit results for module-owned reconciliation.
   statically is treated as stale rather than silently ignored, including when a
   loop, context-manager, exception, match, or walrus target rebinds the
   constant it reads, when a mutation reaches the declaration through another
-  name bound to the same object, or when the declaration is bound by an import
-  whose value lives in another module
+  name bound to the same object whether by method call, subscript or attribute
+  write, or deletion, or when the declaration is bound by an import whose value
+  lives in another module
 - **AND** a proof input or configuration source that exists at the red source
   but cannot be read or parsed, because it is oversized, malformed, or a symlink
   whose executed bytes were never inspected, is treated as stale rather than
-  skipped like an absent candidate
+  skipped like an absent candidate, and a symlink is recognized by its Git mode
+  rather than by failing to parse, because a link text such as `support.py` is
+  itself valid Python
 - **AND** a typing guard is trusted only while unmutated, so an attribute write
   to its `TYPE_CHECKING` member, handing the guard module to any call that could
-  rewrite that member, or a `global` rebinding from a class body drops it, a
-  rebinding invalidates only the branches that follow it, and any literal
+  rewrite that member, copying the module into a second binding through which a
+  write would be invisible, or a `global` rebinding from a class body drops it,
+  a rebinding invalidates only the branches that follow it, and any literal
   branch condition is resolved by its truthiness
 - **AND** module state is treated as unverifiable, failing closed for both the
   guard and the plugin declaration, when a module defines a function that can

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -201,10 +201,13 @@ retain deterministic JUnit results for module-owned reconciliation.
   whose executed bytes were never inspected, is treated as stale rather than
   skipped like an absent candidate
 - **AND** a typing guard is trusted only while unmutated, so an attribute write
-  to its `TYPE_CHECKING` member drops the guard, as does a `global` declaration
-  that rebinds it from a class body or from a function invoked while the module
-  loads, while an uncalled definition does not, and any literal branch condition
-  is resolved by its truthiness
+  to its `TYPE_CHECKING` member or a `global` rebinding from a class body drops
+  it, a rebinding invalidates only the branches that follow it, and any literal
+  branch condition is resolved by its truthiness
+- **AND** module state is treated as unverifiable, failing closed for both the
+  guard and the plugin declaration, when a module defines a function that can
+  rebind a global, write a `TYPE_CHECKING` attribute, or assign `pytest_plugins`
+  and also calls anything while loading
 - **AND** a malformed report field, undecodable or oversized source, or Git
   timeout yields a deterministic finding rather than an unhandled error
 - **AND** the Requirements evidence gate exits nonzero after retaining its

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -190,8 +190,18 @@ retain deterministic JUnit results for module-owned reconciliation.
   written down, that names no committed module, or that is a bare word rather
   than a dotted name is not read as an import, because binding prose would fail
   valid proofs on edits to files pytest never loads
-- **AND** a plugin early-loaded through a configured `addopts` `-p` option is a
-  proof input on the same terms as a declared plugin
+- **AND** a plugin early-loaded through a `-p` option is a proof input on the
+  same terms as a declared plugin, whether the option comes from configured
+  `addopts` or from the command the proof executor builds for every run, because
+  a plugin the run always loads decides collection and report shape
+- **AND** a committed file the resolved proof inputs read by literal path, either
+  as a single string handed to a call or as literals joined onto a path root, is
+  itself a proof input when it lies inside a directory the selected tests live
+  in, because data under the test tree is harness the red-to-green change may not
+  edit; a path outside that tree is what the change is expected to edit and stays
+  unbound, and a path assembled at runtime binds nothing rather than failing the
+  proof, because a harness that writes into a temporary directory is not evidence
+  of anything stale
 - **AND** only the final possible `pytest_plugins` binding is bound, because an
   assignment a later one overwrites never loads, and a name bound only inside a
   function, lambda, or class body does not rebind a module-level guard

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -177,6 +177,11 @@ retain deterministic JUnit results for module-owned reconciliation.
   module-level `pytest_plugins` declaration made by a pytest-considered module
   through its active or runtime-conditionally possible static bindings,
   including known values preserved across non-literal conditional assignments
+- **AND** a plugin early-loaded through a configured `addopts` `-p` option is a
+  proof input on the same terms as a declared plugin
+- **AND** only the final possible `pytest_plugins` binding is bound, because an
+  assignment a later one overwrites never loads, and a name bound only inside a
+  function, lambda, or class body does not rebind a module-level guard
 - **AND** a declared plugin is resolved against the repository root and every
   configured pytest `pythonpath` root, while ordinary imports resolve against
   the repository root alone so governed production modules that a red-to-green

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -278,15 +278,18 @@ retain deterministic JUnit results for module-owned reconciliation.
   attribute through `setattr`, hand the guard module to any call, or assign
   `pytest_plugins`, and also invokes anything while loading, where applying a
   decorator counts as an invocation even when it is a bare name
-- **AND** a module that reaches its own namespace mapping, as through `globals()`
-  or `vars()`, for anything other than reading one key out of it is unverifiable
-  on the same terms, because every other use of the mapping — a subscript write,
-  a method such as `update`, `setdefault`, or `__setitem__`, or handing it to
-  `exec` or any other call — creates the attribute pytest reads without binding
-  any name; the rule is positional rather than a list of mutating methods, which
-  would admit whichever spelling the list omits, and a write to a `pytest_plugins`
-  attribute is unverifiable wherever it appears, since the module object is
-  reachable by other routes such as `sys.modules[__name__]`
+- **AND** a module that reaches its own namespace for anything other than reading
+  one key out of it is unverifiable on the same terms, because every other use of
+  it — a subscript write, a method such as `update`, `setdefault`, or
+  `__setitem__`, or handing it to `exec` or any other call — creates the attribute
+  pytest reads without binding any name; the rule is positional rather than a list
+  of mutating methods, which would admit whichever spelling the list omits
+- **AND** the namespace is recognized by every door that reaches it — `globals()`,
+  `vars()`, this module's own entry in the module table whether taken by subscript,
+  `get`, or `import_module`, and the `__dict__` of any of them — because they are
+  one thing seen from different sides; an entry keyed by any other module is
+  ordinary test substitution and reaches nothing this gate reads, and a write to a
+  `pytest_plugins` attribute is unverifiable wherever it appears
 - **AND** a rewriter is recognized by the guard name it receives rather than by
   the callee's name, so an aliased or wrapped rewriter cannot evade the rule
 - **AND** every rule that asks which name an expression touches resolves that

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -169,8 +169,9 @@ retain deterministic JUnit results for module-owned reconciliation.
 
 - **GIVEN** a retained red proof whose selected test, an applicable pytest
   `conftest.py`, a possible parent package initializer of either input or its
-  repository-local imports, or a statically declared pytest plugin changes
-  after the red source, or an executor run that leaves no non-empty JUnit artifact
+  repository-local imports, or a statically declared module-level pytest
+  plugin changes after the red source, or an executor run that leaves no
+  non-empty JUnit artifact
 - **WHEN** pull-request CI validates or executes the Requirements proof
 - **THEN** the proof remains stale or unproven
 - **AND** the Requirements evidence gate exits nonzero after retaining its

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -173,7 +173,8 @@ retain deterministic JUnit results for module-owned reconciliation.
   including the repository-root initializer, the repository pytest
   configuration source in every implicit candidate the locked pytest version
   discovers beneath the repository root and every selector ancestor pytest
-  searches upward through, every statically reachable repository-local import of
+  searches upward through, each such candidate being bound whether or not it
+  exists at the red source so that adding one afterwards invalidates the proof, every statically reachable repository-local import of
   those files after resolving verified `typing.TYPE_CHECKING` guards, including
   imports inside a function body, because pytest invokes test and fixture bodies
   during the run, while a package initializer keeps its bodies unbound until it
@@ -188,9 +189,10 @@ retain deterministic JUnit results for module-owned reconciliation.
   function, lambda, or class body does not rebind a module-level guard
 - **AND** a declared plugin is resolved against the repository root and every
   configured pytest `pythonpath` root, parsed as pytest parses a path list and
-  normalized as pytest resolves it, so a repository-contained root binds its
-  plugins whether it is spelled with traversal segments or as an absolute path
-  inside the checkout, rather than being dropped, and
+  normalized as pytest resolves it against the directory of the file declaring
+  it, so a repository-contained root binds its plugins whether it is spelled
+  relative to a nested configuration, with traversal segments, or as an absolute
+  path inside the checkout, rather than being dropped, and
   a plugin loaded from such a root resolves its own imports against that root,
   while an input discovered at the repository root resolves ordinary imports
   there alone so governed production modules that a red-to-green change is
@@ -202,8 +204,8 @@ retain deterministic JUnit results for module-owned reconciliation.
   loop, context-manager, exception, match, or walrus target rebinds the
   constant it reads, when a mutation reaches the declaration through another
   name bound to the same object whether by method call, subscript or attribute
-  write, augmented assignment, or deletion, including a chained assignment whose
-  targets share one object, when an executing class body creates the declaration through a
+  write, augmented assignment, deletion, or being handed to a call that could
+  mutate it, including a chained assignment whose targets share one object, when an executing class body creates the declaration through a
   `global` statement, or when the declaration is bound by an import whose value
   lives in another module
 - **AND** a proof input or configuration source that exists at the red source

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -184,7 +184,9 @@ retain deterministic JUnit results for module-owned reconciliation.
   assignment a later one overwrites never loads, and a name bound only inside a
   function, lambda, or class body does not rebind a module-level guard
 - **AND** a declared plugin is resolved against the repository root and every
-  configured pytest `pythonpath` root, parsed as pytest parses a path list, and
+  configured pytest `pythonpath` root, parsed as pytest parses a path list and
+  normalized as pytest resolves it, so a repository-contained root spelled with
+  traversal segments still binds its plugins rather than being dropped, and
   a plugin loaded from such a root resolves its own imports against that root,
   while an input discovered at the repository root resolves ordinary imports
   there alone so governed production modules that a red-to-green change is
@@ -194,20 +196,23 @@ retain deterministic JUnit results for module-owned reconciliation.
 - **AND** an active `pytest_plugins` declaration whose value cannot be resolved
   statically is treated as stale rather than silently ignored, including when a
   loop, context-manager, exception, match, or walrus target rebinds the
-  constant it reads, or when the declaration is bound by an import whose value
-  lives in another module
+  constant it reads, when a mutation reaches the declaration through another
+  name bound to the same object, or when the declaration is bound by an import
+  whose value lives in another module
 - **AND** a proof input or configuration source that exists at the red source
   but cannot be read or parsed, because it is oversized, malformed, or a symlink
   whose executed bytes were never inspected, is treated as stale rather than
   skipped like an absent candidate
 - **AND** a typing guard is trusted only while unmutated, so an attribute write
-  to its `TYPE_CHECKING` member or a `global` rebinding from a class body drops
-  it, a rebinding invalidates only the branches that follow it, and any literal
+  to its `TYPE_CHECKING` member, handing the guard module to any call that could
+  rewrite that member, or a `global` rebinding from a class body drops it, a
+  rebinding invalidates only the branches that follow it, and any literal
   branch condition is resolved by its truthiness
 - **AND** module state is treated as unverifiable, failing closed for both the
   guard and the plugin declaration, when a module defines a function that can
-  rebind a global, write a `TYPE_CHECKING` attribute, or assign `pytest_plugins`
-  and also calls anything while loading
+  rebind a global, write a `TYPE_CHECKING` attribute, rewrite an attribute
+  through `setattr`, or assign `pytest_plugins` and also calls anything while
+  loading
 - **AND** a malformed report field, undecodable or oversized source, or Git
   timeout yields a deterministic finding rather than an unhandled error
 - **AND** the Requirements evidence gate exits nonzero after retaining its

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -172,7 +172,8 @@ retain deterministic JUnit results for module-owned reconciliation.
   (including the repository-root initializer) or its statically reachable
   repository-local imports after resolving verified `typing.TYPE_CHECKING`
   guards, or a module-level pytest plugin declared directly or through the
-  active value of a static module constant by a selected test, applicable
+  active or conditionally possible values of a static module constant by a
+  selected test, applicable
   `conftest.py`, or the specifically registered plugin module—including each
   module in a supported comma-separated declaration—changes after the red
   source, or an executor run that leaves no non-empty JUnit artifact

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -167,10 +167,10 @@ retain deterministic JUnit results for module-owned reconciliation.
 
 #### Scenario: Retained proof inputs or output are missing or stale
 
-- **GIVEN** a retained red proof whose selected test, one of its possible parent
-  package initializers or their repository-local imports, an applicable pytest
-  `conftest.py`, or a statically declared pytest plugin changes after the red
-  source, or an executor run that leaves no non-empty JUnit artifact
+- **GIVEN** a retained red proof whose selected test, an applicable pytest
+  `conftest.py`, a possible parent package initializer of either input or its
+  repository-local imports, or a statically declared pytest plugin changes
+  after the red source, or an executor run that leaves no non-empty JUnit artifact
 - **WHEN** pull-request CI validates or executes the Requirements proof
 - **THEN** the proof remains stale or unproven
 - **AND** the Requirements evidence gate exits nonzero after retaining its

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -205,14 +205,18 @@ retain deterministic JUnit results for module-owned reconciliation.
 - **AND** a literal that cannot name a committed path, because it carries a
   control character or a traversal segment, is discarded before it becomes a Git
   argument, so an arbitrary string in a test fixture cannot raise out of the gate
-- **AND** a join is resolved against the base it starts from, so a harness naming
-  data beside itself through `__file__`, `.parent`, `.parents[n]`, `.resolve()`,
-  or a name bound to any of them binds the file it actually reads, while a join
-  from a base decided at runtime binds nothing rather than being read as though
-  it started at the repository root
-- **AND** a committed link a proof input reads is followed to its target, with
-  every hop bound because editing any of them changes the bytes returned, and a
-  link that leaves the checkout, cycles, or points at nothing is stale
+- **AND** a join is resolved against the base it starts from, in every notation —
+  `base / "a"`, `os.path.join(base, "a")`, and `base.joinpath("a")` are one
+  construction — so a harness naming data beside itself through `__file__`,
+  `.parent`, `.parents[n]`, `.resolve()`, `os.path.dirname`, or a name bound to
+  any of them binds the file it actually reads, while a join from a base decided
+  at runtime binds nothing rather than being read as though it started at the
+  repository root, and a join's components are never read as paths of their own
+- **AND** a committed link a proof input reads is followed to its target at every
+  path component rather than only the last, because a linked directory carries a
+  read exactly as a linked file does, with every link crossed bound because
+  editing any of them changes the bytes returned, and a link that leaves the
+  checkout, cycles, or resolves to nothing is stale
 - **AND** a lookup Git could not answer, including a timed-out one, is stale
   rather than absent, because treating an unanswered lookup as a missing file
   leaves the module and everything it imports untraversed
@@ -274,9 +278,15 @@ retain deterministic JUnit results for module-owned reconciliation.
   attribute through `setattr`, hand the guard module to any call, or assign
   `pytest_plugins`, and also invokes anything while loading, where applying a
   decorator counts as an invocation even when it is a bare name
-- **AND** a module that writes its own namespace mapping, as through
-  `globals()` or `vars()`, is unverifiable on the same terms, because such a
-  write creates the attribute pytest reads without binding any name
+- **AND** a module that reaches its own namespace mapping, as through `globals()`
+  or `vars()`, for anything other than reading one key out of it is unverifiable
+  on the same terms, because every other use of the mapping — a subscript write,
+  a method such as `update`, `setdefault`, or `__setitem__`, or handing it to
+  `exec` or any other call — creates the attribute pytest reads without binding
+  any name; the rule is positional rather than a list of mutating methods, which
+  would admit whichever spelling the list omits, and a write to a `pytest_plugins`
+  attribute is unverifiable wherever it appears, since the module object is
+  reachable by other routes such as `sys.modules[__name__]`
 - **AND** a rewriter is recognized by the guard name it receives rather than by
   the callee's name, so an aliased or wrapped rewriter cannot evade the rule
 - **AND** every rule that asks which name an expression touches resolves that

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -201,9 +201,10 @@ retain deterministic JUnit results for module-owned reconciliation.
   whose executed bytes were never inspected, is treated as stale rather than
   skipped like an absent candidate
 - **AND** a typing guard is trusted only while unmutated, so an attribute write
-  to its `TYPE_CHECKING` member or a `global` declaration that rebinds it from a
-  nested scope drops the guard, while any literal branch condition is resolved
-  by its truthiness
+  to its `TYPE_CHECKING` member drops the guard, as does a `global` declaration
+  that rebinds it from a class body or from a function invoked while the module
+  loads, while an uncalled definition does not, and any literal branch condition
+  is resolved by its truthiness
 - **AND** a malformed report field, undecodable or oversized source, or Git
   timeout yields a deterministic finding rather than an unhandled error
 - **AND** the Requirements evidence gate exits nonzero after retaining its

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -172,11 +172,12 @@ retain deterministic JUnit results for module-owned reconciliation.
   `conftest.py`, every possible parent package initializer of either input
   including the repository-root initializer, the repository pytest
   configuration source in every implicit candidate the locked pytest version
-  discovers, every statically reachable repository-local import of
+  discovers beneath the repository root and every selector ancestor pytest
+  searches upward through, every statically reachable repository-local import of
   those files after resolving verified `typing.TYPE_CHECKING` guards, including
-  imports inside a function body once the module invokes anything while loading,
-  because which body such a call reaches cannot be decided, while a module that
-  invokes nothing keeps its function bodies unbound, and every
+  imports inside a function body, because pytest invokes test and fixture bodies
+  during the run, while a package initializer keeps its bodies unbound until it
+  invokes something while loading, and every
   module-level `pytest_plugins` declaration made by a pytest-considered module
   through its active or runtime-conditionally possible static bindings,
   including known values preserved across non-literal conditional assignments
@@ -201,16 +202,20 @@ retain deterministic JUnit results for module-owned reconciliation.
   loop, context-manager, exception, match, or walrus target rebinds the
   constant it reads, when a mutation reaches the declaration through another
   name bound to the same object whether by method call, subscript or attribute
-  write, or deletion, including a chained assignment whose targets share one
-  object, when an executing class body creates the declaration through a
+  write, augmented assignment, or deletion, including a chained assignment whose
+  targets share one object, when an executing class body creates the declaration through a
   `global` statement, or when the declaration is bound by an import whose value
   lives in another module
 - **AND** a proof input or configuration source that exists at the red source
-  but cannot be read or parsed, because it is oversized, malformed, or a symlink
-  whose executed bytes were never inspected, is treated as stale rather than
-  skipped like an absent candidate, and a symlink is recognized by its Git mode
-  rather than by failing to parse, because a link text such as `support.py` is
-  itself valid Python
+  but cannot be read or parsed, because it is oversized, malformed, unreadable
+  through a failed or timed-out read, or a symlink whose executed bytes were
+  never inspected, is treated as stale rather than skipped like an absent
+  candidate, so an unreadable candidate is never mistaken for a missing one, and
+  a symlink is recognized by its Git mode rather than by failing to parse,
+  because a link text such as `support.py` is itself valid Python
+- **AND** an import resolved through a symlinked directory is treated as stale,
+  because Python follows the directory link while Git records the link rather
+  than the target tree
 - **AND** a typing guard is trusted only while unmutated, so an attribute write
   to its `TYPE_CHECKING` member, handing the guard module to any call that could
   rewrite that member including through a nested argument expression, copying
@@ -229,6 +234,13 @@ retain deterministic JUnit results for module-owned reconciliation.
   write creates the attribute pytest reads without binding any name
 - **AND** a rewriter is recognized by the guard name it receives rather than by
   the callee's name, so an aliased or wrapped rewriter cannot evade the rule
+- **AND** every rule that asks which name an expression touches resolves that
+  name through attribute, subscript, and call chains, so a wrapped form such as
+  a write through the module mapping cannot evade a rule its unwrapped
+  equivalent triggers
+- **AND** each fail-closed rule is bounded to the state this gate depends on, so
+  ordinary module activity that cannot reach a guard or a plugin declaration
+  leaves both resolvable
 - **AND** a malformed report field, undecodable or oversized source, or Git
   timeout yields a deterministic finding rather than an unhandled error
 - **AND** the Requirements evidence gate exits nonzero after retaining its

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -172,7 +172,8 @@ retain deterministic JUnit results for module-owned reconciliation.
 - **AND** pytest-determining inputs are the selected test, every applicable
   `conftest.py`, every possible parent package initializer of either input
   including the repository-root initializer, the repository pytest
-  configuration source, every statically reachable repository-local import of
+  configuration source in every implicit candidate the locked pytest version
+  discovers, every statically reachable repository-local import of
   those files after resolving verified `typing.TYPE_CHECKING` guards, and every
   module-level `pytest_plugins` declaration made by a pytest-considered module
   through its active or runtime-conditionally possible static bindings,

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -202,6 +202,14 @@ retain deterministic JUnit results for module-owned reconciliation.
   unbound, and a path assembled at runtime binds nothing rather than failing the
   proof, because a harness that writes into a temporary directory is not evidence
   of anything stale
+- **AND** a literal that cannot name a committed path, because it carries a
+  control character or a traversal segment, is discarded before it becomes a Git
+  argument, so an arbitrary string in a test fixture cannot raise out of the gate
+- **AND** the resolved input set is measured against this repository so the rule
+  family is held to what it must not bind as well as what it must: no product
+  source is ever an input, every bound file outside the test tree is a recorded
+  exception, and the set stays proportional to the selectors, because a rule that
+  binds too much satisfies every positive expectation while rejecting valid proofs
 - **AND** only the final possible `pytest_plugins` binding is bound, because an
   assignment a later one overwrites never loads, and a name bound only inside a
   function, lambda, or class body does not rebind a module-level guard

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -205,6 +205,23 @@ retain deterministic JUnit results for module-owned reconciliation.
 - **AND** a literal that cannot name a committed path, because it carries a
   control character or a traversal segment, is discarded before it becomes a Git
   argument, so an arbitrary string in a test fixture cannot raise out of the gate
+- **AND** a join is resolved against the base it starts from, so a harness naming
+  data beside itself through `__file__`, `.parent`, `.parents[n]`, `.resolve()`,
+  or a name bound to any of them binds the file it actually reads, while a join
+  from a base decided at runtime binds nothing rather than being read as though
+  it started at the repository root
+- **AND** a committed link a proof input reads is followed to its target, with
+  every hop bound because editing any of them changes the bytes returned, and a
+  link that leaves the checkout, cycles, or points at nothing is stale
+- **AND** a lookup Git could not answer, including a timed-out one, is stale
+  rather than absent, because treating an unanswered lookup as a missing file
+  leaves the module and everything it imports untraversed
+- **AND** the body of a test an exact selection does not run is not traversed,
+  provided the selection resolves to functions defined in that module and the
+  function's name appears nowhere else in it; fixtures are always traversed,
+  because which ones a run activates depends on autouse declarations, indirect
+  parametrization, conftest chains, and plugins, none of which this gate can
+  decide from the module's syntax
 - **AND** the resolved input set is measured against this repository so the rule
   family is held to what it must not bind as well as what it must: no product
   source is ever an input, every bound file outside the test tree is a recorded

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -167,9 +167,10 @@ retain deterministic JUnit results for module-owned reconciliation.
 
 #### Scenario: Retained proof inputs or output are missing or stale
 
-- **GIVEN** a retained red proof whose selected test or an applicable pytest
-  `conftest.py` changes after the red source, or an executor run that leaves no
-  non-empty JUnit artifact
+- **GIVEN** a retained red proof whose selected test, one of its possible parent
+  package initializers, an applicable pytest `conftest.py`, or a statically
+  declared pytest plugin changes after the red source, or an executor run that
+  leaves no non-empty JUnit artifact
 - **WHEN** pull-request CI validates or executes the Requirements proof
 - **THEN** the proof remains stale or unproven
 - **AND** the Requirements evidence gate exits nonzero after retaining its

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -170,8 +170,9 @@ retain deterministic JUnit results for module-owned reconciliation.
 - **GIVEN** a retained red proof whose selected test, an applicable pytest
   `conftest.py`, a possible parent package initializer of either input
   (including the repository-root initializer) or its statically reachable
-  repository-local imports, or a module-level pytest plugin declared directly
-  or through a static module constant by a selected test, applicable
+  repository-local imports after resolving verified `typing.TYPE_CHECKING`
+  guards, or a module-level pytest plugin declared directly or through the
+  active value of a static module constant by a selected test, applicable
   `conftest.py`, or the specifically registered plugin module—including each
   module in a supported comma-separated declaration—changes after the red
   source, or an executor run that leaves no non-empty JUnit artifact

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -169,8 +169,8 @@ retain deterministic JUnit results for module-owned reconciliation.
 
 - **GIVEN** a retained red proof whose selected test, an applicable pytest
   `conftest.py`, a possible parent package initializer of either input
-  (including the repository-root initializer) or its repository-local imports,
-  or a module-level pytest plugin declared by a selected test, applicable
+  (including the repository-root initializer) or the repository-local imports
+  executed while loading it, or a module-level pytest plugin declared by a selected test, applicable
   `conftest.py`, or the specifically registered plugin module—including each
   module in a supported comma-separated declaration—changes after the red
   source, or an executor run that leaves no non-empty JUnit artifact

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -184,7 +184,12 @@ retain deterministic JUnit results for module-owned reconciliation.
 - **WHEN** pull-request CI validates or executes the Requirements proof
 - **THEN** the proof remains stale or unproven
 - **AND** an active `pytest_plugins` declaration whose value cannot be resolved
-  statically is treated as stale rather than silently ignored
+  statically is treated as stale rather than silently ignored, including when a
+  loop, context-manager, exception, match, or walrus target rebinds the
+  constant it reads
+- **AND** a proof input that exists at the red source but cannot be parsed,
+  because it is oversized or malformed, is treated as stale rather than skipped
+  like an absent candidate
 - **AND** a malformed report field, undecodable or oversized source, or Git
   timeout yields a deterministic finding rather than an unhandled error
 - **AND** the Requirements evidence gate exits nonzero after retaining its

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -167,20 +167,22 @@ retain deterministic JUnit results for module-owned reconciliation.
 
 #### Scenario: Retained proof inputs or output are missing or stale
 
-- **GIVEN** a retained red proof whose selected test, an applicable pytest
-  `conftest.py`, a possible parent package initializer of either input
-  (including the repository-root initializer) or its statically reachable
-  repository-local imports after resolving verified `typing.TYPE_CHECKING`
-  guards, or a module-level pytest plugin declared directly or through the
-  active or runtime-conditionally possible values of a static module constant
-  across branch, loop, exception, context, or match constructs by a selected
-  test—including known values preserved across non-literal conditional
-  assignments—applicable
-  `conftest.py`, or the specifically registered plugin module—including each
-  module in a supported comma-separated declaration—changes after the red
-  source, or an executor run that leaves no non-empty JUnit artifact
+- **GIVEN** a retained red proof whose pytest-determining inputs change after
+  the red source, or an executor run that leaves no non-empty JUnit artifact
+- **AND** pytest-determining inputs are the selected test, every applicable
+  `conftest.py`, every possible parent package initializer of either input
+  including the repository-root initializer, the repository pytest
+  configuration source, every statically reachable repository-local import of
+  those files after resolving verified `typing.TYPE_CHECKING` guards, and every
+  module-level `pytest_plugins` declaration made by a pytest-considered module
+  through its active or runtime-conditionally possible static bindings,
+  including known values preserved across non-literal conditional assignments
 - **WHEN** pull-request CI validates or executes the Requirements proof
 - **THEN** the proof remains stale or unproven
+- **AND** an active `pytest_plugins` declaration whose value cannot be resolved
+  statically is treated as stale rather than silently ignored
+- **AND** a malformed report field, undecodable or oversized source, or Git
+  timeout yields a deterministic finding rather than an unhandled error
 - **AND** the Requirements evidence gate exits nonzero after retaining its
   diagnostic reports.
 

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -219,7 +219,9 @@ retain deterministic JUnit results for module-owned reconciliation.
   checkout, cycles, or resolves to nothing is stale
 - **AND** a lookup Git could not answer, including a timed-out one, is stale
   rather than absent, because treating an unanswered lookup as a missing file
-  leaves the module and everything it imports untraversed
+  leaves the module and everything it imports untraversed; this holds for every
+  command the gate issues, so a failed symlink inventory is not a repository
+  without symlinks and a failed tracked-file listing is not an untracked artifact
 - **AND** the body of a test an exact selection does not run is not traversed,
   provided the selection resolves to functions defined in that module and the
   function's name appears nowhere else in it; fixtures are always traversed,
@@ -303,6 +305,12 @@ retain deterministic JUnit results for module-owned reconciliation.
   one thing seen from different sides; an entry keyed by any other module is
   ordinary test substitution and reaches nothing this gate reads, and a write to a
   `pytest_plugins` attribute is unverifiable wherever it appears
+- **AND** the module table is identified as the table itself rather than by the
+  shape of the expression, so an ordinary mapping that merely uses `__name__` as a
+  key is not read as the running module and does not make its file unverifiable
+- **AND** a mutation is attributed to every name its receiver expression contains,
+  as it already is for the names an argument contains, so wrapping a receiver in a
+  subscript, a literal group, or a call cannot hide which object a method changes
 - **AND** a rewriter is recognized by the guard name it receives rather than by
   the callee's name, so an aliased or wrapped rewriter cannot evade the rule
 - **AND** every rule that asks which name an expression touches resolves that

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -168,9 +168,9 @@ retain deterministic JUnit results for module-owned reconciliation.
 #### Scenario: Retained proof inputs or output are missing or stale
 
 - **GIVEN** a retained red proof whose selected test, one of its possible parent
-  package initializers, an applicable pytest `conftest.py`, or a statically
-  declared pytest plugin changes after the red source, or an executor run that
-  leaves no non-empty JUnit artifact
+  package initializers or their repository-local imports, an applicable pytest
+  `conftest.py`, or a statically declared pytest plugin changes after the red
+  source, or an executor run that leaves no non-empty JUnit artifact
 - **WHEN** pull-request CI validates or executes the Requirements proof
 - **THEN** the proof remains stale or unproven
 - **AND** the Requirements evidence gate exits nonzero after retaining its

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -173,7 +173,10 @@ retain deterministic JUnit results for module-owned reconciliation.
   including the repository-root initializer, the repository pytest
   configuration source in every implicit candidate the locked pytest version
   discovers, every statically reachable repository-local import of
-  those files after resolving verified `typing.TYPE_CHECKING` guards, and every
+  those files after resolving verified `typing.TYPE_CHECKING` guards, including
+  imports inside a function body once the module invokes anything while loading,
+  because which body such a call reaches cannot be decided, while a module that
+  invokes nothing keeps its function bodies unbound, and every
   module-level `pytest_plugins` declaration made by a pytest-considered module
   through its active or runtime-conditionally possible static bindings,
   including known values preserved across non-literal conditional assignments

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -197,8 +197,9 @@ retain deterministic JUnit results for module-owned reconciliation.
   constant it reads, or when the declaration is bound by an import whose value
   lives in another module
 - **AND** a proof input or configuration source that exists at the red source
-  but cannot be read or parsed, because it is oversized or malformed, is treated
-  as stale rather than skipped like an absent candidate
+  but cannot be read or parsed, because it is oversized, malformed, or a symlink
+  whose executed bytes were never inspected, is treated as stale rather than
+  skipped like an absent candidate
 - **AND** a typing guard is trusted only while unmutated, so an attribute write
   to its `TYPE_CHECKING` member or a `global` declaration that rebinds it from a
   nested scope drops the guard, while any literal branch condition is resolved

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -171,8 +171,9 @@ retain deterministic JUnit results for module-owned reconciliation.
   `conftest.py`, a possible parent package initializer of either input
   (including the repository-root initializer) or its repository-local imports,
   or a module-level pytest plugin declared by a selected test, applicable
-  `conftest.py`, or registered plugin changes after the red source, or an
-  executor run that leaves no non-empty JUnit artifact
+  `conftest.py`, or registered plugin—including each module in a supported
+  comma-separated declaration—changes after the red source, or an executor run
+  that leaves no non-empty JUnit artifact
 - **WHEN** pull-request CI validates or executes the Requirements proof
 - **THEN** the proof remains stale or unproven
 - **AND** the Requirements evidence gate exits nonzero after retaining its

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -169,8 +169,9 @@ retain deterministic JUnit results for module-owned reconciliation.
 
 - **GIVEN** a retained red proof whose selected test, an applicable pytest
   `conftest.py`, a possible parent package initializer of either input
-  (including the repository-root initializer) or the repository-local imports
-  executed while loading it, or a module-level pytest plugin declared by a selected test, applicable
+  (including the repository-root initializer) or its statically reachable
+  repository-local imports, or a module-level pytest plugin declared directly
+  or through a static module constant by a selected test, applicable
   `conftest.py`, or the specifically registered plugin module—including each
   module in a supported comma-separated declaration—changes after the red
   source, or an executor run that leaves no non-empty JUnit artifact

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -184,8 +184,9 @@ retain deterministic JUnit results for module-owned reconciliation.
   function, lambda, or class body does not rebind a module-level guard
 - **AND** a declared plugin is resolved against the repository root and every
   configured pytest `pythonpath` root, parsed as pytest parses a path list and
-  normalized as pytest resolves it, so a repository-contained root spelled with
-  traversal segments still binds its plugins rather than being dropped, and
+  normalized as pytest resolves it, so a repository-contained root binds its
+  plugins whether it is spelled with traversal segments or as an absolute path
+  inside the checkout, rather than being dropped, and
   a plugin loaded from such a root resolves its own imports against that root,
   while an input discovered at the repository root resolves ordinary imports
   there alone so governed production modules that a red-to-green change is
@@ -197,7 +198,9 @@ retain deterministic JUnit results for module-owned reconciliation.
   loop, context-manager, exception, match, or walrus target rebinds the
   constant it reads, when a mutation reaches the declaration through another
   name bound to the same object whether by method call, subscript or attribute
-  write, or deletion, or when the declaration is bound by an import whose value
+  write, or deletion, including a chained assignment whose targets share one
+  object, when an executing class body creates the declaration through a
+  `global` statement, or when the declaration is bound by an import whose value
   lives in another module
 - **AND** a proof input or configuration source that exists at the red source
   but cannot be read or parsed, because it is oversized, malformed, or a symlink
@@ -207,15 +210,20 @@ retain deterministic JUnit results for module-owned reconciliation.
   itself valid Python
 - **AND** a typing guard is trusted only while unmutated, so an attribute write
   to its `TYPE_CHECKING` member, handing the guard module to any call that could
-  rewrite that member, copying the module into a second binding through which a
-  write would be invisible, or a `global` rebinding from a class body drops it,
-  a rebinding invalidates only the branches that follow it, and any literal
-  branch condition is resolved by its truthiness
+  rewrite that member including through a nested argument expression, copying
+  the module into a second binding through which a write would be invisible, or
+  a `global` rebinding from a class body drops it, a rebinding invalidates only
+  the branches that follow it, and any literal branch condition is resolved by
+  its truthiness
 - **AND** module state is treated as unverifiable, failing closed for both the
-  guard and the plugin declaration, when a module defines a function that can
-  rebind a global, write a `TYPE_CHECKING` attribute, rewrite an attribute
-  through `setattr`, hand the guard module to any call, or assign
-  `pytest_plugins`, and also calls anything while loading
+  guard and the plugin declaration, when a module defines a function or lambda
+  that can rebind a global, write a `TYPE_CHECKING` attribute, rewrite an
+  attribute through `setattr`, hand the guard module to any call, or assign
+  `pytest_plugins`, and also invokes anything while loading, where applying a
+  decorator counts as an invocation even when it is a bare name
+- **AND** a module that writes its own namespace mapping, as through
+  `globals()` or `vars()`, is unverifiable on the same terms, because such a
+  write creates the attribute pytest reads without binding any name
 - **AND** a rewriter is recognized by the guard name it receives rather than by
   the callee's name, so an aliased or wrapped rewriter cannot evade the rule
 - **AND** a malformed report field, undecodable or oversized source, or Git

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -53,10 +53,11 @@ maturity. The
 proof SHALL bind the commit/tree, merge base, mapping digest, selectors,
 test-file digests, JUnit digest, and toolchain identity. Core SHALL reject
 proof when governed production changed before the red commit, including a
-governed source renamed outside its prefix, or when selectors, applicable
-pytest `conftest.py` files, their repository-local imported Python support
-modules (including statically declared `pytest_plugins` and import targets that
-were absent at red), or test files changed after it. Before forwarding a prior-red report to the
+governed source renamed outside its prefix, or when any pytest-determining
+input changed after it. Pytest-determining inputs are enumerated once, in the
+retained-proof scenario of Safe Pull-Request Proof Execution; this requirement
+SHALL NOT restate a partial list that could drift from it.
+Before forwarding a prior-red report to the
 released reconciliation command, core SHALL verify that its source commit is a
 strict ancestor of the final source, the current pull-request base is an
 ancestor of that source, and that the selected test files remain
@@ -84,10 +85,8 @@ SHALL NOT extend it to any other change.
 
 #### Scenario: Same-commit or stale red proof is rejected
 
-- **GIVEN** tests and production code first appear in the same commit, or a
-  mapped selector, its applicable pytest `conftest.py`, a repository-local
-  Python support module imported or declared as a plugin by either input, an
-  absent local import target is added, or its test file changes after the red proof
+- **GIVEN** tests and production code first appear in the same commit, or any
+  pytest-determining input of a mapped selector changes after the red proof
 - **WHEN** the gate evaluates a governed production diff
 - **THEN** it fails with `tdd-order-unproven` or `stale-red-proof`
 - **AND** retained-run discovery searches every completed-run page, skips
@@ -211,8 +210,10 @@ retain deterministic JUnit results for module-owned reconciliation.
 - **AND** module state is treated as unverifiable, failing closed for both the
   guard and the plugin declaration, when a module defines a function that can
   rebind a global, write a `TYPE_CHECKING` attribute, rewrite an attribute
-  through `setattr`, or assign `pytest_plugins` and also calls anything while
-  loading
+  through `setattr`, hand the guard module to any call, or assign
+  `pytest_plugins`, and also calls anything while loading
+- **AND** a rewriter is recognized by the guard name it receives rather than by
+  the callee's name, so an aliased or wrapped rewriter cannot evade the rule
 - **AND** a malformed report field, undecodable or oversized source, or Git
   timeout yields a deterministic finding rather than an unhandled error
 - **AND** the Requirements evidence gate exits nonzero after retaining its

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -172,8 +172,9 @@ retain deterministic JUnit results for module-owned reconciliation.
   (including the repository-root initializer) or its statically reachable
   repository-local imports after resolving verified `typing.TYPE_CHECKING`
   guards, or a module-level pytest plugin declared directly or through the
-  active or conditionally possible values of a static module constant by a
-  selected test, applicable
+  active or runtime-conditionally possible values of a static module constant
+  across branch, loop, exception, context, or match constructs by a selected
+  test, applicable
   `conftest.py`, or the specifically registered plugin module—including each
   module in a supported comma-separated declaration—changes after the red
   source, or an executor run that leaves no non-empty JUnit artifact

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -184,9 +184,11 @@ retain deterministic JUnit results for module-owned reconciliation.
   assignment a later one overwrites never loads, and a name bound only inside a
   function, lambda, or class body does not rebind a module-level guard
 - **AND** a declared plugin is resolved against the repository root and every
-  configured pytest `pythonpath` root, while ordinary imports resolve against
-  the repository root alone so governed production modules that a red-to-green
-  change is expected to edit do not become proof inputs
+  configured pytest `pythonpath` root, parsed as pytest parses a path list, and
+  a plugin loaded from such a root resolves its own imports against that root,
+  while an input discovered at the repository root resolves ordinary imports
+  there alone so governed production modules that a red-to-green change is
+  expected to edit do not become proof inputs
 - **WHEN** pull-request CI validates or executes the Requirements proof
 - **THEN** the proof remains stale or unproven
 - **AND** an active `pytest_plugins` declaration whose value cannot be resolved

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -182,6 +182,14 @@ retain deterministic JUnit results for module-owned reconciliation.
   module-level `pytest_plugins` declaration made by a pytest-considered module
   through its active or runtime-conditionally possible static bindings,
   including known values preserved across non-literal conditional assignments
+- **AND** a dotted module name a reachable body hands to a call is bound when
+  that module exists at the red source, because a dynamic import names its
+  target in data rather than in the callee, so `importlib.import_module`,
+  `__import__`, an alias, a wrapper, and a name read out of a literal group are
+  covered without matching an import mechanism by name; a literal that is only
+  written down, that names no committed module, or that is a bare word rather
+  than a dotted name is not read as an import, because binding prose would fail
+  valid proofs on edits to files pytest never loads
 - **AND** a plugin early-loaded through a configured `addopts` `-p` option is a
   proof input on the same terms as a declared plugin
 - **AND** only the final possible `pytest_plugins` binding is bound, because an

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -226,11 +226,21 @@ retain deterministic JUnit results for module-owned reconciliation.
   because which ones a run activates depends on autouse declarations, indirect
   parametrization, conftest chains, and plugins, none of which this gate can
   decide from the module's syntax
+- **AND** an import resolves against the directory pytest itself places on
+  `sys.path` for the importing file — the first ancestor that is not a package —
+  as well as against the repository root and any configured `pythonpath` root, so
+  a bare import in a non-package test directory binds its sibling; the directory
+  is used only when the configured import mode places it there, because `importlib`
+  mode inserts nothing and a bare name cannot reach a sibling under it
 - **AND** the resolved input set is measured against this repository so the rule
   family is held to what it must not bind as well as what it must: no product
   source is ever an input, every bound file outside the test tree is a recorded
   exception, and the set stays proportional to the selectors, because a rule that
   binds too much satisfies every positive expectation while rejecting valid proofs
+- **AND** the resolved input set is checked against a real pytest run over a set
+  of repository layouts, binding at least every repository-local module that run
+  imports, because each rule is a model of pytest's behaviour and a model that is
+  only read rather than executed diverges without anyone noticing
 - **AND** only the final possible `pytest_plugins` binding is bound, because an
   assignment a later one overwrites never loads, and a name bound only inside a
   function, lambda, or class body does not rebind a module-level guard

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -171,9 +171,9 @@ retain deterministic JUnit results for module-owned reconciliation.
   `conftest.py`, a possible parent package initializer of either input
   (including the repository-root initializer) or its repository-local imports,
   or a module-level pytest plugin declared by a selected test, applicable
-  `conftest.py`, or registered plugin—including each module in a supported
-  comma-separated declaration—changes after the red source, or an executor run
-  that leaves no non-empty JUnit artifact
+  `conftest.py`, or the specifically registered plugin module—including each
+  module in a supported comma-separated declaration—changes after the red
+  source, or an executor run that leaves no non-empty JUnit artifact
 - **WHEN** pull-request CI validates or executes the Requirements proof
 - **THEN** the proof remains stale or unproven
 - **AND** the Requirements evidence gate exits nonzero after retaining its

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -192,7 +192,8 @@ retain deterministic JUnit results for module-owned reconciliation.
 - **AND** an active `pytest_plugins` declaration whose value cannot be resolved
   statically is treated as stale rather than silently ignored, including when a
   loop, context-manager, exception, match, or walrus target rebinds the
-  constant it reads
+  constant it reads, or when the declaration is bound by an import whose value
+  lives in another module
 - **AND** a proof input or configuration source that exists at the red source
   but cannot be read or parsed, because it is oversized or malformed, is treated
   as stale rather than skipped like an absent candidate

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -177,6 +177,10 @@ retain deterministic JUnit results for module-owned reconciliation.
   module-level `pytest_plugins` declaration made by a pytest-considered module
   through its active or runtime-conditionally possible static bindings,
   including known values preserved across non-literal conditional assignments
+- **AND** a declared plugin is resolved against the repository root and every
+  configured pytest `pythonpath` root, while ordinary imports resolve against
+  the repository root alone so governed production modules that a red-to-green
+  change is expected to edit do not become proof inputs
 - **WHEN** pull-request CI validates or executes the Requirements proof
 - **THEN** the proof remains stale or unproven
 - **AND** an active `pytest_plugins` declaration whose value cannot be resolved

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -193,9 +193,13 @@ retain deterministic JUnit results for module-owned reconciliation.
   statically is treated as stale rather than silently ignored, including when a
   loop, context-manager, exception, match, or walrus target rebinds the
   constant it reads
-- **AND** a proof input that exists at the red source but cannot be parsed,
-  because it is oversized or malformed, is treated as stale rather than skipped
-  like an absent candidate
+- **AND** a proof input or configuration source that exists at the red source
+  but cannot be read or parsed, because it is oversized or malformed, is treated
+  as stale rather than skipped like an absent candidate
+- **AND** a typing guard is trusted only while unmutated, so an attribute write
+  to its `TYPE_CHECKING` member or a `global` declaration that rebinds it from a
+  nested scope drops the guard, while any literal branch condition is resolved
+  by its truthiness
 - **AND** a malformed report field, undecodable or oversized source, or Git
   timeout yields a deterministic finding rather than an unhandled error
 - **AND** the Requirements evidence gate exits nonzero after retaining its

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -174,7 +174,8 @@ retain deterministic JUnit results for module-owned reconciliation.
   guards, or a module-level pytest plugin declared directly or through the
   active or runtime-conditionally possible values of a static module constant
   across branch, loop, exception, context, or match constructs by a selected
-  test, applicable
+  test—including known values preserved across non-literal conditional
+  assignments—applicable
   `conftest.py`, or the specifically registered plugin module—including each
   module in a supported comma-separated declaration—changes after the red
   source, or an executor run that leaves no non-empty JUnit artifact

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -238,9 +238,12 @@ retain deterministic JUnit results for module-owned reconciliation.
   exception, and the set stays proportional to the selectors, because a rule that
   binds too much satisfies every positive expectation while rejecting valid proofs
 - **AND** the resolved input set is checked against a real pytest run over a set
-  of repository layouts, binding at least every repository-local module that run
-  imports, because each rule is a model of pytest's behaviour and a model that is
-  only read rather than executed diverges without anyone noticing
+  of repository layouts, binding at least every repository-local file that run
+  imports **or reads**, because each rule is a model of pytest's behaviour and a
+  model that is only read rather than executed diverges without anyone noticing;
+  reads are observed as well as imports because a file consumed as data leaves no
+  trace among the imported modules, and the path-resolution rules are exercised by
+  nothing else
 - **AND** only the final possible `pytest_plugins` binding is bound, because an
   assignment a later one overwrites never loads, and a name bound only inside a
   function, lambda, or class body does not rebind a module-level guard

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -168,10 +168,11 @@ retain deterministic JUnit results for module-owned reconciliation.
 #### Scenario: Retained proof inputs or output are missing or stale
 
 - **GIVEN** a retained red proof whose selected test, an applicable pytest
-  `conftest.py`, a possible parent package initializer of either input or its
-  repository-local imports, or a statically declared module-level pytest
-  plugin changes after the red source, or an executor run that leaves no
-  non-empty JUnit artifact
+  `conftest.py`, a possible parent package initializer of either input
+  (including the repository-root initializer) or its repository-local imports,
+  or a module-level pytest plugin declared by a selected test, applicable
+  `conftest.py`, or registered plugin changes after the red source, or an
+  executor run that leaves no non-empty JUnit artifact
 - **WHEN** pull-request CI validates or executes the Requirements proof
 - **THEN** the proof remains stale or unproven
 - **AND** the Requirements evidence gate exits nonzero after retaining its

--- a/openspec/changes/requirements-07-runtime-proof-delivery/tasks.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/tasks.md
@@ -106,6 +106,18 @@ behavior before its tests exist and have failed for the expected reason.
 
 ## Post-merge cleanup
 
+- [ ] Update `wiki/sources/requirements-07-runtime-proof-delivery.md`
+  (depends-on / blocks / external-deps / status / summary) and run
+  `python3 scripts/wiki_rebuild_graph.py` from the `specfact-cli-internal`
+  repository root. The retained-proof scenario now states pytest-determining
+  inputs as an invariant that includes the pytest configuration source, so the
+  mirrored scope text is stale. Recorded as a follow-up because the sibling
+  internal checkout was unavailable in the session that made the change.
+- [ ] Resolve module names against configured `pythonpath` roots so a pytest
+  plugin or conftest helper reachable only through such a root is bound as a
+  proof input. Latent today: the sole declared plugin resolves at the
+  repository root, and a `pythonpath` change already stales the proof through
+  the pytest configuration input.
 - [ ] Return to the primary core checkout, fetch `dev`, remove the worktree,
   delete the local feature branch after merge, prune worktrees, and optionally
   delete the merged remote branch.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/tasks.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/tasks.md
@@ -113,11 +113,11 @@ behavior before its tests exist and have failed for the expected reason.
   inputs as an invariant that includes the pytest configuration source, so the
   mirrored scope text is stale. Recorded as a follow-up because the sibling
   internal checkout was unavailable in the session that made the change.
-- [ ] Resolve module names against configured `pythonpath` roots so a pytest
-  plugin or conftest helper reachable only through such a root is bound as a
-  proof input. Latent today: the sole declared plugin resolves at the
-  repository root, and a `pythonpath` change already stales the proof through
-  the pytest configuration input.
+- [x] Resolve declared pytest plugins against configured `pythonpath` roots so
+  a plugin reachable only through such a root is bound as a proof input.
+  Deliberately scoped to plugin resolution: rooting ordinary imports would bind
+  governed production modules under `src`, which a red-to-green change is
+  expected to edit, and would reject every valid failing-first flow.
 - [ ] Return to the primary core checkout, fetch `dev`, remove the worktree,
   delete the local feature branch after merge, prune worktrees, and optionally
   delete the merged remote branch.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/tasks.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/tasks.md
@@ -118,6 +118,15 @@ behavior before its tests exist and have failed for the expected reason.
   Deliberately scoped to plugin resolution: rooting ordinary imports would bind
   governed production modules under `src`, which a red-to-green change is
   expected to edit, and would reject every valid failing-first flow.
+- [ ] Apply the same undecodable-input guard to product code that reads JSON
+  with `except (OSError, json.JSONDecodeError)`:
+  `src/specfact_cli/registry/module_state.py`,
+  `src/specfact_cli/registry/help_cache.py`,
+  `src/specfact_cli/utils/context_detection.py`, and
+  `src/specfact_cli/importers/speckit_scanner.py`. These are cache and scanner
+  reads whose intended behavior is to fall back, so an undecodable file crashes
+  the CLI instead. Deferred from the provenance change because they are product
+  paths needing their own contract and coverage treatment.
 - [ ] Return to the primary core checkout, fetch `dev`, remove the worktree,
   delete the local feature branch after merge, prune worktrees, and optionally
   delete the merged remote branch.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/tasks.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/tasks.md
@@ -76,9 +76,21 @@ behavior before its tests exist and have failed for the expected reason.
   configured `pythonpath` roots, `addopts` `-p` plugins, declared
   `pytest_plugins`, and statically reachable repository-local imports — and
   fail closed on any input that cannot be read, parsed, or statically resolved.
-- [x] 3.9 Declare `scripts/requirements_proof_provenance.py` as a governed
+- [ ] 3.9 Declare `scripts/requirements_proof_provenance.py` as a governed
   touchpoint of the failing-first requirement and map its scenarios to exact,
   unparametrized selectors so this change's own gate covers its implementation.
+  Drafted and withdrawn from this pull request: editing
+  `requirements-evidence.yaml` changes the mapping digest, which is pinned in
+  three places that only a product-owner run can regenerate — the acceptance
+  record `requirements-proof/review-evidence.json`, and
+  `legacy_tdd_mapping_digest` plus `legacy_tdd_plan_digest` in
+  `.github/workflows/requirements-evidence.yml`. Landing it here would add a
+  second CI failure on top of the pre-existing one. The draft raised the plan
+  from 18 to 23 cases: a `cli_command` touchpoint for the gate script, and
+  cases R07-CORE-003-S04..S08 covering the configuration source and configured
+  roots, unreadable inputs, unresolvable plugin declarations, guard rewriting,
+  and symlinked selectors. Every drafted selector was verified to collect
+  exactly one test.
 
 ## 4. Passing evidence and delivery verification
 

--- a/openspec/changes/requirements-07-runtime-proof-delivery/tasks.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/tasks.md
@@ -70,6 +70,15 @@ behavior before its tests exist and have failed for the expected reason.
   retain both reports, then continue to existing contract/full quality gates.
 - [x] 3.7 Publish plan, JUnit, finalized JSON/Markdown, review provenance, and
   concise summaries before enforcing any red verdict.
+- [x] 3.8 Resolve the complete set of pytest-determining inputs for a retained
+  red proof — selected tests, applicable `conftest.py` files, parent package
+  initializers, the pytest configuration source in every implicit candidate,
+  configured `pythonpath` roots, `addopts` `-p` plugins, declared
+  `pytest_plugins`, and statically reachable repository-local imports — and
+  fail closed on any input that cannot be read, parsed, or statically resolved.
+- [x] 3.9 Declare `scripts/requirements_proof_provenance.py` as a governed
+  touchpoint of the failing-first requirement and map its scenarios to exact,
+  unparametrized selectors so this change's own gate covers its implementation.
 
 ## 4. Passing evidence and delivery verification
 

--- a/scripts/check_dependency_trust_exceptions.py
+++ b/scripts/check_dependency_trust_exceptions.py
@@ -91,7 +91,7 @@ def _read_exception_records(register_path: Path) -> tuple[list[object], list[str
     """Load the register while preserving fail-closed parse errors."""
     try:
         raw_payload = json.loads(register_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         return [], [f"could not read dependency trust register: {exc}"]
     if not isinstance(raw_payload, dict):
         return [], ["dependency trust register must contain an exceptions list"]
@@ -210,7 +210,7 @@ def _read_security_tool_floors(policy_path: Path = DEFAULT_SECURITY_TOOL_FLOORS)
     """Load normalized, locally verifiable security-tool minimum versions."""
     try:
         raw_payload = json.loads(policy_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         return {}, [f"could not read security tool floor policy: {exc}"]
     if not isinstance(raw_payload, dict):
         return {}, ["security tool floor policy must contain a minimum_versions object"]

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -137,14 +137,16 @@ def _assigned_value(node: ast.AST, name: str) -> ast.AST | None:
     return None
 
 
-def _module_scope_nodes(tree: ast.AST) -> list[ast.AST]:
-    """Return nodes executed at module scope without entering nested scopes."""
+def _module_scope_nodes(tree: ast.AST, *, include_class_bodies: bool = False) -> list[ast.AST]:
+    """Return executable module nodes without entering deferred function scopes."""
     pending = list(ast.iter_child_nodes(tree))
     nodes: list[ast.AST] = []
     while pending:
         node = pending.pop()
         nodes.append(node)
-        if not isinstance(node, (ast.AsyncFunctionDef, ast.ClassDef, ast.FunctionDef, ast.Lambda)):
+        deferred_scope = isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef, ast.Lambda))
+        excluded_class_scope = isinstance(node, ast.ClassDef) and not include_class_bodies
+        if not deferred_scope and not excluded_class_scope:
             pending.extend(ast.iter_child_nodes(node))
     return nodes
 
@@ -176,7 +178,7 @@ def _import_module_names(tree: ast.AST, current_path: str) -> list[list[str]]:
     """Return imported module names, including relative import candidates."""
     current_package = list(PurePosixPath(current_path).parent.parts)
     module_names: list[list[str]] = []
-    for node in ast.walk(tree):
+    for node in _module_scope_nodes(tree, include_class_bodies=True):
         if isinstance(node, ast.Import):
             module_names.extend(alias.name.split(".") for alias in node.names)
         elif isinstance(node, ast.ImportFrom):

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -709,20 +709,47 @@ def _calls_during_module_load(tree: ast.AST) -> bool:
     )
 
 
-def _writes_module_namespace(tree: ast.AST) -> bool:
-    """Return whether the module rewrites its own namespace mapping while loading.
-
-    ``globals()["pytest_plugins"] = [...]`` creates exactly the attribute pytest reads, but
-    through a subscript whose base is a call rather than a name, so no binding is recorded.
-    """
-    return any(
-        isinstance(target, ast.Subscript)
-        and isinstance(target.value, ast.Call)
-        and isinstance(target.value.func, ast.Name)
-        and target.value.func.id in {"globals", "vars"}
-        for node in _executable_scope_nodes(tree, include_class_bodies=True)
-        for target in _write_targets(node)
+def _is_namespace_mapping(expression: ast.expr) -> bool:
+    """Return whether an expression is this module's own namespace mapping."""
+    return (
+        isinstance(expression, ast.Call)
+        and isinstance(expression.func, ast.Name)
+        and expression.func.id in {"globals", "vars"}
     )
+
+
+def _reaches_namespace_mapping(expression: ast.expr) -> bool:
+    """Return whether the namespace mapping is anywhere inside an expression."""
+    return any(_is_namespace_mapping(child) for child in ast.walk(expression) if isinstance(child, ast.expr))
+
+
+def _writes_module_namespace(tree: ast.AST) -> bool:
+    """Return whether the module can create the attribute pytest reads without binding a name.
+
+    ``globals()["pytest_plugins"] = [...]`` writes exactly that attribute through a subscript
+    rather than a name, and so does every other route to the mapping: ``globals().update(...)``,
+    ``setdefault``, ``__setitem__``, and handing the mapping to ``exec`` or to any function that
+    could write it. Enumerating the mutating methods would invite the next spelling, so the rule
+    is positional instead: reading one key out of the mapping is fine, and every other use of it
+    leaves the module's declarations unknowable.
+
+    A write to a ``pytest_plugins`` attribute is treated the same way wherever it appears, since
+    ``sys.modules[__name__].pytest_plugins = [...]`` reaches the module object by another door.
+    """
+    for node in _executable_scope_nodes(tree, include_class_bodies=True):
+        for target in _write_targets(node):
+            if isinstance(target, ast.Subscript) and _is_namespace_mapping(target.value):
+                return True
+            if isinstance(target, ast.Attribute) and target.attr == "pytest_plugins":
+                return True
+        if not isinstance(node, ast.Call):
+            continue
+        # A method on the mapping, or the mapping handed to anything, can rewrite any key.
+        if isinstance(node.func, ast.Attribute) and _is_namespace_mapping(node.func.value):
+            return True
+        if any(_reaches_namespace_mapping(argument) for argument in _handed_over_expressions(node)):
+            return True
+    return False
 
 
 def _unverifiable_module_state(tree: ast.AST) -> bool:
@@ -1187,16 +1214,46 @@ def _discovered_rooted_paths(
     }
 
 
-def _path_join_chain(expression: ast.expr) -> tuple[ast.expr, list[str]] | None:
-    """Split a chain of ``/`` joins into the base it starts from and its literal components."""
+PATH_JOIN_METHODS = frozenset({"join", "joinpath"})
+POSIX_PATH_MODULES = frozenset({"os", "posixpath", "ntpath"})
+PATH_PRESERVING_METHODS = frozenset({"resolve", "absolute", "expanduser"})
+PATH_PARENT_FUNCTIONS = frozenset({"dirname"})
+
+
+def _path_join(expression: ast.expr) -> tuple[ast.expr, list[ast.expr]] | None:
+    """Split a path join into the base it starts from and the component expressions after it.
+
+    Both spellings are one construction: ``base / "a" / "b"``, ``os.path.join(base, "a")``, and
+    ``base.joinpath("a")`` differ only in notation, and a rule that reads one but not the other
+    invites the same finding again in the other form.
+    """
+    if isinstance(expression, ast.BinOp):
+        components: list[ast.expr] = []
+        node: ast.expr = expression
+        while isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+            components.insert(0, node.right)
+            node = node.left
+        return (node, components) if components else None
+    if not isinstance(expression, ast.Call):
+        return None
+    callee = expression.func
+    if not isinstance(callee, ast.Attribute) or callee.attr not in PATH_JOIN_METHODS:
+        return None
+    # ``os.path.join`` takes its base as the first argument; ``base.joinpath`` uses the receiver.
+    joins_receiver = callee.attr == "joinpath" or _root_name(callee) not in POSIX_PATH_MODULES
+    if joins_receiver:
+        return (callee.value, list(expression.args)) if expression.args else None
+    return (expression.args[0], list(expression.args[1:])) if len(expression.args) > 1 else None
+
+
+def _literal_join_parts(components: Sequence[ast.expr]) -> list[str] | None:
+    """Return the components' literal values, or ``None`` when any is decided at runtime."""
     parts: list[str] = []
-    node: ast.expr = expression
-    while isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
-        if not isinstance(node.right, ast.Constant) or not isinstance(node.right.value, str):
+    for component in components:
+        if not isinstance(component, ast.Constant) or not isinstance(component.value, str):
             return None
-        parts.insert(0, node.right.value)
-        node = node.left
-    return (node, parts) if parts else None
+        parts.append(component.value)
+    return parts
 
 
 def _ancestor_directory(path: str, levels: int) -> str:
@@ -1227,16 +1284,31 @@ def _path_base_directory(
     fixture value such as ``tmp_path`` names a file that does not exist in the repository at
     all, and reading it as root-relative would bind whatever committed file happens to share
     the remaining components.
+
+    A join is itself a path, so one resolves here too and every notation for it arrives through
+    the same door: a base is as often ``os.path.join(os.path.dirname(__file__), "data")`` as it
+    is ``Path(__file__).parent / "data"``.
     """
     if depth > MAX_SYMLINK_HOPS:
         return None
+    if isinstance(expression, ast.Constant):
+        return expression.value if isinstance(expression.value, str) else None
+    if _names_the_module_file(expression):
+        return current_path
+    if (join := _path_join(expression)) is not None:
+        base, components = join
+        parts = _literal_join_parts(components)
+        directory = _path_base_directory(base, current_path, bindings, depth + 1)
+        if parts is None or directory is None:
+            return None
+        return "/".join([directory, *parts]) if directory else "/".join(parts)
     if isinstance(expression, ast.Name):
         bound = bindings.get(expression.id)
         return None if bound is None else _path_base_directory(bound, current_path, bindings, depth + 1)
     if isinstance(expression, ast.Call):
         callee = expression.func
         method = callee.attr if isinstance(callee, ast.Attribute) else None
-        if method in {"resolve", "absolute"}:
+        if method in PATH_PRESERVING_METHODS:
             return _path_base_directory(callee.value, current_path, bindings, depth + 1)
         for argument in expression.args:
             base = (
@@ -1246,8 +1318,9 @@ def _path_base_directory(
             )
             if base is None:
                 continue
-            # ``os.path.dirname(x)`` names the directory holding x; a path constructor keeps it.
-            return _ancestor_directory(base, 1) if method == "dirname" else base
+            # ``os.path.dirname(x)`` names the directory holding x; a path constructor keeps it,
+            # and so does a normalizing wrapper such as ``abspath`` or ``realpath``.
+            return _ancestor_directory(base, 1) if method in PATH_PARENT_FUNCTIONS else base
         return None
     if isinstance(expression, ast.Attribute) and expression.attr == "parent":
         base = _path_base_directory(expression.value, current_path, bindings, depth + 1)
@@ -1275,13 +1348,18 @@ def _literal_path_candidates(
     """Return repository-relative paths a reachable body names as literals.
 
     A harness reads a data file the same way it names a module: by handing a literal to a call,
-    or by joining literals onto a path base. Both are resolved, and nothing else is, because a
-    path assembled at runtime — ``tmp_path / name`` — cannot be bound to a committed file and
-    failing closed on it would reject every proof in a repository that uses temporary
-    directories, which is every repository. A join whose base is unknowable is discarded for the
-    same reason, rather than being read as though it started at the repository root.
+    or by joining onto a path base. Both are resolved, and nothing else is, because a path
+    assembled at runtime — ``tmp_path / name`` — cannot be bound to a committed file and failing
+    closed on it would reject every proof in a repository that uses temporary directories, which
+    is every repository. A join whose base is unknowable is discarded for the same reason,
+    rather than being read as though it started at the repository root.
+
+    A join's components are consumed either way, because a component is part of a path and not a
+    path of its own. Without that, the tail of ``os.path.join(tmp_path, "tests/data/case.json")``
+    would still be read as repository-relative and would bind a file the run never opened.
     """
     candidates: list[str] = []
+    consumed: set[int] = set()
     reachable_bodies = _deferred_scopes_are_reachable(tree, current_path)
     nodes = _module_scope_nodes(
         tree,
@@ -1290,14 +1368,17 @@ def _literal_path_candidates(
         skipped_scope_names=skipped_scope_names,
     )
     bindings = _module_scope_bindings(nodes)
+    # Enclosing expressions are visited before the parts they are built from, so a component is
+    # marked consumed before it would otherwise be collected on its own.
     for node in nodes:
-        handed_over = _handed_over_expressions(node)
-        candidates.extend(itertools.chain.from_iterable(_literal_strings(argument) for argument in handed_over))
-        if not isinstance(node, ast.BinOp) or (chain := _path_join_chain(node)) is None:
-            continue
-        base, parts = chain
-        if (directory := _path_base_directory(base, current_path, bindings)) is not None:
-            candidates.append("/".join([directory, *parts]) if directory else "/".join(parts))
+        if isinstance(node, ast.expr) and (join := _path_join(node)) is not None:
+            consumed.update(id(component) for component in join[1])
+            if (resolved := _path_base_directory(node, current_path, bindings)) is not None:
+                candidates.append(resolved)
+                continue
+        for argument in _handed_over_expressions(node):
+            if id(argument) not in consumed:
+                candidates.extend(_literal_strings(argument))
     return [stripped for candidate in candidates if _names_a_repository_path(stripped := candidate.strip("/"))]
 
 
@@ -1363,34 +1444,57 @@ def _referenced_data_paths(
 def _read_data_paths(repo_root: Path, source_ref: str, candidate: str) -> set[str]:
     """Return the committed paths a harness read of ``candidate`` actually consumes.
 
-    A link is followed rather than skipped, because pytest reads the target's bytes while Git
-    records only the link, so binding neither would let the target change unnoticed. Both the
-    link and its target are bound, since editing either changes what the read returns. A link
-    that leaves the repository, cycles, or points at nothing cannot be bound at all, and is
+    A link is followed rather than skipped, because the filesystem reads the target's bytes
+    while Git records only the link, so binding neither would let the target change unnoticed.
+    Every link crossed is bound along with the file finally reached, since editing any of them
+    changes what the read returns.
+
+    The walk goes component by component from the repository root, because a link is as often a
+    directory in the middle of a path as it is the file at the end — ``tests/data_link/case.json``
+    has no Git entry at all, so looking up only the full path finds nothing to follow. A link
+    that leaves the repository, cycles, or points at nothing binds no committed bytes and is
     treated as stale rather than dropped.
     """
-    mode = _tree_entry_mode_at_ref(repo_root, source_ref, candidate)
-    if mode is None:
-        return set()
     bound: set[str] = set()
+    seen: set[str] = set()
     for _ in range(MAX_SYMLINK_HOPS):
-        if mode in REGULAR_FILE_MODES:
-            return bound | {candidate}
-        if mode != SYMLINK_MODE:
-            # A directory is named, not read; there are no bytes to bind.
+        if candidate in seen or not _names_a_repository_path(candidate):
+            raise ValueError("stale-red-proof")
+        seen.add(candidate)
+        crossed = _first_crossed_link(repo_root, source_ref, candidate)
+        if crossed is None:
+            mode = _tree_entry_mode_at_ref(repo_root, source_ref, candidate)
+            if mode in REGULAR_FILE_MODES:
+                return bound | {candidate}
+            if mode is None and bound:
+                # A link was followed to nothing. Creating that file later would start feeding
+                # the read without binding anything, so the chain is not verifiable.
+                raise ValueError("stale-red-proof")
+            # A directory or a path that was never there is named rather than read.
             return bound
-        bound.add(candidate)
-        result = _git_bytes(repo_root, "show", f"{source_ref}:{candidate}")
-        if result.returncode != 0 or len(result.stdout) > MAX_TEST_BLOB_BYTES:
-            raise ValueError("stale-red-proof")
-        target = result.stdout.decode("utf-8", errors="surrogateescape")
-        candidate = _repository_relative_target(candidate, target)
-        if candidate in bound or not _names_a_repository_path(candidate):
-            raise ValueError("stale-red-proof")
-        mode = _tree_entry_mode_at_ref(repo_root, source_ref, candidate)
-        if mode is None:
-            raise ValueError("stale-red-proof")
+        link_path, remainder = crossed
+        bound.add(link_path)
+        candidate = _link_target_path(repo_root, source_ref, link_path, remainder)
     raise ValueError("stale-red-proof")
+
+
+def _first_crossed_link(repo_root: Path, source_ref: str, candidate: str) -> tuple[str, str] | None:
+    """Return the first symlinked prefix of a path and what follows it, if any."""
+    parts = PurePosixPath(candidate).parts
+    for depth, _ in enumerate(parts, start=1):
+        prefix = "/".join(parts[:depth])
+        if _tree_entry_mode_at_ref(repo_root, source_ref, prefix) == SYMLINK_MODE:
+            return prefix, "/".join(parts[depth:])
+    return None
+
+
+def _link_target_path(repo_root: Path, source_ref: str, link_path: str, remainder: str) -> str:
+    """Return the path a link resolves to, keeping whatever the original path named beneath it."""
+    result = _git_bytes(repo_root, "show", f"{source_ref}:{link_path}")
+    if result.returncode != 0 or len(result.stdout) > MAX_TEST_BLOB_BYTES:
+        raise ValueError("stale-red-proof")
+    target = _repository_relative_target(link_path, result.stdout.decode("utf-8", errors="surrogateescape"))
+    return f"{target}/{remainder}" if remainder else target
 
 
 def _repository_relative_target(link_path: str, target: str) -> str:

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -598,13 +598,29 @@ def _record_constant(constants: dict[str, list[object]], name: str, value: objec
         constants[name] = [value]
 
 
+def _import_binding_names(node: ast.AST) -> list[str]:
+    """Return names bound by one import statement, whose values are not statically known."""
+    if isinstance(node, ast.Import):
+        return [alias.asname or alias.name.split(".")[0] for alias in node.names]
+    if isinstance(node, ast.ImportFrom):
+        return [alias.asname or alias.name for alias in node.names if alias.name != "*"]
+    return []
+
+
+def _has_star_import(node: ast.AST) -> bool:
+    """Return whether one statement imports an unknown set of names."""
+    return isinstance(node, ast.ImportFrom) and any(alias.name == "*" for alias in node.names)
+
+
 def _pytest_plugin_names(tree: ast.AST) -> list[list[str]]:
     """Return statically declared ``pytest_plugins`` module names.
 
     Only the final possible binding is reported, because pytest reads the attribute after
     the module is imported, so an assignment that a later one overwrites never loads.
     Raises ``ValueError('stale-red-proof')`` when that binding cannot be resolved, because
-    an unverifiable plugin set cannot prove the retained failure is still current.
+    an unverifiable plugin set cannot prove the retained failure is still current. An
+    imported binding, including one a star import may supply, is treated as unresolved
+    since its value lives in another module.
     """
     conditional_assignment_ids = _conditional_assignment_ids(tree)
     constants: dict[str, list[object]] = {}
@@ -616,6 +632,10 @@ def _pytest_plugin_names(tree: ast.AST) -> list[list[str]]:
                 extends = True
         for name in _compound_binding_names(node):
             _record_constant(constants, name, UNRESOLVED_PLUGIN_VALUE, extends=True)
+        for name in _import_binding_names(node):
+            _record_constant(constants, name, UNRESOLVED_PLUGIN_VALUE, extends=False)
+        if _has_star_import(node):
+            _record_constant(constants, "pytest_plugins", UNRESOLVED_PLUGIN_VALUE, extends=True)
     plugin_names: list[list[str]] = []
     for value in constants.get("pytest_plugins", []):
         if value is UNRESOLVED_PLUGIN_VALUE:

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -109,6 +109,16 @@ def _applicable_conftest_paths(test_path: str) -> set[str]:
     return paths
 
 
+def _parent_package_initializer_paths(path: str) -> set[str]:
+    """Return every possible parent package initializer for a Python path."""
+    parent = PurePosixPath(path).parent
+    paths: set[str] = set()
+    while parent != PurePosixPath("."):
+        paths.add((parent / "__init__.py").as_posix())
+        parent = parent.parent
+    return paths
+
+
 def _python_module_paths(module_parts: Sequence[str]) -> set[str]:
     """Return possible paths for a repository-local module, including an absent target."""
     if not module_parts:
@@ -121,17 +131,26 @@ def _python_module_paths(module_parts: Sequence[str]) -> set[str]:
     return paths
 
 
+def _assigned_value(node: ast.AST, name: str) -> ast.AST | None:
+    """Return the value statically assigned to a named variable."""
+    if isinstance(node, ast.Assign) and any(
+        isinstance(target, ast.Name) and target.id == name for target in node.targets
+    ):
+        return node.value
+    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.target.id == name:
+        return node.value
+    return None
+
+
 def _pytest_plugin_names(tree: ast.AST) -> list[list[str]]:
     """Return statically declared ``pytest_plugins`` module names."""
     plugin_names: list[list[str]] = []
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Assign):
-            continue
-        assigned_names = {target.id for target in node.targets if isinstance(target, ast.Name)}
-        if "pytest_plugins" not in assigned_names:
+        value_node = _assigned_value(node, "pytest_plugins")
+        if value_node is None:
             continue
         try:
-            value = ast.literal_eval(node.value)
+            value = ast.literal_eval(value_node)
         except (ValueError, TypeError):
             continue
         declared_plugins = [value] if isinstance(value, str) else value
@@ -408,6 +427,7 @@ def validate_prior_red_proof(red_proof_path: Path, repo_root: Path, *, base_ref:
         pytest_inputs = {test_path, *_applicable_conftest_paths(test_path)}
         proof_inputs = {
             *pytest_inputs,
+            *(initializer for path in pytest_inputs for initializer in _parent_package_initializer_paths(path)),
             *_imported_python_paths(repo_root, source_ref, sorted(pytest_inputs)),
         }
         if not proof_inputs.isdisjoint(paths_after_red):

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -242,13 +242,19 @@ def _conditional_assignment_ids(tree: ast.AST) -> set[int]:
     type_checking_names, typing_module_names = _verified_type_checking_bindings(tree)
     conditional_ids: set[int] = set()
     for node in ast.walk(tree):
-        if not isinstance(node, ast.If):
-            continue
-        if _static_condition(node.test, type_checking_names, typing_module_names) is not None:
+        if isinstance(node, ast.If):
+            if _static_condition(node.test, type_checking_names, typing_module_names) is not None:
+                continue
+            branch_nodes: tuple[ast.stmt, ...] = (*node.body, *node.orelse)
+        elif isinstance(
+            node, (ast.AsyncFor, ast.AsyncWith, ast.For, ast.Match, ast.Try, ast.TryStar, ast.While, ast.With)
+        ):
+            branch_nodes = tuple(child for child in ast.iter_child_nodes(node) if isinstance(child, ast.stmt))
+        else:
             continue
         conditional_ids.update(
             id(descendant)
-            for branch_node in (*node.body, *node.orelse)
+            for branch_node in branch_nodes
             for descendant in ast.walk(branch_node)
             if _simple_assignments(descendant)
         )

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -38,8 +38,27 @@ GOVERNED_PRODUCTION_PREFIXES = (
     "modules/bundle-mapper/",
 )
 GOVERNED_PRODUCTION_FILES = {"pyproject.toml", "setup.py", "uv.lock", "requirements/ci/locked.txt"}
-PYTEST_CONFIGURATION_FILES = ("pyproject.toml", "pytest.ini", "setup.cfg", "tox.ini")
-PYTEST_INI_SECTIONS = {"pytest.ini": "pytest", "setup.cfg": "tool:pytest", "tox.ini": "pytest"}
+# Implicit configuration candidates and their tables, mirroring pytest's own discovery order.
+PYTEST_CONFIGURATION_FILES = (
+    "pytest.toml",
+    ".pytest.toml",
+    "pytest.ini",
+    ".pytest.ini",
+    "pyproject.toml",
+    "tox.ini",
+    "setup.cfg",
+)
+PYTEST_TOML_TABLES: dict[str, tuple[tuple[str, ...], ...]] = {
+    "pytest.toml": (("pytest",),),
+    ".pytest.toml": (("pytest",),),
+    "pyproject.toml": (("tool", "pytest", "ini_options"), ("tool", "pytest")),
+}
+PYTEST_INI_SECTIONS = {
+    "pytest.ini": "pytest",
+    ".pytest.ini": "pytest",
+    "tox.ini": "pytest",
+    "setup.cfg": "tool:pytest",
+}
 REPOSITORY_ROOT_MODULE_ROOTS = ("",)
 GIT_TIMEOUT_SECONDS = 30
 UNRESOLVED_PLUGIN_VALUE = object()
@@ -142,24 +161,32 @@ def _pythonpath_entries(value: object) -> list[str]:
     return []
 
 
-def _toml_ini_option(text: str, option: str) -> object | None:
-    """Return one option declared under ``[tool.pytest.ini_options]``."""
+def _toml_option_value(text: str, table_paths: Sequence[Sequence[str]], option: str) -> object | None:
+    """Return one option from the first TOML table that declares it."""
     try:
-        node: object = tomllib.loads(text)
+        document: object = tomllib.loads(text)
     except (tomllib.TOMLDecodeError, ValueError):
         return None
-    for key in ("tool", "pytest", "ini_options", option):
-        if not isinstance(node, dict):
-            return None
-        node = cast(dict[str, object], node).get(key)
-    return node
+    for table_path in table_paths:
+        node = document
+        for key in (*table_path, option):
+            if not isinstance(node, dict):
+                node = None
+                break
+            node = cast(dict[str, object], node).get(key)
+        if node is not None:
+            return node
+    return None
 
 
 def _pytest_ini_option(text: str, configuration_path: str, option: str) -> object | None:
-    """Return one pytest ini option from a TOML or ini-style configuration source."""
+    """Return one pytest configuration option from a TOML or ini-style source."""
+    table_paths = PYTEST_TOML_TABLES.get(configuration_path)
+    if table_paths is not None:
+        return _toml_option_value(text, table_paths, option)
     section = PYTEST_INI_SECTIONS.get(configuration_path)
     if section is None:
-        return _toml_ini_option(text, option)
+        return None
     parser = configparser.ConfigParser()
     try:
         parser.read_string(text)
@@ -413,14 +440,18 @@ def _executable_scope_nodes(tree: ast.AST) -> list[ast.AST]:
 def _verified_type_checking_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
     """Return unrebound names imported from the typing module.
 
-    Rebinding is detected across every node that executes at module load, so a nested but
-    reachable assignment or import replaces the guard, while a name bound only inside a
-    function, lambda, or class body does not. A guard is trusted only when imported
-    directly at module scope.
+    Rebinding is detected across every node that executes at module load, including loop,
+    context-manager, exception, and match targets, so a nested but reachable rebinding
+    replaces the guard while a name bound only inside a function, lambda, or class body
+    does not. A guard is trusted only when imported directly at module scope.
     """
     body = tree.body if isinstance(tree, ast.Module) else []
     nodes = _executable_scope_nodes(tree)
-    rebound_names = _other_import_names(nodes) | {name for node in nodes for name, _ in _name_bindings(node)}
+    rebound_names = (
+        _other_import_names(nodes)
+        | {name for node in nodes for name, _ in _name_bindings(node)}
+        | {name for node in nodes for name in _compound_binding_names(node)}
+    )
     return (
         _imported_type_checking_names(body) - rebound_names,
         _imported_typing_module_names(body) - rebound_names,

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -261,16 +261,21 @@ def _addopts_plugin_module_names(repo_root: Path, source_ref: str) -> tuple[tupl
     return tuple(sorted(names))
 
 
-def _safe_module_root(root: str) -> str | None:
+def _safe_module_root(root: str, repo_root: Path) -> str | None:
     """Return a repository-relative module root, normalizing traversal within the repository.
 
     Pytest resolves the configured entry against the rootdir, so ``a/../b`` names the root
-    ``b`` and must bind the plugins reachable through it. An absolute or escaping entry names
-    a tree outside the repository whose files no Git ref can bind, so it yields no root.
+    ``b`` and must bind the plugins reachable through it. An absolute entry is resolved the
+    same way and kept when it lands inside the checkout. Only an entry naming a tree outside
+    the repository yields no root, because no Git ref can bind its files.
     """
     path = PurePosixPath(root)
     if path.is_absolute():
-        return None
+        try:
+            contained = Path(root).resolve().relative_to(repo_root.resolve())
+        except (OSError, ValueError):
+            return None
+        return "" if contained == Path() else contained.as_posix()
     parts: list[str] = []
     for part in path.parts:
         if part == ".":
@@ -294,7 +299,7 @@ def _pythonpath_roots(repo_root: Path, source_ref: str) -> tuple[str, ...]:
     roots: set[str] = set()
     for path, text in _pytest_configuration_sources(repo_root, source_ref):
         entries = _pythonpath_entries(_pytest_ini_option(text, path, "pythonpath"))
-        roots.update(root for entry in entries if (root := _safe_module_root(entry)) is not None)
+        roots.update(root for entry in entries if (root := _safe_module_root(entry, repo_root)) is not None)
     return (*REPOSITORY_ROOT_MODULE_ROOTS, *sorted(roots - set(REPOSITORY_ROOT_MODULE_ROOTS)))
 
 
@@ -517,7 +522,8 @@ def _call_argument_names(node: ast.AST) -> list[str]:
     if not isinstance(node, ast.Call):
         return []
     arguments = [*node.args, *(keyword.value for keyword in node.keywords)]
-    return [argument.id for argument in arguments if isinstance(argument, ast.Name)]
+    # Nested expressions still hand the module over: `setattr([typing][0], ...)` reaches it.
+    return [child.id for argument in arguments for child in ast.walk(argument) if isinstance(child, ast.Name)]
 
 
 def _second_reference_names(nodes: Sequence[ast.AST]) -> set[str]:
@@ -557,7 +563,8 @@ def _module_state_mutating_functions(tree: ast.AST) -> list[ast.AST]:
     guard_names = _imported_typing_module_names(tree.body if isinstance(tree, ast.Module) else [])
     definitions: list[ast.AST] = []
     for node in ast.walk(tree):
-        if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+        # A lambda body runs when it is called, exactly as a function body does.
+        if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef, ast.Lambda)):
             continue
         body_nodes = list(ast.walk(node))
         mutates = (
@@ -573,8 +580,31 @@ def _module_state_mutating_functions(tree: ast.AST) -> list[ast.AST]:
 
 
 def _calls_during_module_load(tree: ast.AST) -> bool:
-    """Return whether the module invokes anything while it loads."""
-    return any(isinstance(node, ast.Call) for node in _executable_scope_nodes(tree, include_class_bodies=True))
+    """Return whether the module invokes anything while it loads.
+
+    Applying a decorator invokes it during import even when the decorator expression is a
+    bare name, which produces no ``ast.Call`` node of its own.
+    """
+    nodes = _executable_scope_nodes(tree, include_class_bodies=True)
+    return any(isinstance(node, ast.Call) for node in nodes) or any(
+        getattr(node, "decorator_list", ()) for node in nodes
+    )
+
+
+def _writes_module_namespace(tree: ast.AST) -> bool:
+    """Return whether the module rewrites its own namespace mapping while loading.
+
+    ``globals()["pytest_plugins"] = [...]`` creates exactly the attribute pytest reads, but
+    through a subscript whose base is a call rather than a name, so no binding is recorded.
+    """
+    return any(
+        isinstance(target, ast.Subscript)
+        and isinstance(target.value, ast.Call)
+        and isinstance(target.value.func, ast.Name)
+        and target.value.func.id in {"globals", "vars"}
+        for node in _executable_scope_nodes(tree, include_class_bodies=True)
+        for target in _write_targets(node)
+    )
 
 
 def _unverifiable_module_state(tree: ast.AST) -> bool:
@@ -583,8 +613,11 @@ def _unverifiable_module_state(tree: ast.AST) -> bool:
     Resolving which function a module-load call reaches would require following aliases,
     wrappers, decorators, and transitive calls, and any partial resolution silently accepts
     the shapes it cannot follow. When a module both defines a state-mutating function and
-    calls anything while loading, the resulting state is therefore treated as unknown.
+    calls anything while loading, the resulting state is therefore treated as unknown. A
+    module that writes its own namespace mapping is unverifiable on the same grounds.
     """
+    if _writes_module_namespace(tree):
+        return True
     return bool(_module_state_mutating_functions(tree)) and _calls_during_module_load(tree)
 
 
@@ -799,12 +832,21 @@ def _pytest_plugin_names(tree: ast.AST) -> list[list[str]]:
     """
     if _unverifiable_module_state(tree):
         raise ValueError("stale-red-proof")
+    if "pytest_plugins" in _global_rebound_names(tree):
+        # An executing class body created the module attribute pytest reads, outside the
+        # module-scope traversal that resolves values.
+        raise ValueError("stale-red-proof")
     conditional_assignment_ids = _conditional_assignment_ids(tree)
     constants: dict[str, list[object]] = {}
+    # Chained targets share one right-hand side node and therefore one runtime object, so the
+    # evaluation is memoized per node to keep alias identity intact.
+    evaluated: dict[int, list[object]] = {}
     for node in _module_scope_nodes(tree):
         for name, assigned_node in _name_bindings(node):
             extends = id(node) in conditional_assignment_ids or bool(_augmented_assignments(node))
-            for value in _resolved_literals(assigned_node, constants):
+            if id(assigned_node) not in evaluated:
+                evaluated[id(assigned_node)] = _resolved_literals(assigned_node, constants)
+            for value in evaluated[id(assigned_node)]:
                 _record_constant(constants, name, value, extends=extends)
                 extends = True
         for name in _compound_binding_names(node):

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import functools
 import hashlib
 import json
 import re
@@ -34,15 +35,33 @@ GOVERNED_PRODUCTION_PREFIXES = (
     "modules/bundle-mapper/",
 )
 GOVERNED_PRODUCTION_FILES = {"pyproject.toml", "setup.py", "uv.lock", "requirements/ci/locked.txt"}
+PYTEST_CONFIGURATION_FILES = ("pyproject.toml", "pytest.ini", "setup.cfg", "tox.ini")
+GIT_TIMEOUT_SECONDS = 30
+UNRESOLVED_PLUGIN_VALUE = object()
+
+
+def _git_bytes(repo_root: Path, *arguments: str) -> subprocess.CompletedProcess[bytes]:
+    """Run Git for payloads that are not required to be valid text."""
+    try:
+        return subprocess.run(
+            ["git", *arguments],
+            cwd=repo_root,
+            capture_output=True,
+            check=False,
+            timeout=GIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(["git", *arguments], returncode=1, stdout=b"", stderr=b"")
 
 
 def _git(repo_root: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["git", *arguments],
-        cwd=repo_root,
-        capture_output=True,
-        check=False,
-        text=True,
+    """Run Git for textual output, treating a timeout as an ordinary command failure."""
+    result = _git_bytes(repo_root, *arguments)
+    return subprocess.CompletedProcess(
+        result.args,
+        returncode=result.returncode,
+        stdout=result.stdout.decode("utf-8", errors="surrogateescape"),
+        stderr=result.stderr.decode("utf-8", errors="surrogateescape"),
     )
 
 
@@ -64,7 +83,8 @@ def _validated_execution_proof(report: dict[str, object]) -> dict[str, object]:
     return cast(dict[str, object], execution_proof)
 
 
-def _validated_selectors(execution_proof: dict[str, object]) -> list[object]:
+def _validated_selectors(execution_proof: dict[str, object]) -> list[str]:
+    """Return selector strings only when the red source and every selector entry are well formed."""
     source_ref = execution_proof.get("source_ref")
     selectors = execution_proof.get("selectors")
     if (
@@ -72,9 +92,10 @@ def _validated_selectors(execution_proof: dict[str, object]) -> list[object]:
         or GIT_OBJECT_PATTERN.fullmatch(source_ref) is None
         or not isinstance(selectors, list)
         or not selectors
+        or not all(isinstance(selector, str) for selector in cast(list[object], selectors))
     ):
         raise ValueError("prior-red-proof-invalid")
-    return selectors
+    return cast(list[str], selectors)
 
 
 def _selector_paths(report: dict[str, object]) -> tuple[str, list[str]]:
@@ -89,8 +110,6 @@ def _selector_paths(report: dict[str, object]) -> tuple[str, list[str]]:
     assert isinstance(source_ref, str)
     paths: set[str] = set()
     for selector in selectors:
-        if not isinstance(selector, str):
-            raise ValueError("prior-red-proof-invalid")
         test_path, separator, _ = selector.partition("::")
         path = PurePosixPath(test_path)
         if not separator or path.is_absolute() or ".." in path.parts or not test_path.endswith(".py"):
@@ -126,15 +145,26 @@ def _python_module_paths(module_parts: Sequence[str]) -> set[str]:
     return paths
 
 
-def _assigned_value(node: ast.AST, name: str) -> ast.AST | None:
-    """Return the value statically assigned to a named variable."""
-    if isinstance(node, ast.Assign) and any(
-        isinstance(target, ast.Name) and target.id == name for target in node.targets
+def _destructured_targets(target: ast.expr, value: ast.expr) -> list[tuple[str, ast.expr]]:
+    """Return the names bound by one assignment target, unpacking literal sequences."""
+    if isinstance(target, ast.Name):
+        return [(target.id, value)]
+    if (
+        isinstance(target, (ast.List, ast.Tuple))
+        and isinstance(value, (ast.List, ast.Tuple))
+        and len(target.elts) == len(value.elts)
     ):
-        return node.value
-    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.target.id == name:
-        return node.value
-    return None
+        return [
+            binding
+            for element, element_value in zip(target.elts, value.elts, strict=True)
+            for binding in _destructured_targets(element, element_value)
+        ]
+    return []
+
+
+def _assigned_value_nodes(node: ast.AST, name: str) -> list[ast.expr]:
+    """Return every value statically bound to a named variable by one statement."""
+    return [value for bound_name, value in _name_bindings(node) if bound_name == name]
 
 
 def _static_condition(test: ast.AST, type_checking_names: set[str], typing_module_names: set[str]) -> bool | None:
@@ -153,13 +183,25 @@ def _static_condition(test: ast.AST, type_checking_names: set[str], typing_modul
     return None
 
 
-def _simple_assignments(node: ast.AST) -> list[tuple[str, ast.AST]]:
-    """Return direct name assignments made by one module statement."""
+def _simple_assignments(node: ast.AST) -> list[tuple[str, ast.expr]]:
+    """Return name assignments that replace any previous binding."""
     if isinstance(node, ast.Assign):
-        return [(target.id, node.value) for target in node.targets if isinstance(target, ast.Name)]
-    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.value is not None:
-        return [(node.target.id, node.value)]
+        return [binding for target in node.targets for binding in _destructured_targets(target, node.value)]
+    if isinstance(node, ast.AnnAssign) and node.value is not None:
+        return _destructured_targets(node.target, node.value)
     return []
+
+
+def _augmented_assignments(node: ast.AST) -> list[tuple[str, ast.expr]]:
+    """Return name assignments that extend rather than replace a previous binding."""
+    if isinstance(node, ast.AugAssign):
+        return _destructured_targets(node.target, node.value)
+    return []
+
+
+def _name_bindings(node: ast.AST) -> list[tuple[str, ast.expr]]:
+    """Return every module-level name binding made by one statement."""
+    return [*_simple_assignments(node), *_augmented_assignments(node)]
 
 
 def _imported_type_checking_names(body: Sequence[ast.stmt]) -> set[str]:
@@ -184,18 +226,18 @@ def _imported_typing_module_names(body: Sequence[ast.stmt]) -> set[str]:
     }
 
 
-def _other_import_names(body: Sequence[ast.stmt]) -> set[str]:
+def _other_import_names(nodes: Sequence[ast.AST]) -> set[str]:
     """Return local names bound by imports other than typing guards."""
     direct_imports = {
         alias.asname or alias.name.split(".")[0]
-        for node in body
+        for node in nodes
         if isinstance(node, ast.Import)
         for alias in node.names
         if alias.name != "typing"
     }
     from_imports = {
         alias.asname or alias.name
-        for node in body
+        for node in nodes
         if isinstance(node, ast.ImportFrom)
         for alias in node.names
         if node.module != "typing" or alias.name != "TYPE_CHECKING"
@@ -204,11 +246,15 @@ def _other_import_names(body: Sequence[ast.stmt]) -> set[str]:
 
 
 def _verified_type_checking_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
-    """Return unrebound names imported from the typing module."""
+    """Return unrebound names imported from the typing module.
+
+    Rebinding is detected across the whole tree because an assignment or an import anywhere
+    in the module may replace the guard, while a guard is only trusted when it is imported
+    directly at module scope.
+    """
     body = tree.body if isinstance(tree, ast.Module) else []
-    rebound_names = _other_import_names(body) | {
-        name for node in ast.walk(tree) for name, _ in _simple_assignments(node)
-    }
+    nodes = list(ast.walk(tree))
+    rebound_names = _other_import_names(nodes) | {name for node in nodes for name, _ in _name_bindings(node)}
     return (
         _imported_type_checking_names(body) - rebound_names,
         _imported_typing_module_names(body) - rebound_names,
@@ -256,19 +302,23 @@ def _conditional_assignment_ids(tree: ast.AST) -> set[int]:
             id(descendant)
             for branch_node in branch_nodes
             for descendant in ast.walk(branch_node)
-            if _simple_assignments(descendant)
+            if _name_bindings(descendant)
         )
     return conditional_ids
 
 
-def _resolved_literals(value_node: ast.AST, constants: dict[str, list[object]]) -> list[object]:
-    """Resolve a literal expression or all possible values of a bound name."""
+def _resolved_literals(value_node: ast.expr, constants: dict[str, list[object]]) -> list[object]:
+    """Resolve a literal expression or all possible values of a bound name.
+
+    An expression that cannot be evaluated yields the unresolved marker so callers fail
+    closed instead of silently treating an active declaration as absent.
+    """
     if isinstance(value_node, ast.Name):
-        return constants.get(value_node.id, [])
+        return constants.get(value_node.id, [UNRESOLVED_PLUGIN_VALUE])
     try:
         return [ast.literal_eval(value_node)]
     except (ValueError, TypeError):
-        return []
+        return [UNRESOLVED_PLUGIN_VALUE]
 
 
 def _plugin_parts(value: object) -> list[list[str]]:
@@ -285,28 +335,37 @@ def _plugin_parts(value: object) -> list[list[str]]:
     ]
 
 
+def _record_constant(constants: dict[str, list[object]], name: str, value: object, *, extends: bool) -> None:
+    """Record one possible value of a module constant, keeping earlier possibilities when they survive."""
+    if extends:
+        constants.setdefault(name, []).append(value)
+    else:
+        constants[name] = [value]
+
+
 def _pytest_plugin_names(tree: ast.AST) -> list[list[str]]:
-    """Return statically declared ``pytest_plugins`` module names."""
+    """Return statically declared ``pytest_plugins`` module names.
+
+    Raises ``ValueError('stale-red-proof')`` when an active declaration cannot be resolved,
+    because an unverifiable plugin set cannot prove the retained failure is still current.
+    """
     plugin_names: list[list[str]] = []
     module_nodes = _module_scope_nodes(tree)
     conditional_assignment_ids = _conditional_assignment_ids(tree)
     constants: dict[str, list[object]] = {}
     for node in module_nodes:
-        value_node = _assigned_value(node, "pytest_plugins")
-        if value_node is not None:
+        for value_node in _assigned_value_nodes(node, "pytest_plugins"):
             for value in _resolved_literals(value_node, constants):
+                if value is UNRESOLVED_PLUGIN_VALUE:
+                    raise ValueError("stale-red-proof")
                 plugin_names.extend(_plugin_parts(value))
-        for name, assigned_node in _simple_assignments(node):
+        for name, assigned_node in _name_bindings(node):
             try:
                 value = ast.literal_eval(assigned_node)
             except (ValueError, TypeError):
-                if id(node) not in conditional_assignment_ids:
-                    constants.pop(name, None)
-                continue
-            if id(node) in conditional_assignment_ids:
-                constants.setdefault(name, []).append(value)
-            else:
-                constants[name] = [value]
+                value = UNRESOLVED_PLUGIN_VALUE
+            extends = id(node) in conditional_assignment_ids or bool(_augmented_assignments(node))
+            _record_constant(constants, name, value, extends=extends)
     return plugin_names
 
 
@@ -325,12 +384,20 @@ def _import_module_names(tree: ast.AST, current_path: str) -> list[list[str]]:
     return module_names
 
 
+@functools.cache
 def _python_tree_at_ref(repo_root: Path, source_ref: str, path: str) -> ast.AST | None:
-    """Parse committed Python source without consulting mutable worktree bytes."""
-    result = _git(repo_root, "show", f"{source_ref}:{path}")
+    """Parse committed Python source without consulting mutable worktree bytes.
+
+    Source is parsed as bytes so a PEP 263 encoding declaration is honoured rather than
+    forcing a UTF-8 decode that would abort the gate on legally encoded modules. Results are
+    cached because the content of a path at an immutable ref cannot change during one run.
+    """
+    result = _git_bytes(repo_root, "show", f"{source_ref}:{path}")
+    if result.returncode != 0 or len(result.stdout) > MAX_TEST_BLOB_BYTES:
+        return None
     try:
-        return ast.parse(result.stdout) if result.returncode == 0 else None
-    except SyntaxError:
+        return ast.parse(result.stdout)
+    except (SyntaxError, ValueError):
         return None
 
 
@@ -447,20 +514,7 @@ def _changed_paths_in_history(
     for revision in revisions.stdout.splitlines():
         parents = _git(repo_root, "rev-list", "--parents", "-n", "1", revision).stdout.split()
         comparison_ref = f"{revision}^{merge_parent}" if len(parents) > 2 else f"{revision}^"
-        result = subprocess.run(
-            [
-                "git",
-                "diff",
-                "--name-status",
-                "-z",
-                "--find-renames",
-                comparison_ref,
-                revision,
-            ],
-            cwd=repo_root,
-            capture_output=True,
-            check=False,
-        )
+        result = _git_bytes(repo_root, "diff", "--name-status", "-z", "--find-renames", comparison_ref, revision)
         commit_paths = _parse_name_status_records(result.stdout) if result.returncode == 0 else None
         if commit_paths is None:
             return None
@@ -485,7 +539,9 @@ def _has_governed_production_path(paths: Sequence[str]) -> bool:
     return any(path in GOVERNED_PRODUCTION_FILES or path.startswith(GOVERNED_PRODUCTION_PREFIXES) for path in paths)
 
 
+@functools.cache
 def _test_path_exists_at_ref(repo_root: Path, source_ref: str, test_path: str) -> bool:
+    """Return whether a path exists at an immutable ref, caching the answer for the run."""
     return _git(repo_root, "cat-file", "-e", f"{source_ref}:{test_path}").returncode == 0
 
 
@@ -504,13 +560,7 @@ def _blob_digest_at_ref(repo_root: Path, source_ref: str, test_path: str) -> str
         return None
     if size_result.returncode != 0 or blob_size > MAX_TEST_BLOB_BYTES:
         return None
-    result = subprocess.run(
-        ["git", "show", f"{source_ref}:{test_path}"],
-        cwd=repo_root,
-        capture_output=True,
-        check=False,
-        timeout=30,
-    )
+    result = _git_bytes(repo_root, "show", f"{source_ref}:{test_path}")
     return f"sha256:{hashlib.sha256(result.stdout).hexdigest()}" if result.returncode == 0 else None
 
 
@@ -564,6 +614,31 @@ def _validate_execution_bindings(
             raise ValueError("prior-red-proof-invalid")
 
 
+def _proof_inputs(repo_root: Path, source_ref: str, selector_paths: Sequence[str]) -> set[str]:
+    """Return every committed path whose change after the red source would invalidate the proof.
+
+    Selectors are resolved together so their shared conftest, initializer, and import graph is
+    traversed once for the whole proof.
+    """
+    pytest_inputs = {
+        path for test_path in selector_paths for path in (test_path, *_ancestor_file_paths(test_path, "conftest.py"))
+    }
+    initializer_inputs = {
+        initializer for path in pytest_inputs for initializer in _ancestor_file_paths(path, "__init__.py")
+    }
+    traversal_inputs = pytest_inputs | initializer_inputs
+    return {
+        *traversal_inputs,
+        *PYTEST_CONFIGURATION_FILES,
+        *_imported_python_paths(
+            repo_root,
+            source_ref,
+            sorted(traversal_inputs),
+            pytest_plugin_source_paths=pytest_inputs,
+        ),
+    }
+
+
 @beartype
 @ensure(
     lambda result: all(
@@ -601,22 +676,12 @@ def validate_prior_red_proof(red_proof_path: Path, repo_root: Path, *, base_ref:
             repo_root, source_ref, test_path
         ):
             return ["prior-red-proof-invalid"]
-        pytest_inputs = {test_path, *_ancestor_file_paths(test_path, "conftest.py")}
-        initializer_inputs = {
-            initializer for path in pytest_inputs for initializer in _ancestor_file_paths(path, "__init__.py")
-        }
-        traversal_inputs = pytest_inputs | initializer_inputs
-        proof_inputs = {
-            *traversal_inputs,
-            *_imported_python_paths(
-                repo_root,
-                source_ref,
-                sorted(traversal_inputs),
-                pytest_plugin_source_paths=pytest_inputs,
-            ),
-        }
-        if not proof_inputs.isdisjoint(paths_after_red):
-            return ["stale-red-proof"]
+    try:
+        proof_inputs = _proof_inputs(repo_root, source_ref, selector_paths)
+    except ValueError as error:
+        return [str(error)]
+    if not proof_inputs.isdisjoint(paths_after_red):
+        return ["stale-red-proof"]
     return []
 
 

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -342,10 +342,14 @@ def _symlink_paths_at_ref(repo_root: Path, source_ref: str) -> frozenset[str]:
 
     Collected in one traversal so any candidate path can be tested for a symlinked ancestor
     without another Git call per lookup.
+
+    A failed traversal is not an empty repository. Reporting one would say "no symlinks here"
+    on the strength of a lookup that never ran, and an import beneath a linked directory would
+    be skipped instead of rejected, so an unanswered inventory is stale like any other.
     """
     result = _git(repo_root, "ls-tree", "-r", "--full-tree", source_ref)
     if result.returncode != 0:
-        return frozenset()
+        raise ValueError("stale-red-proof")
     paths: set[str] = set()
     for line in result.stdout.splitlines():
         metadata, _, path = line.partition("\t")
@@ -721,16 +725,31 @@ def _looks_up_this_module(expression: ast.expr) -> bool:
     ordinary test practice and reaches nothing this gate reads.
     """
     if isinstance(expression, ast.Subscript):
-        keyed_by_this_module = isinstance(expression.slice, ast.Name) and expression.slice.id == "__name__"
-        return keyed_by_this_module and isinstance(expression.value, ast.Attribute)
+        return _names_this_module(expression.slice) and _is_module_table(expression.value)
     if not isinstance(expression, ast.Call):
         return False
-    named_this_module = any(
-        isinstance(argument, ast.Name) and argument.id == "__name__" for argument in expression.args
-    )
+    if not any(_names_this_module(argument) for argument in expression.args):
+        return False
     callee = expression.func
-    method = callee.attr if isinstance(callee, ast.Attribute) else getattr(callee, "id", None)
-    return named_this_module and method in MODULE_LOOKUP_FUNCTIONS
+    if isinstance(callee, ast.Attribute) and callee.attr in MODULE_TABLE_LOOKUP_METHODS:
+        return _is_module_table(callee.value)
+    # ``import_module(__name__)`` returns this module whichever module exposes the function.
+    return (callee.attr if isinstance(callee, ast.Attribute) else getattr(callee, "id", None)) == "import_module"
+
+
+def _names_this_module(expression: ast.expr) -> bool:
+    """Return whether an expression is the running module's own name."""
+    return isinstance(expression, ast.Name) and expression.id == "__name__"
+
+
+def _is_module_table(expression: ast.expr) -> bool:
+    """Return whether an expression is the interpreter's table of loaded modules.
+
+    Requiring the table itself keeps an ordinary mapping that merely uses ``__name__`` as a key
+    from being read as the module object, which would reject every proof in a repository whose
+    harness happens to index anything that way.
+    """
+    return isinstance(expression, ast.Attribute) and expression.attr == "modules"
 
 
 def _is_namespace_mapping(expression: ast.expr) -> bool:
@@ -988,15 +1007,15 @@ def _mutated_name_targets(node: ast.AST) -> list[str]:
     A method call, a subscript or attribute write, and a deletion all change the object a
     name is bound to without rebinding the name itself, so a binding copied from it earlier
     still observes the change.
+
+    A receiver is read the way an argument already is: every name inside it is reported, not
+    only a bare one. ``[PLUGINS][0].append(...)`` mutates exactly the object ``PLUGINS`` names,
+    and a rule matching only a direct name misses every wrapper that can carry it there.
     """
     names: list[str] = []
     for child in ast.walk(node):
-        if (
-            isinstance(child, ast.Call)
-            and isinstance(child.func, ast.Attribute)
-            and isinstance(child.func.value, ast.Name)
-        ):
-            names.append(child.func.value.id)
+        if isinstance(child, ast.Call) and isinstance(child.func, ast.Attribute):
+            names.extend(nested.id for nested in ast.walk(child.func.value) if isinstance(nested, ast.Name))
         if isinstance(child, ast.AugAssign) and isinstance(child.target, ast.Name):
             # `x += [...]` extends a list in place, so every alias observes it.
             names.append(child.target.id)
@@ -1247,7 +1266,7 @@ def _discovered_rooted_paths(
     }
 
 
-MODULE_LOOKUP_FUNCTIONS = frozenset({"get", "setdefault", "import_module"})
+MODULE_TABLE_LOOKUP_METHODS = frozenset({"get", "setdefault"})
 # Import modes that put a test file's own directory on sys.path. ``prepend`` is pytest's default.
 PREPENDING_IMPORT_MODES = frozenset({"prepend", "append"})
 PATH_JOIN_METHODS = frozenset({"join", "joinpath"})
@@ -1723,12 +1742,20 @@ def _validate_retained_red_junit(red_proof_path: Path, report: dict[str, object]
 
 
 def _artifact_is_tracked(repo_root: Path, artifact_path: Path) -> bool:
-    """Return whether an artifact is controlled by the pull-request Git tree."""
+    """Return whether an artifact is controlled by the pull-request Git tree.
+
+    ``ls-files --error-unmatch`` exits non-zero both for an untracked path and for a command
+    that could not run, so the two are separated by asking for the listing instead: an answer
+    naming the path means tracked, an empty answer means untracked, and a failure is neither.
+    """
     try:
         relative_path = artifact_path.resolve().relative_to(repo_root.resolve())
     except ValueError:
         return False
-    return _git(repo_root, "ls-files", "--error-unmatch", "--", relative_path.as_posix()).returncode == 0
+    result = _git(repo_root, "ls-files", "--", relative_path.as_posix())
+    if result.returncode != 0:
+        raise ValueError("prior-red-proof-invalid")
+    return bool(result.stdout.strip())
 
 
 def _is_ancestor(repo_root: Path, ancestor: str, descendant: str) -> bool:
@@ -1950,10 +1977,13 @@ def _proof_inputs(
 )
 def validate_prior_red_proof(red_proof_path: Path, repo_root: Path, *, base_ref: str, final_ref: str) -> list[str]:
     """Return deterministic findings when a red report cannot prove failing-first order."""
-    if _artifact_is_tracked(repo_root, red_proof_path) or _artifact_is_tracked(
-        repo_root, red_proof_path.with_suffix(".xml")
-    ):
-        return ["prior-red-proof-invalid"]
+    try:
+        if _artifact_is_tracked(repo_root, red_proof_path) or _artifact_is_tracked(
+            repo_root, red_proof_path.with_suffix(".xml")
+        ):
+            return ["prior-red-proof-invalid"]
+    except ValueError as error:
+        return [str(error)]
     try:
         report = _read_red_proof(red_proof_path)
         _validate_retained_red_junit(red_proof_path, report)

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -709,17 +709,46 @@ def _calls_during_module_load(tree: ast.AST) -> bool:
     )
 
 
-def _is_namespace_mapping(expression: ast.expr) -> bool:
-    """Return whether an expression is this module's own namespace mapping."""
-    return (
-        isinstance(expression, ast.Call)
-        and isinstance(expression.func, ast.Name)
-        and expression.func.id in {"globals", "vars"}
+def _looks_up_this_module(expression: ast.expr) -> bool:
+    """Return whether an expression fetches this module's own entry from the module table.
+
+    ``sys.modules[__name__]``, the same entry via ``.get``, and ``import_module(__name__)`` all
+    hand back the running module. The key must be ``__name__``: substituting *another* module is
+    ordinary test practice and reaches nothing this gate reads.
+    """
+    if isinstance(expression, ast.Subscript):
+        keyed_by_this_module = isinstance(expression.slice, ast.Name) and expression.slice.id == "__name__"
+        return keyed_by_this_module and isinstance(expression.value, ast.Attribute)
+    if not isinstance(expression, ast.Call):
+        return False
+    named_this_module = any(
+        isinstance(argument, ast.Name) and argument.id == "__name__" for argument in expression.args
     )
+    callee = expression.func
+    method = callee.attr if isinstance(callee, ast.Attribute) else getattr(callee, "id", None)
+    return named_this_module and method in MODULE_LOOKUP_FUNCTIONS
+
+
+def _is_namespace_mapping(expression: ast.expr) -> bool:
+    """Return whether an expression denotes this module's own namespace or module object.
+
+    The namespace is reachable by more than one door — ``globals()``, ``vars()``, the module
+    object itself, and the ``__dict__`` of either — and they are the same thing seen from
+    different sides, so one predicate recognizes them all and every rule below applies to each.
+    """
+    if isinstance(expression, ast.Attribute) and expression.attr == "__dict__":
+        return _is_namespace_mapping(expression.value)
+    if _looks_up_this_module(expression):
+        return True
+    if not isinstance(expression, ast.Call) or not isinstance(expression.func, ast.Name):
+        return False
+    if expression.func.id == "globals":
+        return not expression.args
+    return expression.func.id == "vars" and (not expression.args or _is_namespace_mapping(expression.args[0]))
 
 
 def _reaches_namespace_mapping(expression: ast.expr) -> bool:
-    """Return whether the namespace mapping is anywhere inside an expression."""
+    """Return whether the namespace is anywhere inside an expression."""
     return any(_is_namespace_mapping(child) for child in ast.walk(expression) if isinstance(child, ast.expr))
 
 
@@ -1214,6 +1243,7 @@ def _discovered_rooted_paths(
     }
 
 
+MODULE_LOOKUP_FUNCTIONS = frozenset({"get", "setdefault", "import_module"})
 PATH_JOIN_METHODS = frozenset({"join", "joinpath"})
 POSIX_PATH_MODULES = frozenset({"os", "posixpath", "ntpath"})
 PATH_PRESERVING_METHODS = frozenset({"resolve", "absolute", "expanduser"})

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -109,12 +109,17 @@ def _ancestor_file_paths(path: str, filename: str) -> set[str]:
     return paths
 
 
-def _python_module_paths(module_parts: Sequence[str]) -> set[str]:
-    """Return possible paths for a repository-local module, including an absent target."""
+def _python_module_target_paths(module_parts: Sequence[str]) -> set[str]:
+    """Return the file and package targets for a repository-local module name."""
     if not module_parts:
         return set()
     module_path = PurePosixPath(*module_parts)
-    paths = {module_path.with_suffix(".py").as_posix(), (module_path / "__init__.py").as_posix()}
+    return {module_path.with_suffix(".py").as_posix(), (module_path / "__init__.py").as_posix()}
+
+
+def _python_module_paths(module_parts: Sequence[str]) -> set[str]:
+    """Return possible paths for a repository-local module, including its parent packages."""
+    paths = _python_module_target_paths(module_parts)
     for parent_depth in range(1, len(module_parts)):
         parent_path = PurePosixPath(*module_parts[:parent_depth])
         paths.add((parent_path / "__init__.py").as_posix())
@@ -217,7 +222,11 @@ def _imported_python_paths(
         if tree is None:
             continue
         ordinary_paths = _discovered_python_paths(_import_module_names(tree, current_path))
-        plugin_paths = _discovered_python_paths(_pytest_plugin_names(tree)) if inspect_pytest_plugins else set()
+        plugin_names = _pytest_plugin_names(tree) if inspect_pytest_plugins else []
+        plugin_paths = _discovered_python_paths(plugin_names)
+        plugin_target_paths = {
+            path for module_parts in plugin_names for path in _python_module_target_paths(module_parts)
+        }
         imported_paths.update(ordinary_paths, plugin_paths)
         pending.extend(
             (imported_path, False)
@@ -225,7 +234,7 @@ def _imported_python_paths(
             if _test_path_exists_at_ref(repo_root, source_ref, imported_path)
         )
         pending.extend(
-            (plugin_path, True)
+            (plugin_path, plugin_path in plugin_target_paths)
             for plugin_path in plugin_paths
             if _test_path_exists_at_ref(repo_root, source_ref, plugin_path)
         )

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -269,8 +269,42 @@ def _augmented_assignments(node: ast.AST) -> list[tuple[str, ast.expr]]:
     return []
 
 
+def _target_names(target: ast.expr) -> list[str]:
+    """Return every name bound by an assignment-like target expression."""
+    if isinstance(target, ast.Name):
+        return [target.id]
+    if isinstance(target, (ast.List, ast.Tuple)):
+        return [name for element in target.elts for name in _target_names(element)]
+    if isinstance(target, ast.Starred):
+        return _target_names(target.value)
+    return []
+
+
+def _compound_binding_names(node: ast.AST) -> list[str]:
+    """Return names bound by a compound statement target, whose value is not statically known.
+
+    Loop, context-manager, exception, and match targets rebind a module constant without an
+    evaluable right-hand side, so their names must be recorded rather than left stale.
+    """
+    if isinstance(node, (ast.AsyncFor, ast.For)):
+        return _target_names(node.target)
+    if isinstance(node, (ast.AsyncWith, ast.With)):
+        return [
+            name for item in node.items if item.optional_vars is not None for name in _target_names(item.optional_vars)
+        ]
+    if isinstance(node, ast.ExceptHandler):
+        return [node.name] if node.name else []
+    if isinstance(node, (ast.MatchAs, ast.MatchStar)):
+        return [node.name] if node.name else []
+    if isinstance(node, ast.MatchMapping):
+        return [node.rest] if node.rest else []
+    return []
+
+
 def _name_bindings(node: ast.AST) -> list[tuple[str, ast.expr]]:
     """Return every module-level name binding made by one statement."""
+    if isinstance(node, ast.NamedExpr):
+        return _destructured_targets(node.target, node.value)
     return [*_simple_assignments(node), *_augmented_assignments(node)]
 
 
@@ -436,6 +470,8 @@ def _pytest_plugin_names(tree: ast.AST) -> list[list[str]]:
                 value = UNRESOLVED_PLUGIN_VALUE
             extends = id(node) in conditional_assignment_ids or bool(_augmented_assignments(node))
             _record_constant(constants, name, value, extends=extends)
+        for name in _compound_binding_names(node):
+            _record_constant(constants, name, UNRESOLVED_PLUGIN_VALUE, extends=True)
     return plugin_names
 
 
@@ -501,6 +537,8 @@ def _imported_python_paths(
         traversed_paths.add(traversal)
         tree = _python_tree_at_ref(repo_root, source_ref, current_path)
         if tree is None:
+            if _test_path_is_regular_at_ref(repo_root, source_ref, current_path):
+                raise ValueError("stale-red-proof")
             continue
         ordinary_paths = _discovered_python_paths(
             _import_module_names(tree, current_path), REPOSITORY_ROOT_MODULE_ROOTS
@@ -625,6 +663,7 @@ def _test_path_exists_at_ref(repo_root: Path, source_ref: str, test_path: str) -
     return _git(repo_root, "cat-file", "-e", f"{source_ref}:{test_path}").returncode == 0
 
 
+@functools.cache
 def _test_path_is_regular_at_ref(repo_root: Path, source_ref: str, test_path: str) -> bool:
     """Reject symlink selectors because pytest follows bytes not bound by their Git blob."""
     result = _git(repo_root, "ls-tree", source_ref, "--", test_path)

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -198,12 +198,18 @@ def _pytest_ini_option(text: str, configuration_path: str, option: str) -> objec
 
 @functools.cache
 def _pytest_configuration_sources(repo_root: Path, source_ref: str) -> tuple[tuple[str, str], ...]:
-    """Return the readable pytest configuration candidates committed at the red source."""
+    """Return the readable pytest configuration candidates committed at the red source.
+
+    Raises ``ValueError('stale-red-proof')`` when a candidate exists but exceeds the read
+    bound, because an unread configuration could declare plugins or roots this gate must bind.
+    """
     sources: list[tuple[str, str]] = []
     for path in PYTEST_CONFIGURATION_FILES:
         result = _git_bytes(repo_root, "show", f"{source_ref}:{path}")
-        if result.returncode != 0 or len(result.stdout) > MAX_TEST_BLOB_BYTES:
+        if result.returncode != 0:
             continue
+        if len(result.stdout) > MAX_TEST_BLOB_BYTES:
+            raise ValueError("stale-red-proof")
         sources.append((path, result.stdout.decode("utf-8", errors="surrogateescape")))
     return tuple(sources)
 
@@ -311,8 +317,12 @@ def _destructured_targets(target: ast.expr, value: ast.expr) -> list[tuple[str, 
 
 def _static_condition(test: ast.AST, type_checking_names: set[str], typing_module_names: set[str]) -> bool | None:
     """Return a known branch condition used during module loading."""
-    if isinstance(test, ast.Constant) and isinstance(test.value, bool):
-        return test.value
+    try:
+        # Any literal has known truthiness, so `if 0:`, `if None:`, and `if ():` are as
+        # static as `if False:`. A dynamic expression raises and stays runtime-unknown.
+        return bool(ast.literal_eval(test))
+    except (ValueError, TypeError):
+        pass
     if isinstance(test, ast.Name) and test.id in type_checking_names:
         return False
     if (
@@ -453,13 +463,43 @@ def _executable_scope_nodes(tree: ast.AST) -> list[ast.AST]:
     return nodes
 
 
+def _guard_attribute_targets(node: ast.AST) -> list[str]:
+    """Return module names whose ``TYPE_CHECKING`` attribute this statement writes."""
+    targets: list[ast.expr] = []
+    if isinstance(node, ast.Assign):
+        targets = list(node.targets)
+    elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+        targets = [node.target]
+    return [
+        target.value.id
+        for target in targets
+        if isinstance(target, ast.Attribute) and target.attr == "TYPE_CHECKING" and isinstance(target.value, ast.Name)
+    ]
+
+
+def _global_rebound_names(tree: ast.AST) -> set[str]:
+    """Return names a ``global`` declaration rebinds from inside a nested scope.
+
+    A class body executes during import and a ``global`` declaration makes its assignment
+    module-scoped, so such a binding is not confined to the nested scope.
+    """
+    nodes = list(ast.walk(tree))
+    declared = {name for node in nodes if isinstance(node, ast.Global) for name in node.names}
+    bound = {name for node in nodes for name, _ in _name_bindings(node)} | {
+        name for node in nodes for name in _compound_binding_names(node)
+    }
+    return declared & bound
+
+
 def _verified_type_checking_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
     """Return unrebound names imported from the typing module.
 
     Rebinding is detected across every node that executes at module load, including loop,
     context-manager, exception, and match targets, so a nested but reachable rebinding
     replaces the guard while a name bound only inside a function, lambda, or class body
-    does not. A guard is trusted only when imported directly at module scope.
+    does not — unless a ``global`` declaration makes that binding module-scoped. A module
+    guard is also dropped when its ``TYPE_CHECKING`` attribute is written directly. A guard
+    is trusted only when imported directly at module scope.
     """
     body = tree.body if isinstance(tree, ast.Module) else []
     nodes = _executable_scope_nodes(tree)
@@ -467,10 +507,12 @@ def _verified_type_checking_bindings(tree: ast.AST) -> tuple[set[str], set[str]]
         _other_import_names(nodes)
         | {name for node in nodes for name, _ in _name_bindings(node)}
         | {name for node in nodes for name in _compound_binding_names(node)}
+        | _global_rebound_names(tree)
     )
+    mutated_guard_names = {name for node in nodes for name in _guard_attribute_targets(node)}
     return (
         _imported_type_checking_names(body) - rebound_names,
-        _imported_typing_module_names(body) - rebound_names,
+        _imported_typing_module_names(body) - rebound_names - mutated_guard_names,
     )
 
 

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -500,50 +500,86 @@ def _globally_rebound_in(nodes: Sequence[ast.AST]) -> set[str]:
     return declared & bound
 
 
-def _called_names(nodes: Sequence[ast.AST]) -> set[str]:
-    """Return names invoked directly among the given nodes."""
-    return {node.func.id for node in nodes if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)}
+def _module_state_mutating_functions(tree: ast.AST) -> list[ast.AST]:
+    """Return function definitions whose body can change module state this gate depends on.
+
+    A ``global`` rebinding, a ``TYPE_CHECKING`` attribute write, or a ``pytest_plugins``
+    assignment inside a function all alter what pytest sees once that function runs.
+    """
+    definitions: list[ast.AST] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+            continue
+        body_nodes = list(ast.walk(node))
+        mutates = (
+            _globally_rebound_in(body_nodes)
+            or any(_guard_attribute_targets(child) for child in body_nodes)
+            or any(name == "pytest_plugins" for child in body_nodes for name, _ in _name_bindings(child))
+        )
+        if mutates:
+            definitions.append(node)
+    return definitions
+
+
+def _calls_during_module_load(tree: ast.AST) -> bool:
+    """Return whether the module invokes anything while it loads."""
+    return any(isinstance(node, ast.Call) for node in _executable_scope_nodes(tree, include_class_bodies=True))
+
+
+def _unverifiable_module_state(tree: ast.AST) -> bool:
+    """Return whether an invoked function could change module state before pytest reads it.
+
+    Resolving which function a module-load call reaches would require following aliases,
+    wrappers, decorators, and transitive calls, and any partial resolution silently accepts
+    the shapes it cannot follow. When a module both defines a state-mutating function and
+    calls anything while loading, the resulting state is therefore treated as unknown.
+    """
+    return bool(_module_state_mutating_functions(tree)) and _calls_during_module_load(tree)
 
 
 def _global_rebound_names(tree: ast.AST) -> set[str]:
     """Return names a ``global`` declaration rebinds while the module loads.
 
-    A class body executes during import, so a ``global`` binding there always applies. A
-    function body applies only when that function is invoked as the module loads, because
-    an uncalled definition never runs and must not drop the guard.
+    A class body executes during import, so a ``global`` binding there always applies.
+    Bindings inside function bodies are covered by ``_unverifiable_module_state`` instead,
+    because whether such a body runs cannot be decided by inspecting call names.
     """
-    executing_nodes = _executable_scope_nodes(tree, include_class_bodies=True)
-    rebound = _globally_rebound_in(executing_nodes)
-    called = _called_names(executing_nodes)
-    for node in ast.walk(tree):
-        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name in called:
-            rebound |= _globally_rebound_in(list(ast.walk(node)))
-    return rebound
+    return _globally_rebound_in(_executable_scope_nodes(tree, include_class_bodies=True))
 
 
-def _verified_type_checking_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
+def _nodes_before(nodes: Sequence[ast.AST], before_line: int | None) -> list[ast.AST]:
+    """Return the nodes that appear before a source line, or all of them when unbounded."""
+    if before_line is None:
+        return list(nodes)
+    return [node for node in nodes if getattr(node, "lineno", 0) < before_line]
+
+
+def _verified_type_checking_bindings(tree: ast.AST, before_line: int | None = None) -> tuple[set[str], set[str]]:
     """Return unrebound names imported from the typing module.
+
+    A rebinding only invalidates a guard used after it, so ``before_line`` bounds the scan to
+    statements that already ran; an unbounded call sees the whole module.
 
     Rebinding is detected across every node that executes at module load, including loop,
     context-manager, exception, and match targets, so a nested but reachable rebinding
     replaces the guard while a name bound only inside a function, lambda, or class body
     does not — unless a ``global`` declaration makes that binding module-scoped. A module
-    guard is also dropped when its ``TYPE_CHECKING`` attribute is written directly. A guard
-    is trusted only when imported directly at module scope.
+    guard is also dropped when its ``TYPE_CHECKING`` attribute is written directly, and no
+    guard is trusted at all when an invoked function could change module state. A guard is
+    trusted only when imported directly at module scope.
     """
     body = tree.body if isinstance(tree, ast.Module) else []
-    nodes = _executable_scope_nodes(tree)
+    if _unverifiable_module_state(tree):
+        return set(), set()
+    nodes = _nodes_before(_executable_scope_nodes(tree), before_line)
+    executing_nodes = _nodes_before(_executable_scope_nodes(tree, include_class_bodies=True), before_line)
     rebound_names = (
         _other_import_names(nodes)
         | {name for node in nodes for name, _ in _name_bindings(node)}
         | {name for node in nodes for name in _compound_binding_names(node)}
-        | _global_rebound_names(tree)
+        | _globally_rebound_in(executing_nodes)
     )
-    mutated_guard_names = {
-        name
-        for node in _executable_scope_nodes(tree, include_class_bodies=True)
-        for name in _guard_attribute_targets(node)
-    }
+    mutated_guard_names = {name for node in executing_nodes for name in _guard_attribute_targets(node)}
     return (
         _imported_type_checking_names(body) - rebound_names,
         _imported_typing_module_names(body) - rebound_names - mutated_guard_names,
@@ -552,7 +588,6 @@ def _verified_type_checking_bindings(tree: ast.AST) -> tuple[set[str], set[str]]
 
 def _module_scope_nodes(tree: ast.AST, *, include_class_bodies: bool = False) -> list[ast.AST]:
     """Return executable module nodes without entering deferred function scopes."""
-    type_checking_names, typing_module_names = _verified_type_checking_bindings(tree)
     pending = list(reversed(list(ast.iter_child_nodes(tree))))
     nodes: list[ast.AST] = []
     while pending:
@@ -566,7 +601,8 @@ def _module_scope_nodes(tree: ast.AST, *, include_class_bodies: bool = False) ->
             continue
         if (
             isinstance(node, ast.If)
-            and (condition := _static_condition(node.test, type_checking_names, typing_module_names)) is not None
+            and (condition := _static_condition(node.test, *_verified_type_checking_bindings(tree, node.lineno)))
+            is not None
         ):
             pending.extend(reversed(node.body if condition else node.orelse))
             continue
@@ -576,11 +612,10 @@ def _module_scope_nodes(tree: ast.AST, *, include_class_bodies: bool = False) ->
 
 def _conditional_assignment_ids(tree: ast.AST) -> set[int]:
     """Return assignments under branches whose runtime outcome is unknown."""
-    type_checking_names, typing_module_names = _verified_type_checking_bindings(tree)
     conditional_ids: set[int] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.If):
-            if _static_condition(node.test, type_checking_names, typing_module_names) is not None:
+            if _static_condition(node.test, *_verified_type_checking_bindings(tree, node.lineno)) is not None:
                 continue
             branch_nodes: tuple[ast.stmt, ...] = (*node.body, *node.orelse)
         elif isinstance(
@@ -667,6 +702,8 @@ def _pytest_plugin_names(tree: ast.AST) -> list[list[str]]:
     imported binding, including one a star import may supply, is treated as unresolved
     since its value lives in another module.
     """
+    if _unverifiable_module_state(tree):
+        raise ValueError("stale-red-proof")
     conditional_assignment_ids = _conditional_assignment_ids(tree)
     constants: dict[str, list[object]] = {}
     for node in _module_scope_nodes(tree):

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -1156,7 +1156,20 @@ def _literal_path_candidates(tree: ast.AST, current_path: str) -> list[str]:
         candidates.extend(itertools.chain.from_iterable(_literal_strings(argument) for argument in handed_over))
         if isinstance(node, ast.BinOp) and (joined := _joined_path_literal(node)) is not None:
             candidates.append(joined)
-    return [candidate.strip("/") for candidate in candidates if candidate.strip("/")]
+    return [stripped for candidate in candidates if _names_a_repository_path(stripped := candidate.strip("/"))]
+
+
+def _names_a_repository_path(candidate: str) -> bool:
+    """Return whether a literal could name a committed repository path at all.
+
+    Arbitrary strings reach here — a selector fixture, a shell fragment, a message — and they
+    are handed to Git as arguments. A control character cannot appear in a committed path, and
+    a null byte cannot even be passed to a subprocess, so such a literal is discarded before it
+    becomes a Git argument rather than raising out of the middle of the gate.
+    """
+    if not candidate or ".." in PurePosixPath(candidate).parts:
+        return False
+    return not any(character < " " or character == "\x7f" for character in candidate)
 
 
 def _harness_directories(selector_paths: Sequence[str]) -> tuple[str, ...]:

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -272,17 +272,21 @@ def _pytest_configuration_sources(
     return tuple(sources)
 
 
-def _addopts_plugin_names(value: object) -> list[list[str]]:
-    """Return module names early-loaded through ``-p`` in a configured ``addopts`` setting."""
+def _addopts_tokens(value: object) -> list[str]:
+    """Return the individual arguments of a configured ``addopts`` setting."""
     if isinstance(value, str):
         try:
-            tokens = shlex.split(value)
+            return shlex.split(value)
         except ValueError:
             return []
-    elif isinstance(value, list):
-        tokens = [token for token in cast(list[object], value) if isinstance(token, str)]
-    else:
-        return []
+    if isinstance(value, list):
+        return [token for token in cast(list[object], value) if isinstance(token, str)]
+    return []
+
+
+def _addopts_plugin_names(value: object) -> list[list[str]]:
+    """Return module names early-loaded through ``-p`` in a configured ``addopts`` setting."""
+    tokens = _addopts_tokens(value)
     names: list[str] = []
     expecting_name = False
     for token in tokens:
@@ -1244,6 +1248,8 @@ def _discovered_rooted_paths(
 
 
 MODULE_LOOKUP_FUNCTIONS = frozenset({"get", "setdefault", "import_module"})
+# Import modes that put a test file's own directory on sys.path. ``prepend`` is pytest's default.
+PREPENDING_IMPORT_MODES = frozenset({"prepend", "append"})
 PATH_JOIN_METHODS = frozenset({"join", "joinpath"})
 POSIX_PATH_MODULES = frozenset({"os", "posixpath", "ntpath"})
 PATH_PRESERVING_METHODS = frozenset({"resolve", "absolute", "expanduser"})
@@ -1576,9 +1582,45 @@ def _module_relative_path(path: str, module_root: str) -> str:
     return path.removeprefix(prefix) if module_root and path.startswith(prefix) else path
 
 
-def _import_roots(module_root: str) -> tuple[str, ...]:
-    """Return the roots an import inside a module discovered under one root may resolve against."""
-    return ("",) if not module_root else ("", module_root)
+def _import_roots(module_root: str, prepended_root: str | None = None) -> tuple[str, ...]:
+    """Return the roots an import inside a module may resolve against.
+
+    The repository root is always one, and a module discovered beneath a configured
+    ``pythonpath`` root resolves against that root as pytest does. The third is the directory
+    pytest itself puts on ``sys.path`` for this file, which is what makes a bare ``import
+    helper`` in a non-package test directory reach its sibling.
+    """
+    roots = ["", *([module_root] if module_root else []), *([prepended_root] if prepended_root else [])]
+    return tuple(dict.fromkeys(roots))
+
+
+def _configured_import_mode(repo_root: Path, source_ref: str, directories: tuple[str, ...]) -> str:
+    """Return the import mode the proof run uses, which decides whether a directory is prepended."""
+    for path, text in _pytest_configuration_sources(repo_root, source_ref, directories):
+        value = _pytest_ini_option(text, PurePosixPath(path).name, "addopts")
+        tokens = _addopts_tokens(value)
+        for index, token in enumerate(tokens):
+            if token.startswith("--import-mode="):
+                return token.partition("=")[2]
+            if token == "--import-mode" and index + 1 < len(tokens):
+                return tokens[index + 1]
+    return "prepend"
+
+
+def _prepended_root(repo_root: Path, source_ref: str, path: str) -> str:
+    """Return the directory pytest inserts on ``sys.path`` for one test or conftest file.
+
+    Pytest walks up from the file while each directory is a package, and prepends the first
+    directory that is not. Resolving this is what the enumeration of import roots was missing:
+    the roots are not a property of the repository, they are a property of each file's position
+    in it.
+    """
+    directory = PurePosixPath(path).parent
+    while directory != PurePosixPath(".") and _test_path_exists_at_ref(
+        repo_root, source_ref, (directory / "__init__.py").as_posix()
+    ):
+        directory = directory.parent
+    return "" if directory == PurePosixPath(".") else directory.as_posix()
 
 
 def _imported_python_paths(
@@ -1588,6 +1630,7 @@ def _imported_python_paths(
     *,
     plugin_module_roots: Sequence[str],
     selection: Mapping[str, frozenset[str]],
+    prepends_test_directories: bool,
 ) -> set[str]:
     """Return transitive repository-local Python imports used by pytest inputs.
 
@@ -1613,7 +1656,8 @@ def _imported_python_paths(
             if _test_path_exists_at_ref(repo_root, source_ref, current_path):
                 raise ValueError("stale-red-proof")
             continue
-        import_roots = _import_roots(module_root)
+        prepended_root = _prepended_root(repo_root, source_ref, current_path) if prepends_test_directories else None
+        import_roots = _import_roots(module_root, prepended_root)
         relative_path = _module_relative_path(current_path, module_root)
         skipped_scopes = _unexecuted_test_scopes(tree, selection.get(current_path, frozenset()))
         ordinary_rooted = _discovered_rooted_paths(
@@ -1882,7 +1926,13 @@ def _proof_inputs(
         *traversal_inputs,
         *(path for _, path in addopts_rooted),
         *_imported_python_paths(
-            repo_root, source_ref, seeds, plugin_module_roots=plugin_module_roots, selection=selection or {}
+            repo_root,
+            source_ref,
+            seeds,
+            plugin_module_roots=plugin_module_roots,
+            selection=selection or {},
+            prepends_test_directories=_configured_import_mode(repo_root, source_ref, configuration_directories)
+            in PREPENDING_IMPORT_MODES,
         ),
     }
     return {

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -520,6 +520,15 @@ def _call_argument_names(node: ast.AST) -> list[str]:
     return [argument.id for argument in arguments if isinstance(argument, ast.Name)]
 
 
+def _second_reference_names(nodes: Sequence[ast.AST]) -> set[str]:
+    """Return names copied into another binding, through which a later write is invisible.
+
+    ``alias = typing`` binds the same module object, so ``alias.TYPE_CHECKING = True``
+    rewrites the guard that ``typing`` also names while recording only ``alias``.
+    """
+    return {value.id for node in nodes for _, value in _name_bindings(node) if isinstance(value, ast.Name)}
+
+
 def _rewrites_attributes(nodes: Sequence[ast.AST]) -> bool:
     """Return whether these nodes rewrite an attribute through the ``setattr`` builtin."""
     return any(
@@ -622,9 +631,11 @@ def _verified_type_checking_bindings(tree: ast.AST, before_line: int | None = No
         | {name for node in nodes for name in _compound_binding_names(node)}
         | _globally_rebound_in(executing_nodes)
     )
-    mutated_guard_names = {name for node in executing_nodes for name in _guard_attribute_targets(node)} | {
-        name for node in executing_nodes for name in _call_argument_names(node)
-    }
+    mutated_guard_names = (
+        {name for node in executing_nodes for name in _guard_attribute_targets(node)}
+        | {name for node in executing_nodes for name in _call_argument_names(node)}
+        | _second_reference_names(executing_nodes)
+    )
     return (
         _imported_type_checking_names(body) - rebound_names,
         _imported_typing_module_names(body) - rebound_names - mutated_guard_names,
@@ -723,13 +734,39 @@ def _import_binding_names(node: ast.AST) -> list[str]:
     return []
 
 
+def _mutation_target_names(target: ast.expr) -> list[str]:
+    """Return the name a subscript or attribute write changes in place."""
+    if isinstance(target, (ast.Attribute, ast.Subscript)) and isinstance(target.value, ast.Name):
+        return [target.value.id]
+    return []
+
+
+def _write_targets(node: ast.AST) -> list[ast.expr]:
+    """Return the targets of one assignment or deletion statement."""
+    if isinstance(node, (ast.Assign, ast.Delete)):
+        return list(node.targets)
+    if isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+        return [node.target]
+    return []
+
+
 def _mutated_name_targets(node: ast.AST) -> list[str]:
-    """Return names this statement mutates in place, whose resulting value is unknown."""
-    return [
-        node.func.value.id
-        for node in ast.walk(node)
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name)
-    ]
+    """Return names this statement mutates in place, whose resulting value is unknown.
+
+    A method call, a subscript or attribute write, and a deletion all change the object a
+    name is bound to without rebinding the name itself, so a binding copied from it earlier
+    still observes the change.
+    """
+    names: list[str] = []
+    for child in ast.walk(node):
+        if (
+            isinstance(child, ast.Call)
+            and isinstance(child.func, ast.Attribute)
+            and isinstance(child.func.value, ast.Name)
+        ):
+            names.append(child.func.value.id)
+        names.extend(name for target in _write_targets(child) for name in _mutation_target_names(target))
+    return names
 
 
 def _aliased_names(constants: dict[str, list[object]], name: str) -> set[str]:
@@ -809,9 +846,15 @@ def _python_tree_at_ref(repo_root: Path, source_ref: str, path: str) -> ast.AST 
     Source is parsed as bytes so a PEP 263 encoding declaration is honoured rather than
     forcing a UTF-8 decode that would abort the gate on legally encoded modules. Results are
     cached because the content of a path at an immutable ref cannot change during one run.
+
+    The Git mode is checked independently of parsing, because a link text such as
+    ``real_conftest.py`` is itself valid Python and would otherwise parse as an attribute
+    expression while pytest executes the target instead.
     """
     result = _git_bytes(repo_root, "show", f"{source_ref}:{path}")
     if result.returncode != 0 or len(result.stdout) > MAX_TEST_BLOB_BYTES:
+        return None
+    if not _test_path_is_regular_at_ref(repo_root, source_ref, path):
         return None
     try:
         return ast.parse(result.stdout)

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -7,6 +7,7 @@ import ast
 import configparser
 import functools
 import hashlib
+import itertools
 import json
 import re
 import shlex
@@ -997,14 +998,67 @@ def _pytest_plugin_names(tree: ast.AST) -> list[list[str]]:
     return plugin_names
 
 
+def _deferred_scopes_are_reachable(tree: ast.AST, current_path: str) -> bool:
+    """Report whether a module's deferred bodies run during the pytest session.
+
+    Pytest invokes test and fixture bodies during the run, so their imports always execute.
+    Only a package initializer needs an import-time call to reach one of its own functions.
+    """
+    is_package_initializer = PurePosixPath(current_path).name == "__init__.py"
+    return not is_package_initializer or _calls_during_module_load(tree)
+
+
+def _literal_module_candidates(tree: ast.AST, current_path: str) -> list[list[str]]:
+    """Return module names spelled as string literals in a reachable body.
+
+    A dynamic import names its target in data rather than in the callee, so the mechanism is
+    not what identifies it: ``importlib.import_module``, ``__import__``, an alias, a wrapper, or
+    a name read out of a list all execute the same module. Resolving the literal itself covers
+    every such spelling without matching a mechanism by name — the matching that aliasing and
+    indirection defeat.
+
+    Two positions narrow the literals worth reading as names. It must be handed to a call,
+    because a string merely written down is not loaded by anyone — a ``pytest_plugins`` value in
+    a scope pytest ignores names a module that is never imported. And it must be dotted, because
+    a bare word is ordinary prose, the directory component in ``Path("src")``; reading those as
+    imports binds unrelated files and fails valid proofs with no legible cause. The cost is that
+    a single-part dynamic target resting directly on an import root stays unbound; that gap is
+    bounded, while prose is not. Because even a handed-over dotted literal may be prose, the
+    caller keeps only the names whose module exists at the red source.
+    """
+    names: list[list[str]] = []
+    reachable_bodies = _deferred_scopes_are_reachable(tree, current_path)
+    for node in _module_scope_nodes(tree, include_class_bodies=True, include_deferred_scopes=reachable_bodies):
+        if not isinstance(node, ast.Call):
+            continue
+        arguments = [*node.args, *(keyword.value for keyword in node.keywords)]
+        for value in itertools.chain.from_iterable(_literal_strings(argument) for argument in arguments):
+            parts = value.split(".")
+            if len(parts) > 1 and all(part.isidentifier() for part in parts):
+                names.append(parts)
+    return names
+
+
+def _literal_strings(expression: ast.expr) -> list[str]:
+    """Return the string literals an expression hands over, including through a literal group.
+
+    A loader is as often given a collection of names as a single one, and the elements of a
+    literal sequence are handed over just as directly as a bare argument is.
+    """
+    if isinstance(expression, ast.Constant):
+        return [expression.value] if isinstance(expression.value, str) else []
+    if isinstance(expression, (ast.List, ast.Tuple, ast.Set)):
+        return [value for element in expression.elts for value in _literal_strings(element)]
+    if isinstance(expression, ast.Dict):
+        return [value for element in expression.values for value in _literal_strings(element)]
+    return []
+
+
 def _import_module_names(tree: ast.AST, current_path: str) -> list[list[str]]:
     """Return imported module names, including relative import candidates."""
     current_package = list(PurePosixPath(current_path).parent.parts)
     module_names: list[list[str]] = []
-    # Pytest invokes test and fixture bodies during the run, so their imports always execute.
-    # Only a package initializer needs an import-time call to reach one of its own functions.
-    is_package_initializer = PurePosixPath(current_path).name == "__init__.py"
-    reachable_bodies = not is_package_initializer or _calls_during_module_load(tree)
+    reachable_bodies = _deferred_scopes_are_reachable(tree, current_path)
     for node in _module_scope_nodes(tree, include_class_bodies=True, include_deferred_scopes=reachable_bodies):
         if isinstance(node, ast.Import):
             module_names.extend(alias.name.split(".") for alias in node.names)
@@ -1051,6 +1105,27 @@ def _discovered_rooted_paths(
     }
 
 
+def _committed_module_names(
+    module_names: Sequence[Sequence[str]], module_roots: Sequence[str], repo_root: Path, source_ref: str
+) -> list[list[str]]:
+    """Return the module names whose own file is committed at the red source.
+
+    An ordinary ``import`` statement is proof that its target is imported, so its absent
+    candidates are bound as absent and a later addition invalidates the proof. A name merely
+    guessed from a string literal carries no such proof, so a name is kept only once the module
+    it points at exists. The test is the module's own file rather than any of the candidate
+    paths, because a parent package's ``__init__.py`` can exist while the named module does not.
+    """
+    return [
+        list(module_parts)
+        for module_parts in module_names
+        if any(
+            _test_path_exists_at_ref(repo_root, source_ref, path)
+            for path in _python_module_target_paths(module_parts, module_roots)
+        )
+    ]
+
+
 def _module_relative_path(path: str, module_root: str) -> str:
     """Return a path relative to the module root it was discovered under."""
     prefix = f"{module_root}/"
@@ -1093,9 +1168,14 @@ def _imported_python_paths(
             if _test_path_exists_at_ref(repo_root, source_ref, current_path):
                 raise ValueError("stale-red-proof")
             continue
-        ordinary_rooted = _discovered_rooted_paths(
-            _import_module_names(tree, _module_relative_path(current_path, module_root)),
-            _import_roots(module_root),
+        import_roots = _import_roots(module_root)
+        relative_path = _module_relative_path(current_path, module_root)
+        ordinary_rooted = _discovered_rooted_paths(_import_module_names(tree, relative_path), import_roots)
+        ordinary_rooted |= _discovered_rooted_paths(
+            _committed_module_names(
+                _literal_module_candidates(tree, relative_path), import_roots, repo_root, source_ref
+            ),
+            import_roots,
         )
         plugin_names = _pytest_plugin_names(tree) if inspect_pytest_plugins else []
         plugin_rooted = _discovered_rooted_paths(plugin_names, plugin_module_roots)

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -209,13 +209,15 @@ def _pytest_configuration_sources(repo_root: Path, source_ref: str) -> tuple[tup
 
     Raises ``ValueError('stale-red-proof')`` when a candidate exists but exceeds the read
     bound, because an unread configuration could declare plugins or roots this gate must bind.
+    A symlinked candidate is rejected on the same terms: pytest reads the target bytes, while
+    the blob at this path holds only the link text.
     """
     sources: list[tuple[str, str]] = []
     for path in PYTEST_CONFIGURATION_FILES:
         result = _git_bytes(repo_root, "show", f"{source_ref}:{path}")
         if result.returncode != 0:
             continue
-        if len(result.stdout) > MAX_TEST_BLOB_BYTES:
+        if len(result.stdout) > MAX_TEST_BLOB_BYTES or not _test_path_is_regular_at_ref(repo_root, source_ref, path):
             raise ValueError("stale-red-proof")
         sources.append((path, result.stdout.decode("utf-8", errors="surrogateescape")))
     return tuple(sources)
@@ -260,12 +262,26 @@ def _addopts_plugin_module_names(repo_root: Path, source_ref: str) -> tuple[tupl
 
 
 def _safe_module_root(root: str) -> str | None:
-    """Return a repository-relative module root, rejecting absolute or escaping entries."""
+    """Return a repository-relative module root, normalizing traversal within the repository.
+
+    Pytest resolves the configured entry against the rootdir, so ``a/../b`` names the root
+    ``b`` and must bind the plugins reachable through it. An absolute or escaping entry names
+    a tree outside the repository whose files no Git ref can bind, so it yields no root.
+    """
     path = PurePosixPath(root)
-    if path.is_absolute() or ".." in path.parts:
+    if path.is_absolute():
         return None
-    normalized = path.as_posix()
-    return "" if normalized == "." else normalized
+    parts: list[str] = []
+    for part in path.parts:
+        if part == ".":
+            continue
+        if part != "..":
+            parts.append(part)
+        elif parts:
+            parts.pop()
+        else:
+            return None
+    return "/".join(parts)
 
 
 @functools.cache
@@ -491,6 +507,26 @@ def _guard_attribute_targets(node: ast.AST) -> list[str]:
     ]
 
 
+def _call_argument_names(node: ast.AST) -> list[str]:
+    """Return module names handed to a call, which can rewrite any attribute they expose.
+
+    ``setattr(typing, "TYPE_CHECKING", True)`` and ``vars(typing)["TYPE_CHECKING"] = True``
+    both rewrite the guard without an attribute-assignment target, and resolving which calls
+    do so would need the callee's body, so passing the module at all drops the guard.
+    """
+    if not isinstance(node, ast.Call):
+        return []
+    arguments = [*node.args, *(keyword.value for keyword in node.keywords)]
+    return [argument.id for argument in arguments if isinstance(argument, ast.Name)]
+
+
+def _rewrites_attributes(nodes: Sequence[ast.AST]) -> bool:
+    """Return whether these nodes rewrite an attribute through the ``setattr`` builtin."""
+    return any(
+        isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "setattr" for node in nodes
+    )
+
+
 def _globally_rebound_in(nodes: Sequence[ast.AST]) -> set[str]:
     """Return names both declared ``global`` and bound among the given nodes."""
     declared = {name for node in nodes if isinstance(node, ast.Global) for name in node.names}
@@ -503,8 +539,9 @@ def _globally_rebound_in(nodes: Sequence[ast.AST]) -> set[str]:
 def _module_state_mutating_functions(tree: ast.AST) -> list[ast.AST]:
     """Return function definitions whose body can change module state this gate depends on.
 
-    A ``global`` rebinding, a ``TYPE_CHECKING`` attribute write, or a ``pytest_plugins``
-    assignment inside a function all alter what pytest sees once that function runs.
+    A ``global`` rebinding, a ``TYPE_CHECKING`` attribute write, a ``setattr`` rewrite, or a
+    ``pytest_plugins`` assignment inside a function all alter what pytest sees once that
+    function runs.
     """
     definitions: list[ast.AST] = []
     for node in ast.walk(tree):
@@ -514,6 +551,7 @@ def _module_state_mutating_functions(tree: ast.AST) -> list[ast.AST]:
         mutates = (
             _globally_rebound_in(body_nodes)
             or any(_guard_attribute_targets(child) for child in body_nodes)
+            or _rewrites_attributes(body_nodes)
             or any(name == "pytest_plugins" for child in body_nodes for name, _ in _name_bindings(child))
         )
         if mutates:
@@ -564,9 +602,10 @@ def _verified_type_checking_bindings(tree: ast.AST, before_line: int | None = No
     context-manager, exception, and match targets, so a nested but reachable rebinding
     replaces the guard while a name bound only inside a function, lambda, or class body
     does not — unless a ``global`` declaration makes that binding module-scoped. A module
-    guard is also dropped when its ``TYPE_CHECKING`` attribute is written directly, and no
-    guard is trusted at all when an invoked function could change module state. A guard is
-    trusted only when imported directly at module scope.
+    guard is also dropped when its ``TYPE_CHECKING`` attribute is written directly or when the
+    module itself is handed to a call that could rewrite it, and no guard is trusted at all
+    when an invoked function could change module state. A guard is trusted only when imported
+    directly at module scope.
     """
     body = tree.body if isinstance(tree, ast.Module) else []
     if _unverifiable_module_state(tree):
@@ -579,7 +618,9 @@ def _verified_type_checking_bindings(tree: ast.AST, before_line: int | None = No
         | {name for node in nodes for name in _compound_binding_names(node)}
         | _globally_rebound_in(executing_nodes)
     )
-    mutated_guard_names = {name for node in executing_nodes for name in _guard_attribute_targets(node)}
+    mutated_guard_names = {name for node in executing_nodes for name in _guard_attribute_targets(node)} | {
+        name for node in executing_nodes for name in _call_argument_names(node)
+    }
     return (
         _imported_type_checking_names(body) - rebound_names,
         _imported_typing_module_names(body) - rebound_names - mutated_guard_names,
@@ -687,6 +728,19 @@ def _mutated_name_targets(node: ast.AST) -> list[str]:
     ]
 
 
+def _aliased_names(constants: dict[str, list[object]], name: str) -> set[str]:
+    """Return every name recorded as the same mutable object as this one.
+
+    Assigning one name to another copies the reference, so mutating either changes both.
+    Only mutable containers are compared by identity, because equal immutable values may be
+    interned and share identity without sharing a binding.
+    """
+    mutated = [value for value in constants.get(name, []) if isinstance(value, (dict, list, set))]
+    return {
+        other for other, values in constants.items() if any(value is target for value in values for target in mutated)
+    }
+
+
 def _has_star_import(node: ast.AST) -> bool:
     """Return whether one statement imports an unknown set of names."""
     return isinstance(node, ast.ImportFrom) and any(alias.name == "*" for alias in node.names)
@@ -717,8 +771,8 @@ def _pytest_plugin_names(tree: ast.AST) -> list[list[str]]:
         for name in _import_binding_names(node):
             _record_constant(constants, name, UNRESOLVED_PLUGIN_VALUE, extends=False)
         for name in _mutated_name_targets(node):
-            if name in constants:
-                _record_constant(constants, name, UNRESOLVED_PLUGIN_VALUE, extends=True)
+            for aliased in _aliased_names(constants, name):
+                _record_constant(constants, aliased, UNRESOLVED_PLUGIN_VALUE, extends=True)
         if _has_star_import(node):
             _record_constant(constants, "pytest_plugins", UNRESOLVED_PLUGIN_VALUE, extends=True)
     plugin_names: list[list[str]] = []

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -187,12 +187,13 @@ def _pytest_ini_option(text: str, configuration_path: str, option: str) -> objec
     section = PYTEST_INI_SECTIONS.get(configuration_path)
     if section is None:
         return None
-    parser = configparser.ConfigParser()
+    # Interpolation is disabled because pytest accepts literal percent signs in option values.
+    parser = configparser.ConfigParser(interpolation=None)
     try:
         parser.read_string(text)
+        return parser.get(section, option, fallback=None)
     except configparser.Error:
         return None
-    return parser.get(section, option, fallback=None)
 
 
 @functools.cache
@@ -420,11 +421,25 @@ def _other_import_names(nodes: Sequence[ast.AST]) -> set[str]:
     return direct_imports | from_imports
 
 
+def _scope_header_nodes(node: ast.AST) -> list[ast.AST]:
+    """Return the parts of a scope-defining statement that execute where the statement appears.
+
+    Decorators, argument defaults, annotations, and base-class expressions run in the
+    enclosing scope even though the body does not, so a walrus in a default can rebind a
+    module name.
+    """
+    body = getattr(node, "body", [])
+    body_nodes = body if isinstance(body, list) else [body]
+    body_ids = {id(child) for child in cast(list[object], body_nodes)}
+    return [child for child in ast.iter_child_nodes(node) if id(child) not in body_ids]
+
+
 def _executable_scope_nodes(tree: ast.AST) -> list[ast.AST]:
-    """Return nodes that run at module load, without entering deferred or class scopes.
+    """Return nodes that run at module load, without entering deferred or class bodies.
 
     Function, lambda, and class bodies cannot rebind a module-level name, so names bound
-    there must not count as rebinding the typing guard.
+    there must not count as rebinding the typing guard. Their headers still execute in the
+    enclosing scope and are traversed.
     """
     pending = list(ast.iter_child_nodes(tree))
     nodes: list[ast.AST] = []
@@ -432,6 +447,7 @@ def _executable_scope_nodes(tree: ast.AST) -> list[ast.AST]:
         node = pending.pop()
         nodes.append(node)
         if isinstance(node, (ast.AsyncFunctionDef, ast.ClassDef, ast.FunctionDef, ast.Lambda)):
+            pending.extend(_scope_header_nodes(node))
             continue
         pending.extend(ast.iter_child_nodes(node))
     return nodes

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -451,19 +451,26 @@ def _scope_header_nodes(node: ast.AST) -> list[ast.AST]:
     return [child for child in ast.iter_child_nodes(node) if id(child) not in body_ids]
 
 
-def _executable_scope_nodes(tree: ast.AST) -> list[ast.AST]:
-    """Return nodes that run at module load, without entering deferred or class bodies.
+def _executable_scope_nodes(tree: ast.AST, *, include_class_bodies: bool = False) -> list[ast.AST]:
+    """Return nodes that run at module load, without entering deferred scopes.
 
-    Function, lambda, and class bodies cannot rebind a module-level name, so names bound
-    there must not count as rebinding the typing guard. Their headers still execute in the
-    enclosing scope and are traversed.
+    Function and lambda bodies do not run where they appear, and a class body binds class
+    attributes rather than module names, so neither counts as rebinding the typing guard.
+    Their headers still execute in the enclosing scope and are traversed. A class body is
+    included when the caller looks for module mutations rather than name bindings, because
+    the body does execute during import.
     """
+    deferred = (
+        (ast.AsyncFunctionDef, ast.FunctionDef, ast.Lambda)
+        if include_class_bodies
+        else (ast.AsyncFunctionDef, ast.ClassDef, ast.FunctionDef, ast.Lambda)
+    )
     pending = list(ast.iter_child_nodes(tree))
     nodes: list[ast.AST] = []
     while pending:
         node = pending.pop()
         nodes.append(node)
-        if isinstance(node, (ast.AsyncFunctionDef, ast.ClassDef, ast.FunctionDef, ast.Lambda)):
+        if isinstance(node, deferred):
             pending.extend(_scope_header_nodes(node))
             continue
         pending.extend(ast.iter_child_nodes(node))
@@ -516,7 +523,11 @@ def _verified_type_checking_bindings(tree: ast.AST) -> tuple[set[str], set[str]]
         | {name for node in nodes for name in _compound_binding_names(node)}
         | _global_rebound_names(tree)
     )
-    mutated_guard_names = {name for node in nodes for name in _guard_attribute_targets(node)}
+    mutated_guard_names = {
+        name
+        for node in _executable_scope_nodes(tree, include_class_bodies=True)
+        for name in _guard_attribute_targets(node)
+    }
     return (
         _imported_type_checking_names(body) - rebound_names,
         _imported_typing_module_names(body) - rebound_names - mutated_guard_names,
@@ -614,6 +625,15 @@ def _import_binding_names(node: ast.AST) -> list[str]:
     return []
 
 
+def _mutated_name_targets(node: ast.AST) -> list[str]:
+    """Return names this statement mutates in place, whose resulting value is unknown."""
+    return [
+        node.func.value.id
+        for node in ast.walk(node)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name)
+    ]
+
+
 def _has_star_import(node: ast.AST) -> bool:
     """Return whether one statement imports an unknown set of names."""
     return isinstance(node, ast.ImportFrom) and any(alias.name == "*" for alias in node.names)
@@ -641,6 +661,9 @@ def _pytest_plugin_names(tree: ast.AST) -> list[list[str]]:
             _record_constant(constants, name, UNRESOLVED_PLUGIN_VALUE, extends=True)
         for name in _import_binding_names(node):
             _record_constant(constants, name, UNRESOLVED_PLUGIN_VALUE, extends=False)
+        for name in _mutated_name_targets(node):
+            if name in constants:
+                _record_constant(constants, name, UNRESOLVED_PLUGIN_VALUE, extends=True)
         if _has_star_import(node):
             _record_constant(constants, "pytest_plugins", UNRESOLVED_PLUGIN_VALUE, extends=True)
     plugin_names: list[list[str]] = []
@@ -732,7 +755,9 @@ def _imported_python_paths(
         current_path, inspect_pytest_plugins, module_root = traversal
         tree = _python_tree_at_ref(repo_root, source_ref, current_path)
         if tree is None:
-            if _test_path_is_regular_at_ref(repo_root, source_ref, current_path):
+            # An existing input that is neither parseable nor a plain absent candidate cannot
+            # be verified: a symlink executes bytes this gate never inspected.
+            if _test_path_exists_at_ref(repo_root, source_ref, current_path):
                 raise ValueError("stale-red-proof")
             continue
         ordinary_rooted = _discovered_rooted_paths(

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -539,10 +539,13 @@ def _globally_rebound_in(nodes: Sequence[ast.AST]) -> set[str]:
 def _module_state_mutating_functions(tree: ast.AST) -> list[ast.AST]:
     """Return function definitions whose body can change module state this gate depends on.
 
-    A ``global`` rebinding, a ``TYPE_CHECKING`` attribute write, a ``setattr`` rewrite, or a
-    ``pytest_plugins`` assignment inside a function all alter what pytest sees once that
-    function runs.
+    A ``global`` rebinding, a ``TYPE_CHECKING`` attribute write, a ``setattr`` rewrite, a
+    call handed the typing module, or a ``pytest_plugins`` assignment inside a function all
+    alter what pytest sees once that function runs. The guard is tracked by the name it is
+    passed under rather than by the callee's name, because an aliased or wrapped rewriter
+    defeats any match on ``setattr`` alone.
     """
+    guard_names = _imported_typing_module_names(tree.body if isinstance(tree, ast.Module) else [])
     definitions: list[ast.AST] = []
     for node in ast.walk(tree):
         if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
@@ -552,6 +555,7 @@ def _module_state_mutating_functions(tree: ast.AST) -> list[ast.AST]:
             _globally_rebound_in(body_nodes)
             or any(_guard_attribute_targets(child) for child in body_nodes)
             or _rewrites_attributes(body_nodes)
+            or any(name in guard_names for child in body_nodes for name in _call_argument_names(child))
             or any(name == "pytest_plugins" for child in body_nodes for name, _ in _name_bindings(child))
         )
         if mutates:

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -157,7 +157,13 @@ def _pytest_plugin_names(tree: ast.AST) -> list[list[str]]:
             continue
         declared_plugins = [value] if isinstance(value, str) else value
         if isinstance(declared_plugins, (list, tuple)):
-            plugin_names.extend(plugin.split(".") for plugin in declared_plugins if isinstance(plugin, str))
+            plugin_names.extend(
+                plugin_name.strip().split(".")
+                for declaration in declared_plugins
+                if isinstance(declaration, str)
+                for plugin_name in declaration.split(",")
+                if plugin_name.strip()
+            )
     return plugin_names
 
 

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -99,22 +99,12 @@ def _selector_paths(report: dict[str, object]) -> tuple[str, list[str]]:
     return source_ref, sorted(paths)
 
 
-def _applicable_conftest_paths(test_path: str) -> set[str]:
-    """Return root and ancestor pytest support files that can affect a selected test."""
-    parent = PurePosixPath(test_path).parent
-    paths = {"conftest.py"}
-    while parent != PurePosixPath("."):
-        paths.add((parent / "conftest.py").as_posix())
-        parent = parent.parent
-    return paths
-
-
-def _parent_package_initializer_paths(path: str) -> set[str]:
-    """Return every possible parent package initializer for a Python path."""
+def _ancestor_file_paths(path: str, filename: str) -> set[str]:
+    """Return a root file candidate and the same file beneath every ancestor."""
     parent = PurePosixPath(path).parent
-    paths: set[str] = set()
+    paths = {filename}
     while parent != PurePosixPath("."):
-        paths.add((parent / "__init__.py").as_posix())
+        paths.add((parent / filename).as_posix())
         parent = parent.parent
     return paths
 
@@ -174,7 +164,7 @@ def _pytest_plugin_names(tree: ast.AST) -> list[list[str]]:
 def _import_module_names(tree: ast.AST, current_path: str) -> list[list[str]]:
     """Return imported module names, including relative import candidates."""
     current_package = list(PurePosixPath(current_path).parent.parts)
-    module_names = _pytest_plugin_names(tree)
+    module_names: list[list[str]] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             module_names.extend(alias.name.split(".") for alias in node.names)
@@ -195,22 +185,44 @@ def _python_tree_at_ref(repo_root: Path, source_ref: str, path: str) -> ast.AST 
         return None
 
 
-def _imported_python_paths(repo_root: Path, source_ref: str, source_paths: Sequence[str]) -> set[str]:
+def _discovered_python_paths(module_names: Sequence[Sequence[str]]) -> set[str]:
+    """Return every repository path candidate for discovered module names."""
+    return {path for module_parts in module_names for path in _python_module_paths(module_parts)}
+
+
+def _imported_python_paths(
+    repo_root: Path,
+    source_ref: str,
+    source_paths: Sequence[str],
+    *,
+    pytest_plugin_source_paths: set[str],
+) -> set[str]:
     """Return transitive repository-local Python imports used by pytest inputs."""
-    pending = list(source_paths)
+    pending = [(path, path in pytest_plugin_source_paths) for path in source_paths]
+    traversed_paths: set[tuple[str, bool]] = set()
     imported_paths: set[str] = set()
     while pending:
-        current_path = pending.pop()
+        current_path, inspect_pytest_plugins = pending.pop()
+        traversal = (current_path, inspect_pytest_plugins)
+        if traversal in traversed_paths:
+            continue
+        traversed_paths.add(traversal)
         tree = _python_tree_at_ref(repo_root, source_ref, current_path)
         if tree is None:
             continue
-        for module_parts in _import_module_names(tree, current_path):
-            for imported_path in _python_module_paths(module_parts):
-                if imported_path in imported_paths:
-                    continue
-                imported_paths.add(imported_path)
-                if _test_path_exists_at_ref(repo_root, source_ref, imported_path):
-                    pending.append(imported_path)
+        ordinary_paths = _discovered_python_paths(_import_module_names(tree, current_path))
+        plugin_paths = _discovered_python_paths(_pytest_plugin_names(tree)) if inspect_pytest_plugins else set()
+        imported_paths.update(ordinary_paths, plugin_paths)
+        pending.extend(
+            (imported_path, False)
+            for imported_path in ordinary_paths
+            if _test_path_exists_at_ref(repo_root, source_ref, imported_path)
+        )
+        pending.extend(
+            (plugin_path, True)
+            for plugin_path in plugin_paths
+            if _test_path_exists_at_ref(repo_root, source_ref, plugin_path)
+        )
     return imported_paths
 
 
@@ -436,14 +448,19 @@ def validate_prior_red_proof(red_proof_path: Path, repo_root: Path, *, base_ref:
             repo_root, source_ref, test_path
         ):
             return ["prior-red-proof-invalid"]
-        pytest_inputs = {test_path, *_applicable_conftest_paths(test_path)}
+        pytest_inputs = {test_path, *_ancestor_file_paths(test_path, "conftest.py")}
         initializer_inputs = {
-            initializer for path in pytest_inputs for initializer in _parent_package_initializer_paths(path)
+            initializer for path in pytest_inputs for initializer in _ancestor_file_paths(path, "__init__.py")
         }
         traversal_inputs = pytest_inputs | initializer_inputs
         proof_inputs = {
             *traversal_inputs,
-            *_imported_python_paths(repo_root, source_ref, sorted(traversal_inputs)),
+            *_imported_python_paths(
+                repo_root,
+                source_ref,
+                sorted(traversal_inputs),
+                pytest_plugin_source_paths=pytest_inputs,
+            ),
         }
         if not proof_inputs.isdisjoint(paths_after_red):
             return ["stale-red-proof"]

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -203,6 +203,17 @@ def _pytest_ini_option(text: str, configuration_path: str, option: str) -> objec
         return None
 
 
+def _configuration_candidate_paths(directories: Sequence[str]) -> set[str]:
+    """Return every configuration path pytest may read for these directories.
+
+    The returned set is bound as proof input, so adding or changing a nested candidate after
+    the red source invalidates the proof exactly as a root-level one does.
+    """
+    return {
+        f"{directory}/{name}" if directory else name for directory in directories for name in PYTEST_CONFIGURATION_FILES
+    }
+
+
 def _configuration_directories(selector_paths: Sequence[str]) -> tuple[str, ...]:
     """Return the repository root and every selector ancestor pytest may take configuration from.
 
@@ -375,7 +386,14 @@ def _pythonpath_roots(repo_root: Path, source_ref: str, directories: tuple[str, 
     roots: set[str] = set()
     for path, text in _pytest_configuration_sources(repo_root, source_ref, directories):
         entries = _pythonpath_entries(_pytest_ini_option(text, PurePosixPath(path).name, "pythonpath"))
-        roots.update(root for entry in entries if (root := _safe_module_root(entry, repo_root)) is not None)
+        # Pytest joins a relative entry to the declaring file's directory, so a nested
+        # configuration names a root beneath itself rather than beneath the repository root.
+        declaring_directory = PurePosixPath(path).parent
+        roots.update(
+            root
+            for entry in entries
+            if (root := _safe_module_root((declaring_directory / entry).as_posix(), repo_root)) is not None
+        )
     return (*REPOSITORY_ROOT_MODULE_ROOTS, *sorted(roots - set(REPOSITORY_ROOT_MODULE_ROOTS)))
 
 
@@ -918,6 +936,16 @@ def _aliased_names(constants: dict[str, list[object]], name: str) -> set[str]:
     }
 
 
+def _received_call_argument_names(node: ast.AST) -> list[str]:
+    """Return names handed to any call within this statement.
+
+    An unbound-method form such as ``list.append(P, ...)`` mutates the argument rather than
+    the receiver, so a declaration reached this way is no more knowable than one mutated
+    through its own method.
+    """
+    return [name for child in ast.walk(node) for name in _call_argument_names(child)]
+
+
 def _has_star_import(node: ast.AST) -> bool:
     """Return whether one statement imports an unknown set of names."""
     return isinstance(node, ast.ImportFrom) and any(alias.name == "*" for alias in node.names)
@@ -956,7 +984,7 @@ def _pytest_plugin_names(tree: ast.AST) -> list[list[str]]:
             _record_constant(constants, name, UNRESOLVED_PLUGIN_VALUE, extends=True)
         for name in _import_binding_names(node):
             _record_constant(constants, name, UNRESOLVED_PLUGIN_VALUE, extends=False)
-        for name in _mutated_name_targets(node):
+        for name in (*_mutated_name_targets(node), *_received_call_argument_names(node)):
             for aliased in _aliased_names(constants, name):
                 _record_constant(constants, aliased, UNRESOLVED_PLUGIN_VALUE, extends=True)
         if _has_star_import(node):
@@ -1294,7 +1322,7 @@ def _proof_inputs(repo_root: Path, source_ref: str, selector_paths: Sequence[str
     seeds += [(path, (root, path) in addopts_targets, root) for root, path in sorted(addopts_rooted)]
     return {
         *traversal_inputs,
-        *PYTEST_CONFIGURATION_FILES,
+        *_configuration_candidate_paths(configuration_directories),
         *(path for _, path in addopts_rooted),
         *_imported_python_paths(
             repo_root,

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -425,10 +425,13 @@ def validate_prior_red_proof(red_proof_path: Path, repo_root: Path, *, base_ref:
         ):
             return ["prior-red-proof-invalid"]
         pytest_inputs = {test_path, *_applicable_conftest_paths(test_path)}
+        initializer_inputs = {
+            initializer for path in pytest_inputs for initializer in _parent_package_initializer_paths(path)
+        }
+        traversal_inputs = pytest_inputs | initializer_inputs
         proof_inputs = {
-            *pytest_inputs,
-            *(initializer for path in pytest_inputs for initializer in _parent_package_initializer_paths(path)),
-            *_imported_python_paths(repo_root, source_ref, sorted(pytest_inputs)),
+            *traversal_inputs,
+            *_imported_python_paths(repo_root, source_ref, sorted(traversal_inputs)),
         }
         if not proof_inputs.isdisjoint(paths_after_red):
             return ["stale-red-proof"]

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -491,18 +491,34 @@ def _guard_attribute_targets(node: ast.AST) -> list[str]:
     ]
 
 
-def _global_rebound_names(tree: ast.AST) -> set[str]:
-    """Return names a ``global`` declaration rebinds from inside a nested scope.
-
-    A class body executes during import and a ``global`` declaration makes its assignment
-    module-scoped, so such a binding is not confined to the nested scope.
-    """
-    nodes = list(ast.walk(tree))
+def _globally_rebound_in(nodes: Sequence[ast.AST]) -> set[str]:
+    """Return names both declared ``global`` and bound among the given nodes."""
     declared = {name for node in nodes if isinstance(node, ast.Global) for name in node.names}
     bound = {name for node in nodes for name, _ in _name_bindings(node)} | {
         name for node in nodes for name in _compound_binding_names(node)
     }
     return declared & bound
+
+
+def _called_names(nodes: Sequence[ast.AST]) -> set[str]:
+    """Return names invoked directly among the given nodes."""
+    return {node.func.id for node in nodes if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)}
+
+
+def _global_rebound_names(tree: ast.AST) -> set[str]:
+    """Return names a ``global`` declaration rebinds while the module loads.
+
+    A class body executes during import, so a ``global`` binding there always applies. A
+    function body applies only when that function is invoked as the module loads, because
+    an uncalled definition never runs and must not drop the guard.
+    """
+    executing_nodes = _executable_scope_nodes(tree, include_class_bodies=True)
+    rebound = _globally_rebound_in(executing_nodes)
+    called = _called_names(executing_nodes)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name in called:
+            rebound |= _globally_rebound_in(list(ast.walk(node)))
+    return rebound
 
 
 def _verified_type_checking_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
@@ -545,6 +561,8 @@ def _module_scope_nodes(tree: ast.AST, *, include_class_bodies: bool = False) ->
         deferred_scope = isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef, ast.Lambda))
         excluded_class_scope = isinstance(node, ast.ClassDef) and not include_class_bodies
         if deferred_scope or excluded_class_scope:
+            # The body does not run here, but decorators, defaults, and bases do.
+            pending.extend(reversed(_scope_header_nodes(node)))
             continue
         if (
             isinstance(node, ast.If)

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -142,10 +142,22 @@ def _assigned_value(node: ast.AST, name: str) -> ast.AST | None:
     return None
 
 
+def _module_scope_nodes(tree: ast.AST) -> list[ast.AST]:
+    """Return nodes executed at module scope without entering nested scopes."""
+    pending = list(ast.iter_child_nodes(tree))
+    nodes: list[ast.AST] = []
+    while pending:
+        node = pending.pop()
+        nodes.append(node)
+        if not isinstance(node, (ast.AsyncFunctionDef, ast.ClassDef, ast.FunctionDef, ast.Lambda)):
+            pending.extend(ast.iter_child_nodes(node))
+    return nodes
+
+
 def _pytest_plugin_names(tree: ast.AST) -> list[list[str]]:
     """Return statically declared ``pytest_plugins`` module names."""
     plugin_names: list[list[str]] = []
-    for node in ast.walk(tree):
+    for node in _module_scope_nodes(tree):
         value_node = _assigned_value(node, "pytest_plugins")
         if value_node is None:
             continue

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -137,6 +137,17 @@ def _assigned_value(node: ast.AST, name: str) -> ast.AST | None:
     return None
 
 
+def _static_condition(test: ast.AST) -> bool | None:
+    """Return a known branch condition used during module loading."""
+    if isinstance(test, ast.Constant) and isinstance(test.value, bool):
+        return test.value
+    if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
+        return False
+    if isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING":
+        return False
+    return None
+
+
 def _module_scope_nodes(tree: ast.AST, *, include_class_bodies: bool = False) -> list[ast.AST]:
     """Return executable module nodes without entering deferred function scopes."""
     pending = list(ast.iter_child_nodes(tree))
@@ -146,21 +157,44 @@ def _module_scope_nodes(tree: ast.AST, *, include_class_bodies: bool = False) ->
         nodes.append(node)
         deferred_scope = isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef, ast.Lambda))
         excluded_class_scope = isinstance(node, ast.ClassDef) and not include_class_bodies
-        if not deferred_scope and not excluded_class_scope:
-            pending.extend(ast.iter_child_nodes(node))
+        if deferred_scope or excluded_class_scope:
+            continue
+        if isinstance(node, ast.If) and (condition := _static_condition(node.test)) is not None:
+            pending.extend(node.body if condition else node.orelse)
+            continue
+        pending.extend(ast.iter_child_nodes(node))
     return nodes
+
+
+def _literal_module_constants(nodes: Sequence[ast.AST]) -> dict[str, object]:
+    """Return simple module names whose assigned values are Python literals."""
+    constants: dict[str, object] = {}
+    for node in nodes:
+        assignments: list[tuple[str, ast.AST]] = []
+        if isinstance(node, ast.Assign):
+            assignments.extend((target.id, node.value) for target in node.targets if isinstance(target, ast.Name))
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.value is not None:
+            assignments.append((node.target.id, node.value))
+        for name, value_node in assignments:
+            try:
+                constants[name] = ast.literal_eval(value_node)
+            except (ValueError, TypeError):
+                continue
+    return constants
 
 
 def _pytest_plugin_names(tree: ast.AST) -> list[list[str]]:
     """Return statically declared ``pytest_plugins`` module names."""
     plugin_names: list[list[str]] = []
-    for node in _module_scope_nodes(tree):
+    module_nodes = _module_scope_nodes(tree)
+    constants = _literal_module_constants(module_nodes)
+    for node in module_nodes:
         value_node = _assigned_value(node, "pytest_plugins")
         if value_node is None:
             continue
         try:
-            value = ast.literal_eval(value_node)
-        except (ValueError, TypeError):
+            value = constants[value_node.id] if isinstance(value_node, ast.Name) else ast.literal_eval(value_node)
+        except (KeyError, ValueError, TypeError):
             continue
         declared_plugins = [value] if isinstance(value, str) else value
         if isinstance(declared_plugins, (list, tuple)):

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -9,6 +9,7 @@ import functools
 import hashlib
 import json
 import re
+import shlex
 import subprocess
 import sys
 import tomllib
@@ -141,27 +142,80 @@ def _pythonpath_entries(value: object) -> list[str]:
     return []
 
 
-def _toml_pythonpath(text: str) -> list[str]:
-    """Return ``pythonpath`` declared under ``[tool.pytest.ini_options]``."""
+def _toml_ini_option(text: str, option: str) -> object | None:
+    """Return one option declared under ``[tool.pytest.ini_options]``."""
     try:
         node: object = tomllib.loads(text)
     except (tomllib.TOMLDecodeError, ValueError):
-        return []
-    for key in ("tool", "pytest", "ini_options", "pythonpath"):
+        return None
+    for key in ("tool", "pytest", "ini_options", option):
         if not isinstance(node, dict):
-            return []
+            return None
         node = cast(dict[str, object], node).get(key)
-    return _pythonpath_entries(node)
+    return node
 
 
-def _ini_pythonpath(text: str, section: str) -> list[str]:
-    """Return ``pythonpath`` declared in an ini-style pytest configuration section."""
+def _pytest_ini_option(text: str, configuration_path: str, option: str) -> object | None:
+    """Return one pytest ini option from a TOML or ini-style configuration source."""
+    section = PYTEST_INI_SECTIONS.get(configuration_path)
+    if section is None:
+        return _toml_ini_option(text, option)
     parser = configparser.ConfigParser()
     try:
         parser.read_string(text)
     except configparser.Error:
+        return None
+    return parser.get(section, option, fallback=None)
+
+
+@functools.cache
+def _pytest_configuration_sources(repo_root: Path, source_ref: str) -> tuple[tuple[str, str], ...]:
+    """Return the readable pytest configuration candidates committed at the red source."""
+    sources: list[tuple[str, str]] = []
+    for path in PYTEST_CONFIGURATION_FILES:
+        result = _git_bytes(repo_root, "show", f"{source_ref}:{path}")
+        if result.returncode != 0 or len(result.stdout) > MAX_TEST_BLOB_BYTES:
+            continue
+        sources.append((path, result.stdout.decode("utf-8", errors="surrogateescape")))
+    return tuple(sources)
+
+
+def _addopts_plugin_names(value: object) -> list[list[str]]:
+    """Return module names early-loaded through ``-p`` in a configured ``addopts`` setting."""
+    if isinstance(value, str):
+        try:
+            tokens = shlex.split(value)
+        except ValueError:
+            return []
+    elif isinstance(value, list):
+        tokens = [token for token in cast(list[object], value) if isinstance(token, str)]
+    else:
         return []
-    return _pythonpath_entries(parser.get(section, "pythonpath", fallback=None))
+    names: list[str] = []
+    expecting_name = False
+    for token in tokens:
+        if expecting_name:
+            names.append(token)
+            expecting_name = False
+        elif token == "-p":
+            expecting_name = True
+        elif token.startswith("-p") and len(token) > 2:
+            names.append(token.removeprefix("-p"))
+    return [name.split(".") for name in names if name and not name.startswith("no:")]
+
+
+@functools.cache
+def _addopts_plugin_module_names(repo_root: Path, source_ref: str) -> tuple[tuple[str, ...], ...]:
+    """Return plugin module names early-loaded by configured ``addopts`` at the red source.
+
+    ``-p name`` loads a plugin module regardless of autoload settings, so a repository-local
+    module named there decides collection exactly as a declared ``pytest_plugins`` entry does.
+    """
+    names: set[tuple[str, ...]] = set()
+    for path, text in _pytest_configuration_sources(repo_root, source_ref):
+        for parts in _addopts_plugin_names(_pytest_ini_option(text, path, "addopts")):
+            names.add(tuple(parts))
+    return tuple(sorted(names))
 
 
 def _safe_module_root(root: str) -> str | None:
@@ -181,13 +235,8 @@ def _pythonpath_roots(repo_root: Path, source_ref: str) -> tuple[str, ...]:
     precedence, because binding a root pytest did not use only widens the proof inputs.
     """
     roots: set[str] = set()
-    for path in PYTEST_CONFIGURATION_FILES:
-        result = _git_bytes(repo_root, "show", f"{source_ref}:{path}")
-        if result.returncode != 0 or len(result.stdout) > MAX_TEST_BLOB_BYTES:
-            continue
-        text = result.stdout.decode("utf-8", errors="surrogateescape")
-        section = PYTEST_INI_SECTIONS.get(path)
-        entries = _ini_pythonpath(text, section) if section else _toml_pythonpath(text)
+    for path, text in _pytest_configuration_sources(repo_root, source_ref):
+        entries = _pythonpath_entries(_pytest_ini_option(text, path, "pythonpath"))
         roots.update(root for entry in entries if (root := _safe_module_root(entry)) is not None)
     return (*REPOSITORY_ROOT_MODULE_ROOTS, *sorted(roots - set(REPOSITORY_ROOT_MODULE_ROOTS)))
 
@@ -230,11 +279,6 @@ def _destructured_targets(target: ast.expr, value: ast.expr) -> list[tuple[str, 
             for binding in _destructured_targets(element, element_value)
         ]
     return []
-
-
-def _assigned_value_nodes(node: ast.AST, name: str) -> list[ast.expr]:
-    """Return every value statically bound to a named variable by one statement."""
-    return [value for bound_name, value in _name_bindings(node) if bound_name == name]
 
 
 def _static_condition(test: ast.AST, type_checking_names: set[str], typing_module_names: set[str]) -> bool | None:
@@ -349,15 +393,33 @@ def _other_import_names(nodes: Sequence[ast.AST]) -> set[str]:
     return direct_imports | from_imports
 
 
+def _executable_scope_nodes(tree: ast.AST) -> list[ast.AST]:
+    """Return nodes that run at module load, without entering deferred or class scopes.
+
+    Function, lambda, and class bodies cannot rebind a module-level name, so names bound
+    there must not count as rebinding the typing guard.
+    """
+    pending = list(ast.iter_child_nodes(tree))
+    nodes: list[ast.AST] = []
+    while pending:
+        node = pending.pop()
+        nodes.append(node)
+        if isinstance(node, (ast.AsyncFunctionDef, ast.ClassDef, ast.FunctionDef, ast.Lambda)):
+            continue
+        pending.extend(ast.iter_child_nodes(node))
+    return nodes
+
+
 def _verified_type_checking_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
     """Return unrebound names imported from the typing module.
 
-    Rebinding is detected across the whole tree because an assignment or an import anywhere
-    in the module may replace the guard, while a guard is only trusted when it is imported
+    Rebinding is detected across every node that executes at module load, so a nested but
+    reachable assignment or import replaces the guard, while a name bound only inside a
+    function, lambda, or class body does not. A guard is trusted only when imported
     directly at module scope.
     """
     body = tree.body if isinstance(tree, ast.Module) else []
-    nodes = list(ast.walk(tree))
+    nodes = _executable_scope_nodes(tree)
     rebound_names = _other_import_names(nodes) | {name for node in nodes for name, _ in _name_bindings(node)}
     return (
         _imported_type_checking_names(body) - rebound_names,
@@ -450,28 +512,26 @@ def _record_constant(constants: dict[str, list[object]], name: str, value: objec
 def _pytest_plugin_names(tree: ast.AST) -> list[list[str]]:
     """Return statically declared ``pytest_plugins`` module names.
 
-    Raises ``ValueError('stale-red-proof')`` when an active declaration cannot be resolved,
-    because an unverifiable plugin set cannot prove the retained failure is still current.
+    Only the final possible binding is reported, because pytest reads the attribute after
+    the module is imported, so an assignment that a later one overwrites never loads.
+    Raises ``ValueError('stale-red-proof')`` when that binding cannot be resolved, because
+    an unverifiable plugin set cannot prove the retained failure is still current.
     """
-    plugin_names: list[list[str]] = []
-    module_nodes = _module_scope_nodes(tree)
     conditional_assignment_ids = _conditional_assignment_ids(tree)
     constants: dict[str, list[object]] = {}
-    for node in module_nodes:
-        for value_node in _assigned_value_nodes(node, "pytest_plugins"):
-            for value in _resolved_literals(value_node, constants):
-                if value is UNRESOLVED_PLUGIN_VALUE:
-                    raise ValueError("stale-red-proof")
-                plugin_names.extend(_plugin_parts(value))
+    for node in _module_scope_nodes(tree):
         for name, assigned_node in _name_bindings(node):
-            try:
-                value = ast.literal_eval(assigned_node)
-            except (ValueError, TypeError):
-                value = UNRESOLVED_PLUGIN_VALUE
             extends = id(node) in conditional_assignment_ids or bool(_augmented_assignments(node))
-            _record_constant(constants, name, value, extends=extends)
+            for value in _resolved_literals(assigned_node, constants):
+                _record_constant(constants, name, value, extends=extends)
+                extends = True
         for name in _compound_binding_names(node):
             _record_constant(constants, name, UNRESOLVED_PLUGIN_VALUE, extends=True)
+    plugin_names: list[list[str]] = []
+    for value in constants.get("pytest_plugins", []):
+        if value is UNRESOLVED_PLUGIN_VALUE:
+            raise ValueError("stale-red-proof")
+        plugin_names.extend(_plugin_parts(value))
     return plugin_names
 
 
@@ -737,7 +797,8 @@ def _proof_inputs(repo_root: Path, source_ref: str, selector_paths: Sequence[str
     """Return every committed path whose change after the red source would invalidate the proof.
 
     Selectors are resolved together so their shared conftest, initializer, and import graph is
-    traversed once for the whole proof.
+    traversed once for the whole proof. Plugins early-loaded through configured ``addopts``
+    ``-p`` options are seeded alongside them, because pytest loads those modules too.
     """
     pytest_inputs = {
         path for test_path in selector_paths for path in (test_path, *_ancestor_file_paths(test_path, "conftest.py"))
@@ -746,15 +807,24 @@ def _proof_inputs(repo_root: Path, source_ref: str, selector_paths: Sequence[str
         initializer for path in pytest_inputs for initializer in _ancestor_file_paths(path, "__init__.py")
     }
     traversal_inputs = pytest_inputs | initializer_inputs
+    plugin_module_roots = _pythonpath_roots(repo_root, source_ref)
+    addopts_names = _addopts_plugin_module_names(repo_root, source_ref)
+    addopts_paths = _discovered_python_paths(addopts_names, plugin_module_roots)
+    addopts_targets = {
+        path
+        for module_parts in addopts_names
+        for path in _python_module_target_paths(module_parts, plugin_module_roots)
+    }
     return {
         *traversal_inputs,
         *PYTEST_CONFIGURATION_FILES,
+        *addopts_paths,
         *_imported_python_paths(
             repo_root,
             source_ref,
-            sorted(traversal_inputs),
-            pytest_plugin_source_paths=pytest_inputs,
-            plugin_module_roots=_pythonpath_roots(repo_root, source_ref),
+            sorted(traversal_inputs | addopts_paths),
+            pytest_plugin_source_paths=pytest_inputs | addopts_targets,
+            plugin_module_roots=plugin_module_roots,
         ),
     }
 

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import argparse
 import ast
+import configparser
 import functools
 import hashlib
 import json
 import re
 import subprocess
 import sys
+import tomllib
 from collections.abc import Sequence
 from pathlib import Path, PurePosixPath
 from typing import cast
@@ -36,6 +38,8 @@ GOVERNED_PRODUCTION_PREFIXES = (
 )
 GOVERNED_PRODUCTION_FILES = {"pyproject.toml", "setup.py", "uv.lock", "requirements/ci/locked.txt"}
 PYTEST_CONFIGURATION_FILES = ("pyproject.toml", "pytest.ini", "setup.cfg", "tox.ini")
+PYTEST_INI_SECTIONS = {"pytest.ini": "pytest", "setup.cfg": "tool:pytest", "tox.ini": "pytest"}
+REPOSITORY_ROOT_MODULE_ROOTS = ("",)
 GIT_TIMEOUT_SECONDS = 30
 UNRESOLVED_PLUGIN_VALUE = object()
 
@@ -128,20 +132,86 @@ def _ancestor_file_paths(path: str, filename: str) -> set[str]:
     return paths
 
 
-def _python_module_target_paths(module_parts: Sequence[str]) -> set[str]:
-    """Return the file and package targets for a repository-local module name."""
+def _pythonpath_entries(value: object) -> list[str]:
+    """Return the individual roots of a pytest ``pythonpath`` setting."""
+    if isinstance(value, str):
+        return value.split()
+    if isinstance(value, list):
+        return [entry for entry in cast(list[object], value) if isinstance(entry, str)]
+    return []
+
+
+def _toml_pythonpath(text: str) -> list[str]:
+    """Return ``pythonpath`` declared under ``[tool.pytest.ini_options]``."""
+    try:
+        node: object = tomllib.loads(text)
+    except (tomllib.TOMLDecodeError, ValueError):
+        return []
+    for key in ("tool", "pytest", "ini_options", "pythonpath"):
+        if not isinstance(node, dict):
+            return []
+        node = cast(dict[str, object], node).get(key)
+    return _pythonpath_entries(node)
+
+
+def _ini_pythonpath(text: str, section: str) -> list[str]:
+    """Return ``pythonpath`` declared in an ini-style pytest configuration section."""
+    parser = configparser.ConfigParser()
+    try:
+        parser.read_string(text)
+    except configparser.Error:
+        return []
+    return _pythonpath_entries(parser.get(section, "pythonpath", fallback=None))
+
+
+def _safe_module_root(root: str) -> str | None:
+    """Return a repository-relative module root, rejecting absolute or escaping entries."""
+    path = PurePosixPath(root)
+    if path.is_absolute() or ".." in path.parts:
+        return None
+    normalized = path.as_posix()
+    return "" if normalized == "." else normalized
+
+
+@functools.cache
+def _pythonpath_roots(repo_root: Path, source_ref: str) -> tuple[str, ...]:
+    """Return module roots configured through pytest ``pythonpath`` at the red source.
+
+    Every configuration candidate is read rather than replicating pytest's inifile
+    precedence, because binding a root pytest did not use only widens the proof inputs.
+    """
+    roots: set[str] = set()
+    for path in PYTEST_CONFIGURATION_FILES:
+        result = _git_bytes(repo_root, "show", f"{source_ref}:{path}")
+        if result.returncode != 0 or len(result.stdout) > MAX_TEST_BLOB_BYTES:
+            continue
+        text = result.stdout.decode("utf-8", errors="surrogateescape")
+        section = PYTEST_INI_SECTIONS.get(path)
+        entries = _ini_pythonpath(text, section) if section else _toml_pythonpath(text)
+        roots.update(root for entry in entries if (root := _safe_module_root(entry)) is not None)
+    return (*REPOSITORY_ROOT_MODULE_ROOTS, *sorted(roots - set(REPOSITORY_ROOT_MODULE_ROOTS)))
+
+
+def _rooted_path(root: str, relative: str) -> str:
+    """Return a repository-relative path beneath one module root."""
+    return f"{root}/{relative}" if root else relative
+
+
+def _python_module_target_paths(module_parts: Sequence[str], module_roots: Sequence[str]) -> set[str]:
+    """Return the file and package targets for a repository-local module name under each root."""
     if not module_parts:
         return set()
     module_path = PurePosixPath(*module_parts)
-    return {module_path.with_suffix(".py").as_posix(), (module_path / "__init__.py").as_posix()}
+    relatives = (module_path.with_suffix(".py").as_posix(), (module_path / "__init__.py").as_posix())
+    return {_rooted_path(root, relative) for root in module_roots for relative in relatives}
 
 
-def _python_module_paths(module_parts: Sequence[str]) -> set[str]:
+def _python_module_paths(module_parts: Sequence[str], module_roots: Sequence[str]) -> set[str]:
     """Return possible paths for a repository-local module, including its parent packages."""
-    paths = _python_module_target_paths(module_parts)
+    paths = _python_module_target_paths(module_parts, module_roots)
     for parent_depth in range(1, len(module_parts)):
         parent_path = PurePosixPath(*module_parts[:parent_depth])
-        paths.add((parent_path / "__init__.py").as_posix())
+        paths.update(_rooted_path(root, (parent_path / "__init__.py").as_posix()) for root in module_roots)
     return paths
 
 
@@ -401,9 +471,9 @@ def _python_tree_at_ref(repo_root: Path, source_ref: str, path: str) -> ast.AST 
         return None
 
 
-def _discovered_python_paths(module_names: Sequence[Sequence[str]]) -> set[str]:
+def _discovered_python_paths(module_names: Sequence[Sequence[str]], module_roots: Sequence[str]) -> set[str]:
     """Return every repository path candidate for discovered module names."""
-    return {path for module_parts in module_names for path in _python_module_paths(module_parts)}
+    return {path for module_parts in module_names for path in _python_module_paths(module_parts, module_roots)}
 
 
 def _imported_python_paths(
@@ -412,8 +482,14 @@ def _imported_python_paths(
     source_paths: Sequence[str],
     *,
     pytest_plugin_source_paths: set[str],
+    plugin_module_roots: Sequence[str],
 ) -> set[str]:
-    """Return transitive repository-local Python imports used by pytest inputs."""
+    """Return transitive repository-local Python imports used by pytest inputs.
+
+    Configured ``pythonpath`` roots widen plugin resolution only. Ordinary imports stay
+    anchored at the repository root, because resolving them through a root such as ``src``
+    would bind governed production modules that a red-to-green change is expected to edit.
+    """
     pending = [(path, path in pytest_plugin_source_paths) for path in source_paths]
     traversed_paths: set[tuple[str, bool]] = set()
     imported_paths: set[str] = set()
@@ -426,11 +502,15 @@ def _imported_python_paths(
         tree = _python_tree_at_ref(repo_root, source_ref, current_path)
         if tree is None:
             continue
-        ordinary_paths = _discovered_python_paths(_import_module_names(tree, current_path))
+        ordinary_paths = _discovered_python_paths(
+            _import_module_names(tree, current_path), REPOSITORY_ROOT_MODULE_ROOTS
+        )
         plugin_names = _pytest_plugin_names(tree) if inspect_pytest_plugins else []
-        plugin_paths = _discovered_python_paths(plugin_names)
+        plugin_paths = _discovered_python_paths(plugin_names, plugin_module_roots)
         plugin_target_paths = {
-            path for module_parts in plugin_names for path in _python_module_target_paths(module_parts)
+            path
+            for module_parts in plugin_names
+            for path in _python_module_target_paths(module_parts, plugin_module_roots)
         }
         imported_paths.update(ordinary_paths, plugin_paths)
         pending.extend(
@@ -635,6 +715,7 @@ def _proof_inputs(repo_root: Path, source_ref: str, selector_paths: Sequence[str
             source_ref,
             sorted(traversal_inputs),
             pytest_plugin_source_paths=pytest_inputs,
+            plugin_module_roots=_pythonpath_roots(repo_root, source_ref),
         ),
     }
 

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -206,7 +206,9 @@ def _other_import_names(body: Sequence[ast.stmt]) -> set[str]:
 def _verified_type_checking_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
     """Return unrebound names imported from the typing module."""
     body = tree.body if isinstance(tree, ast.Module) else []
-    rebound_names = _other_import_names(body) | {name for node in body for name, _ in _simple_assignments(node)}
+    rebound_names = _other_import_names(body) | {
+        name for node in ast.walk(tree) for name, _ in _simple_assignments(node)
+    }
     return (
         _imported_type_checking_names(body) - rebound_names,
         _imported_typing_module_names(body) - rebound_names,
@@ -235,12 +237,32 @@ def _module_scope_nodes(tree: ast.AST, *, include_class_bodies: bool = False) ->
     return nodes
 
 
-def _resolved_literal(value_node: ast.AST, constants: dict[str, object]) -> object | None:
-    """Resolve a literal expression or a previously bound literal name."""
+def _conditional_assignment_ids(tree: ast.AST) -> set[int]:
+    """Return assignments under branches whose runtime outcome is unknown."""
+    type_checking_names, typing_module_names = _verified_type_checking_bindings(tree)
+    conditional_ids: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        if _static_condition(node.test, type_checking_names, typing_module_names) is not None:
+            continue
+        conditional_ids.update(
+            id(descendant)
+            for branch_node in (*node.body, *node.orelse)
+            for descendant in ast.walk(branch_node)
+            if _simple_assignments(descendant)
+        )
+    return conditional_ids
+
+
+def _resolved_literals(value_node: ast.AST, constants: dict[str, list[object]]) -> list[object]:
+    """Resolve a literal expression or all possible values of a bound name."""
+    if isinstance(value_node, ast.Name):
+        return constants.get(value_node.id, [])
     try:
-        return constants[value_node.id] if isinstance(value_node, ast.Name) else ast.literal_eval(value_node)
-    except (KeyError, ValueError, TypeError):
-        return None
+        return [ast.literal_eval(value_node)]
+    except (ValueError, TypeError):
+        return []
 
 
 def _plugin_parts(value: object) -> list[list[str]]:
@@ -261,16 +283,23 @@ def _pytest_plugin_names(tree: ast.AST) -> list[list[str]]:
     """Return statically declared ``pytest_plugins`` module names."""
     plugin_names: list[list[str]] = []
     module_nodes = _module_scope_nodes(tree)
-    constants: dict[str, object] = {}
+    conditional_assignment_ids = _conditional_assignment_ids(tree)
+    constants: dict[str, list[object]] = {}
     for node in module_nodes:
         value_node = _assigned_value(node, "pytest_plugins")
         if value_node is not None:
-            plugin_names.extend(_plugin_parts(_resolved_literal(value_node, constants)))
+            for value in _resolved_literals(value_node, constants):
+                plugin_names.extend(_plugin_parts(value))
         for name, assigned_node in _simple_assignments(node):
             try:
-                constants[name] = ast.literal_eval(assigned_node)
+                value = ast.literal_eval(assigned_node)
             except (ValueError, TypeError):
                 constants.pop(name, None)
+                continue
+            if id(node) in conditional_assignment_ids:
+                constants.setdefault(name, []).append(value)
+            else:
+                constants[name] = [value]
     return plugin_names
 
 

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -203,23 +203,46 @@ def _pytest_ini_option(text: str, configuration_path: str, option: str) -> objec
         return None
 
 
+def _configuration_directories(selector_paths: Sequence[str]) -> tuple[str, ...]:
+    """Return the repository root and every selector ancestor pytest may take configuration from.
+
+    Pytest searches upward from the arguments' common ancestor, so a nested ``tests/pytest.ini``
+    decides collection for a selector beneath it.
+    """
+    directories = {""}
+    for path in selector_paths:
+        parent = PurePosixPath(path).parent
+        while parent != PurePosixPath("."):
+            directories.add(parent.as_posix())
+            parent = parent.parent
+    return tuple(sorted(directories))
+
+
 @functools.cache
-def _pytest_configuration_sources(repo_root: Path, source_ref: str) -> tuple[tuple[str, str], ...]:
+def _pytest_configuration_sources(
+    repo_root: Path, source_ref: str, directories: tuple[str, ...] = ("",)
+) -> tuple[tuple[str, str], ...]:
     """Return the readable pytest configuration candidates committed at the red source.
 
-    Raises ``ValueError('stale-red-proof')`` when a candidate exists but exceeds the read
-    bound, because an unread configuration could declare plugins or roots this gate must bind.
-    A symlinked candidate is rejected on the same terms: pytest reads the target bytes, while
-    the blob at this path holds only the link text.
+    Raises ``ValueError('stale-red-proof')`` when a candidate exists but cannot be read,
+    whether because it is oversized, symlinked, or its Git read failed, because an unread
+    configuration could declare plugins or roots this gate must bind. An absent candidate is
+    distinguished from an unreadable one so a timeout is never mistaken for absence.
     """
     sources: list[tuple[str, str]] = []
-    for path in PYTEST_CONFIGURATION_FILES:
-        result = _git_bytes(repo_root, "show", f"{source_ref}:{path}")
-        if result.returncode != 0:
-            continue
-        if len(result.stdout) > MAX_TEST_BLOB_BYTES or not _test_path_is_regular_at_ref(repo_root, source_ref, path):
-            raise ValueError("stale-red-proof")
-        sources.append((path, result.stdout.decode("utf-8", errors="surrogateescape")))
+    for directory in directories:
+        for name in PYTEST_CONFIGURATION_FILES:
+            path = f"{directory}/{name}" if directory else name
+            result = _git_bytes(repo_root, "show", f"{source_ref}:{path}")
+            if result.returncode != 0:
+                if _test_path_exists_at_ref(repo_root, source_ref, path):
+                    raise ValueError("stale-red-proof")
+                continue
+            if len(result.stdout) > MAX_TEST_BLOB_BYTES or not _test_path_is_regular_at_ref(
+                repo_root, source_ref, path
+            ):
+                raise ValueError("stale-red-proof")
+            sources.append((path, result.stdout.decode("utf-8", errors="surrogateescape")))
     return tuple(sources)
 
 
@@ -248,17 +271,70 @@ def _addopts_plugin_names(value: object) -> list[list[str]]:
 
 
 @functools.cache
-def _addopts_plugin_module_names(repo_root: Path, source_ref: str) -> tuple[tuple[str, ...], ...]:
+def _addopts_plugin_module_names(
+    repo_root: Path, source_ref: str, directories: tuple[str, ...] = ("",)
+) -> tuple[tuple[str, ...], ...]:
     """Return plugin module names early-loaded by configured ``addopts`` at the red source.
 
     ``-p name`` loads a plugin module regardless of autoload settings, so a repository-local
     module named there decides collection exactly as a declared ``pytest_plugins`` entry does.
     """
     names: set[tuple[str, ...]] = set()
-    for path, text in _pytest_configuration_sources(repo_root, source_ref):
-        for parts in _addopts_plugin_names(_pytest_ini_option(text, path, "addopts")):
+    for path, text in _pytest_configuration_sources(repo_root, source_ref, directories):
+        for parts in _addopts_plugin_names(_pytest_ini_option(text, PurePosixPath(path).name, "addopts")):
             names.add(tuple(parts))
     return tuple(sorted(names))
+
+
+def _root_name(expression: ast.expr) -> str | None:
+    """Return the base name an attribute, subscript, or call chain is rooted at.
+
+    Every check that asks "which name does this touch" resolves through this helper, so a
+    wrapped form such as ``typing.__dict__["TYPE_CHECKING"]`` cannot evade a rule that its
+    unwrapped equivalent triggers.
+    """
+    node: ast.expr = expression
+    while True:
+        if isinstance(node, ast.Name):
+            return node.id
+        if isinstance(node, (ast.Attribute, ast.Subscript)):
+            node = node.value
+            continue
+        if isinstance(node, ast.Call):
+            node = node.func
+            continue
+        return None
+
+
+@functools.cache
+def _symlink_paths_at_ref(repo_root: Path, source_ref: str) -> frozenset[str]:
+    """Return every symlinked path committed at the red source.
+
+    Collected in one traversal so any candidate path can be tested for a symlinked ancestor
+    without another Git call per lookup.
+    """
+    result = _git(repo_root, "ls-tree", "-r", "--full-tree", source_ref)
+    if result.returncode != 0:
+        return frozenset()
+    paths: set[str] = set()
+    for line in result.stdout.splitlines():
+        metadata, _, path = line.partition("\t")
+        if metadata.startswith("120000 "):
+            paths.add(path.strip('"'))
+    return frozenset(paths)
+
+
+def _has_symlinked_ancestor(repo_root: Path, source_ref: str, path: str) -> bool:
+    """Return whether a directory link stands between the repository root and this path."""
+    symlinks = _symlink_paths_at_ref(repo_root, source_ref)
+    if not symlinks:
+        return False
+    parent = PurePosixPath(path).parent
+    while parent != PurePosixPath("."):
+        if parent.as_posix() in symlinks:
+            return True
+        parent = parent.parent
+    return False
 
 
 def _safe_module_root(root: str, repo_root: Path) -> str | None:
@@ -290,15 +366,15 @@ def _safe_module_root(root: str, repo_root: Path) -> str | None:
 
 
 @functools.cache
-def _pythonpath_roots(repo_root: Path, source_ref: str) -> tuple[str, ...]:
+def _pythonpath_roots(repo_root: Path, source_ref: str, directories: tuple[str, ...] = ("",)) -> tuple[str, ...]:
     """Return module roots configured through pytest ``pythonpath`` at the red source.
 
     Every configuration candidate is read rather than replicating pytest's inifile
     precedence, because binding a root pytest did not use only widens the proof inputs.
     """
     roots: set[str] = set()
-    for path, text in _pytest_configuration_sources(repo_root, source_ref):
-        entries = _pythonpath_entries(_pytest_ini_option(text, path, "pythonpath"))
+    for path, text in _pytest_configuration_sources(repo_root, source_ref, directories):
+        entries = _pythonpath_entries(_pytest_ini_option(text, PurePosixPath(path).name, "pythonpath"))
         roots.update(root for entry in entries if (root := _safe_module_root(entry, repo_root)) is not None)
     return (*REPOSITORY_ROOT_MODULE_ROOTS, *sorted(roots - set(REPOSITORY_ROOT_MODULE_ROOTS)))
 
@@ -505,11 +581,20 @@ def _guard_attribute_targets(node: ast.AST) -> list[str]:
         targets = list(node.targets)
     elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
         targets = [node.target]
-    return [
-        target.value.id
-        for target in targets
-        if isinstance(target, ast.Attribute) and target.attr == "TYPE_CHECKING" and isinstance(target.value, ast.Name)
+    guarded: list[ast.expr] = [
+        target for target in targets if isinstance(target, ast.Attribute) and target.attr == "TYPE_CHECKING"
     ]
+    # A write through the module mapping reaches the same attribute the guard reads. The key
+    # is matched so an ordinary `mapping[key] = value` does not read as a guard write, which
+    # would make almost every module unverifiable.
+    guarded.extend(
+        target
+        for target in targets
+        if isinstance(target, ast.Subscript)
+        and isinstance(target.slice, ast.Constant)
+        and target.slice.value == "TYPE_CHECKING"
+    )
+    return [name for target in guarded for name in (_root_name(target.value),) if name is not None]
 
 
 def _call_argument_names(node: ast.AST) -> list[str]:
@@ -779,9 +864,13 @@ def _import_binding_names(node: ast.AST) -> list[str]:
 
 
 def _mutation_target_names(target: ast.expr) -> list[str]:
-    """Return the name a subscript or attribute write changes in place."""
-    if isinstance(target, (ast.Attribute, ast.Subscript)) and isinstance(target.value, ast.Name):
-        return [target.value.id]
+    """Return the name a subscript or attribute write changes in place.
+
+    The base is resolved through wrapper chains, so ``typing.__dict__["TYPE_CHECKING"]``
+    reports ``typing`` exactly as a direct attribute write does.
+    """
+    if isinstance(target, (ast.Attribute, ast.Subscript)):
+        return [name for name in (_root_name(target.value),) if name is not None]
     return []
 
 
@@ -809,6 +898,9 @@ def _mutated_name_targets(node: ast.AST) -> list[str]:
             and isinstance(child.func.value, ast.Name)
         ):
             names.append(child.func.value.id)
+        if isinstance(child, ast.AugAssign) and isinstance(child.target, ast.Name):
+            # `x += [...]` extends a list in place, so every alias observes it.
+            names.append(child.target.id)
         names.extend(name for target in _write_targets(child) for name in _mutation_target_names(target))
     return names
 
@@ -881,10 +973,10 @@ def _import_module_names(tree: ast.AST, current_path: str) -> list[list[str]]:
     """Return imported module names, including relative import candidates."""
     current_package = list(PurePosixPath(current_path).parent.parts)
     module_names: list[list[str]] = []
-    # A function body runs only when something invokes it. A module that calls nothing while
-    # loading cannot reach one, so its bodies stay unbound; once the module does invoke
-    # something, which body that reaches cannot be decided, so every body counts.
-    reachable_bodies = _calls_during_module_load(tree)
+    # Pytest invokes test and fixture bodies during the run, so their imports always execute.
+    # Only a package initializer needs an import-time call to reach one of its own functions.
+    is_package_initializer = PurePosixPath(current_path).name == "__init__.py"
+    reachable_bodies = not is_package_initializer or _calls_during_module_load(tree)
     for node in _module_scope_nodes(tree, include_class_bodies=True, include_deferred_scopes=reachable_bodies):
         if isinstance(node, ast.Import):
             module_names.extend(alias.name.split(".") for alias in node.names)
@@ -985,6 +1077,12 @@ def _imported_python_paths(
             for root in plugin_module_roots
             for path in _python_module_target_paths(module_parts, (root,))
         }
+        for _, candidate in sorted(ordinary_rooted | plugin_rooted):
+            if not _test_path_exists_at_ref(repo_root, source_ref, candidate) and _has_symlinked_ancestor(
+                repo_root, source_ref, candidate
+            ):
+                # Python follows the directory link; Git records the link, not the target tree.
+                raise ValueError("stale-red-proof")
         imported_paths.update(path for _, path in ordinary_rooted | plugin_rooted)
         pending.extend(
             (imported_path, False, root)
@@ -1182,8 +1280,9 @@ def _proof_inputs(repo_root: Path, source_ref: str, selector_paths: Sequence[str
         initializer for path in pytest_inputs for initializer in _ancestor_file_paths(path, "__init__.py")
     }
     traversal_inputs = pytest_inputs | initializer_inputs
-    plugin_module_roots = _pythonpath_roots(repo_root, source_ref)
-    addopts_names = _addopts_plugin_module_names(repo_root, source_ref)
+    configuration_directories = _configuration_directories(selector_paths)
+    plugin_module_roots = _pythonpath_roots(repo_root, source_ref, configuration_directories)
+    addopts_names = _addopts_plugin_module_names(repo_root, source_ref, configuration_directories)
     addopts_rooted = _discovered_rooted_paths(addopts_names, plugin_module_roots)
     addopts_targets = {
         (root, path)

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -14,7 +14,7 @@ import shlex
 import subprocess
 import sys
 import tomllib
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path, PurePosixPath
 from typing import cast
 from xml.etree import ElementTree
@@ -60,6 +60,9 @@ PYTEST_INI_SECTIONS = {
     "tox.ini": "pytest",
     "setup.cfg": "tool:pytest",
 }
+REGULAR_FILE_MODES = frozenset({"100644", "100755"})
+SYMLINK_MODE = "120000"
+MAX_SYMLINK_HOPS = 8
 REPOSITORY_ROOT_MODULE_ROOTS = ("",)
 # Plugins the executor early-loads with ``-p`` on every proof run. They are not declared in any
 # configuration this gate can read, so they are named here and held to the executor's own command
@@ -127,8 +130,12 @@ def _validated_selectors(execution_proof: dict[str, object]) -> list[str]:
     return cast(list[str], selectors)
 
 
-def _selector_paths(report: dict[str, object]) -> tuple[str, list[str]]:
-    """Validate the released red-report shape and extract unique selector file paths."""
+def _selector_paths(report: dict[str, object]) -> tuple[str, dict[str, frozenset[str]]]:
+    """Validate the released red-report shape and extract the selection per test file.
+
+    The node identifiers are kept, not only their paths, because an exact selection runs one
+    node out of a module and the bodies of the others never execute.
+    """
     execution_proof = _validated_execution_proof(report)
     if report.get("gate_decision") != "pass" or report.get("observed_maturity") != "red":
         raise ValueError("prior-red-proof-invalid")
@@ -137,14 +144,17 @@ def _selector_paths(report: dict[str, object]) -> tuple[str, list[str]]:
     selectors = _validated_selectors(execution_proof)
     source_ref = execution_proof["source_ref"]
     assert isinstance(source_ref, str)
-    paths: set[str] = set()
+    selection: dict[str, set[str]] = {}
     for selector in selectors:
-        test_path, separator, _ = selector.partition("::")
+        test_path, separator, node_id = selector.partition("::")
         path = PurePosixPath(test_path)
         if not separator or path.is_absolute() or ".." in path.parts or not test_path.endswith(".py"):
             raise ValueError("prior-red-proof-invalid")
-        paths.add(test_path)
-    return source_ref, sorted(paths)
+        # A parametrized node carries its case in brackets; the function it runs is the name.
+        selection.setdefault(test_path, set()).update(
+            component.partition("[")[0] for component in node_id.split("::") if component
+        )
+    return source_ref, {path: frozenset(names) for path, names in selection.items()}
 
 
 def _ancestor_file_paths(path: str, filename: str) -> set[str]:
@@ -784,7 +794,11 @@ def _verified_type_checking_bindings(tree: ast.AST, before_line: int | None = No
 
 
 def _module_scope_nodes(
-    tree: ast.AST, *, include_class_bodies: bool = False, include_deferred_scopes: bool = False
+    tree: ast.AST,
+    *,
+    include_class_bodies: bool = False,
+    include_deferred_scopes: bool = False,
+    skipped_scope_names: frozenset[str] = frozenset(),
 ) -> list[ast.AST]:
     """Return executable module nodes without entering deferred function scopes.
 
@@ -792,14 +806,16 @@ def _module_scope_nodes(
     loads executes its imports at import time, and one invoked from a fixture executes them
     while the selected test runs, so either way the imported file decides the outcome.
     Static branch pruning still applies inside those bodies, so a guarded type-only import
-    stays unbound.
+    stays unbound. Named scopes are skipped even then, for bodies the run provably never
+    enters — their headers still execute where they appear.
     """
     pending = list(reversed(list(ast.iter_child_nodes(tree))))
     nodes: list[ast.AST] = []
     while pending:
         node = pending.pop()
         nodes.append(node)
-        deferred_scope = (
+        skipped = isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name in skipped_scope_names
+        deferred_scope = skipped or (
             isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef, ast.Lambda)) and not include_deferred_scopes
         )
         excluded_class_scope = isinstance(node, ast.ClassDef) and not include_class_bodies
@@ -1002,6 +1018,40 @@ def _pytest_plugin_names(tree: ast.AST) -> list[list[str]]:
     return plugin_names
 
 
+def _unexecuted_test_scopes(tree: ast.AST, selected_names: frozenset[str]) -> frozenset[str]:
+    """Return test functions in this module that an exact selection provably never runs.
+
+    Pytest collects the module but runs only the selected node identifiers, so the body of an
+    unselected test executes nothing — binding what it imports rejects proofs over code the run
+    never touched. Only bodies that are provably unreachable are dropped: a function is skipped
+    only when it is a test, is not itself selected, and its name appears nowhere else in the
+    module, because a name that is referenced may be called from a body that does run.
+
+    Nothing is dropped unless at least one selected identifier matches a function defined here.
+    A selection this gate cannot resolve to names — a generated identifier, an unfamiliar
+    layout — leaves every scope traversed, because guessing wrong in this direction accepts
+    stale evidence rather than merely rejecting fresh evidence.
+
+    Fixtures are never dropped. Which fixtures a run activates depends on autouse declarations,
+    indirect parametrization, conftest chains, and plugins, none of which is decidable from this
+    module's syntax, so they are treated as executed.
+    """
+    if not selected_names:
+        return frozenset()
+    definitions = [node for node in ast.walk(tree) if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))]
+    defined_names = {node.name for node in definitions}
+    if not selected_names & defined_names:
+        return frozenset()
+    referenced = {node.id for node in ast.walk(tree) if isinstance(node, ast.Name)} | {
+        node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)
+    }
+    return frozenset(
+        node.name
+        for node in definitions
+        if node.name.startswith("test_") and node.name not in selected_names and node.name not in referenced
+    )
+
+
 def _deferred_scopes_are_reachable(tree: ast.AST, current_path: str) -> bool:
     """Report whether a module's deferred bodies run during the pytest session.
 
@@ -1012,7 +1062,9 @@ def _deferred_scopes_are_reachable(tree: ast.AST, current_path: str) -> bool:
     return not is_package_initializer or _calls_during_module_load(tree)
 
 
-def _literal_module_candidates(tree: ast.AST, current_path: str) -> list[list[str]]:
+def _literal_module_candidates(
+    tree: ast.AST, current_path: str, skipped_scope_names: frozenset[str] = frozenset()
+) -> list[list[str]]:
     """Return module names spelled as string literals in a reachable body.
 
     A dynamic import names its target in data rather than in the callee, so the mechanism is
@@ -1032,7 +1084,12 @@ def _literal_module_candidates(tree: ast.AST, current_path: str) -> list[list[st
     """
     names: list[list[str]] = []
     reachable_bodies = _deferred_scopes_are_reachable(tree, current_path)
-    for node in _module_scope_nodes(tree, include_class_bodies=True, include_deferred_scopes=reachable_bodies):
+    for node in _module_scope_nodes(
+        tree,
+        include_class_bodies=True,
+        include_deferred_scopes=reachable_bodies,
+        skipped_scope_names=skipped_scope_names,
+    ):
         handed_over = _handed_over_expressions(node)
         for value in itertools.chain.from_iterable(_literal_strings(argument) for argument in handed_over):
             parts = value.split(".")
@@ -1072,12 +1129,19 @@ def _literal_strings(expression: ast.expr) -> list[str]:
     return []
 
 
-def _import_module_names(tree: ast.AST, current_path: str) -> list[list[str]]:
+def _import_module_names(
+    tree: ast.AST, current_path: str, skipped_scope_names: frozenset[str] = frozenset()
+) -> list[list[str]]:
     """Return imported module names, including relative import candidates."""
     current_package = list(PurePosixPath(current_path).parent.parts)
     module_names: list[list[str]] = []
     reachable_bodies = _deferred_scopes_are_reachable(tree, current_path)
-    for node in _module_scope_nodes(tree, include_class_bodies=True, include_deferred_scopes=reachable_bodies):
+    for node in _module_scope_nodes(
+        tree,
+        include_class_bodies=True,
+        include_deferred_scopes=reachable_bodies,
+        skipped_scope_names=skipped_scope_names,
+    ):
         if isinstance(node, ast.Import):
             module_names.extend(alias.name.split(".") for alias in node.names)
         elif isinstance(node, ast.ImportFrom):
@@ -1123,13 +1187,8 @@ def _discovered_rooted_paths(
     }
 
 
-def _joined_path_literal(expression: ast.expr) -> str | None:
-    """Return the repository-relative path a chain of ``/`` joins spells, if it is fully literal.
-
-    ``REPO_ROOT / "tests" / "data" / "case.json"`` names a file as directly as a single string
-    does; the root the chain starts from is dropped because a path built inside the checkout is
-    only bindable relative to it.
-    """
+def _path_join_chain(expression: ast.expr) -> tuple[ast.expr, list[str]] | None:
+    """Split a chain of ``/`` joins into the base it starts from and its literal components."""
     parts: list[str] = []
     node: ast.expr = expression
     while isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
@@ -1137,25 +1196,108 @@ def _joined_path_literal(expression: ast.expr) -> str | None:
             return None
         parts.insert(0, node.right.value)
         node = node.left
-    return "/".join(parts) if parts else None
+    return (node, parts) if parts else None
 
 
-def _literal_path_candidates(tree: ast.AST, current_path: str) -> list[str]:
+def _ancestor_directory(path: str, levels: int) -> str:
+    """Return the directory that many levels above a repository-relative path."""
+    ancestor = PurePosixPath(path)
+    for _ in range(levels):
+        ancestor = ancestor.parent
+    return "" if ancestor == PurePosixPath(".") else ancestor.as_posix()
+
+
+def _names_the_module_file(expression: ast.expr) -> bool:
+    """Return whether an expression is the ``__file__`` of the module being inspected."""
+    return isinstance(expression, ast.Name) and expression.id == "__file__"
+
+
+def _path_base_directory(
+    expression: ast.expr, current_path: str, bindings: Mapping[str, ast.expr], depth: int = 0
+) -> str | None:
+    """Return the repository-relative location a path expression denotes, if it is knowable.
+
+    A harness names its data relative to itself far more often than to the repository root, so
+    ``Path(__file__).parent / "data"`` must resolve against the module being inspected rather
+    than being read as a root-relative ``data``. The forms that appear in practice are covered —
+    ``__file__`` turned into a path, ``.parent``, ``.parents[n]``, ``.resolve()``, and a
+    module-level name bound to any of them.
+
+    A base that is not one of those is unknowable, and ``None`` says so: a chain rooted at a
+    fixture value such as ``tmp_path`` names a file that does not exist in the repository at
+    all, and reading it as root-relative would bind whatever committed file happens to share
+    the remaining components.
+    """
+    if depth > MAX_SYMLINK_HOPS:
+        return None
+    if isinstance(expression, ast.Name):
+        bound = bindings.get(expression.id)
+        return None if bound is None else _path_base_directory(bound, current_path, bindings, depth + 1)
+    if isinstance(expression, ast.Call):
+        callee = expression.func
+        method = callee.attr if isinstance(callee, ast.Attribute) else None
+        if method in {"resolve", "absolute"}:
+            return _path_base_directory(callee.value, current_path, bindings, depth + 1)
+        for argument in expression.args:
+            base = (
+                current_path
+                if _names_the_module_file(argument)
+                else _path_base_directory(argument, current_path, bindings, depth + 1)
+            )
+            if base is None:
+                continue
+            # ``os.path.dirname(x)`` names the directory holding x; a path constructor keeps it.
+            return _ancestor_directory(base, 1) if method == "dirname" else base
+        return None
+    if isinstance(expression, ast.Attribute) and expression.attr == "parent":
+        base = _path_base_directory(expression.value, current_path, bindings, depth + 1)
+        return None if base is None else _ancestor_directory(base, 1)
+    if (
+        isinstance(expression, ast.Subscript)
+        and isinstance(expression.value, ast.Attribute)
+        and expression.value.attr == "parents"
+        and isinstance(expression.slice, ast.Constant)
+        and isinstance(expression.slice.value, int)
+    ):
+        base = _path_base_directory(expression.value.value, current_path, bindings, depth + 1)
+        return None if base is None else _ancestor_directory(base, expression.slice.value + 1)
+    return None
+
+
+def _module_scope_bindings(nodes: Sequence[ast.AST]) -> dict[str, ast.expr]:
+    """Return the last module-scope value assigned to each name."""
+    return {name: value for node in nodes for name, value in _simple_assignments(node)}
+
+
+def _literal_path_candidates(
+    tree: ast.AST, current_path: str, skipped_scope_names: frozenset[str] = frozenset()
+) -> list[str]:
     """Return repository-relative paths a reachable body names as literals.
 
     A harness reads a data file the same way it names a module: by handing a literal to a call,
-    or by joining literals onto a path root. Both are resolved, and nothing else is, because a
+    or by joining literals onto a path base. Both are resolved, and nothing else is, because a
     path assembled at runtime — ``tmp_path / name`` — cannot be bound to a committed file and
     failing closed on it would reject every proof in a repository that uses temporary
-    directories, which is every repository.
+    directories, which is every repository. A join whose base is unknowable is discarded for the
+    same reason, rather than being read as though it started at the repository root.
     """
     candidates: list[str] = []
     reachable_bodies = _deferred_scopes_are_reachable(tree, current_path)
-    for node in _module_scope_nodes(tree, include_class_bodies=True, include_deferred_scopes=reachable_bodies):
+    nodes = _module_scope_nodes(
+        tree,
+        include_class_bodies=True,
+        include_deferred_scopes=reachable_bodies,
+        skipped_scope_names=skipped_scope_names,
+    )
+    bindings = _module_scope_bindings(nodes)
+    for node in nodes:
         handed_over = _handed_over_expressions(node)
         candidates.extend(itertools.chain.from_iterable(_literal_strings(argument) for argument in handed_over))
-        if isinstance(node, ast.BinOp) and (joined := _joined_path_literal(node)) is not None:
-            candidates.append(joined)
+        if not isinstance(node, ast.BinOp) or (chain := _path_join_chain(node)) is None:
+            continue
+        base, parts = chain
+        if (directory := _path_base_directory(base, current_path, bindings)) is not None:
+            candidates.append("/".join([directory, *parts]) if directory else "/".join(parts))
     return [stripped for candidate in candidates if _names_a_repository_path(stripped := candidate.strip("/"))]
 
 
@@ -1192,7 +1334,11 @@ def _is_harness_path(path: str, harness_directories: Sequence[str]) -> bool:
 
 
 def _referenced_data_paths(
-    repo_root: Path, source_ref: str, python_paths: Sequence[str], selector_paths: Sequence[str]
+    repo_root: Path,
+    source_ref: str,
+    python_paths: Sequence[str],
+    selector_paths: Sequence[str],
+    selection: Mapping[str, frozenset[str]],
 ) -> set[str]:
     """Return committed harness data the resolved Python proof inputs read by literal path.
 
@@ -1203,14 +1349,70 @@ def _referenced_data_paths(
     if not harness_directories:
         return set()
     return {
-        candidate
+        bound
         for path in python_paths
         if (tree := _python_tree_at_ref(repo_root, source_ref, path)) is not None
-        for candidate in _literal_path_candidates(tree, path)
+        for candidate in _literal_path_candidates(
+            tree, path, _unexecuted_test_scopes(tree, selection.get(path, frozenset()))
+        )
         if _is_harness_path(candidate, harness_directories)
-        and _test_path_exists_at_ref(repo_root, source_ref, candidate)
-        and _test_path_is_regular_at_ref(repo_root, source_ref, candidate)
+        for bound in _read_data_paths(repo_root, source_ref, candidate)
     }
+
+
+def _read_data_paths(repo_root: Path, source_ref: str, candidate: str) -> set[str]:
+    """Return the committed paths a harness read of ``candidate`` actually consumes.
+
+    A link is followed rather than skipped, because pytest reads the target's bytes while Git
+    records only the link, so binding neither would let the target change unnoticed. Both the
+    link and its target are bound, since editing either changes what the read returns. A link
+    that leaves the repository, cycles, or points at nothing cannot be bound at all, and is
+    treated as stale rather than dropped.
+    """
+    mode = _tree_entry_mode_at_ref(repo_root, source_ref, candidate)
+    if mode is None:
+        return set()
+    bound: set[str] = set()
+    for _ in range(MAX_SYMLINK_HOPS):
+        if mode in REGULAR_FILE_MODES:
+            return bound | {candidate}
+        if mode != SYMLINK_MODE:
+            # A directory is named, not read; there are no bytes to bind.
+            return bound
+        bound.add(candidate)
+        result = _git_bytes(repo_root, "show", f"{source_ref}:{candidate}")
+        if result.returncode != 0 or len(result.stdout) > MAX_TEST_BLOB_BYTES:
+            raise ValueError("stale-red-proof")
+        target = result.stdout.decode("utf-8", errors="surrogateescape")
+        candidate = _repository_relative_target(candidate, target)
+        if candidate in bound or not _names_a_repository_path(candidate):
+            raise ValueError("stale-red-proof")
+        mode = _tree_entry_mode_at_ref(repo_root, source_ref, candidate)
+        if mode is None:
+            raise ValueError("stale-red-proof")
+    raise ValueError("stale-red-proof")
+
+
+def _repository_relative_target(link_path: str, target: str) -> str:
+    """Return where a committed link points, relative to the repository root.
+
+    A link text is resolved against the directory holding the link, exactly as the filesystem
+    resolves it. An absolute text names nothing inside the checkout and is returned unchanged so
+    the caller rejects it.
+    """
+    if target.startswith("/"):
+        return target
+    resolved: list[str] = list(PurePosixPath(link_path).parent.parts)
+    for part in PurePosixPath(target).parts:
+        if part == ".":
+            continue
+        if part != "..":
+            resolved.append(part)
+        elif resolved:
+            resolved.pop()
+        else:
+            return f"../{target}"
+    return "/".join(resolved)
 
 
 def _committed_module_names(
@@ -1251,6 +1453,7 @@ def _imported_python_paths(
     seeds: Sequence[tuple[str, bool, str]],
     *,
     plugin_module_roots: Sequence[str],
+    selection: Mapping[str, frozenset[str]],
 ) -> set[str]:
     """Return transitive repository-local Python imports used by pytest inputs.
 
@@ -1278,10 +1481,16 @@ def _imported_python_paths(
             continue
         import_roots = _import_roots(module_root)
         relative_path = _module_relative_path(current_path, module_root)
-        ordinary_rooted = _discovered_rooted_paths(_import_module_names(tree, relative_path), import_roots)
+        skipped_scopes = _unexecuted_test_scopes(tree, selection.get(current_path, frozenset()))
+        ordinary_rooted = _discovered_rooted_paths(
+            _import_module_names(tree, relative_path, skipped_scopes), import_roots
+        )
         ordinary_rooted |= _discovered_rooted_paths(
             _committed_module_names(
-                _literal_module_candidates(tree, relative_path), import_roots, repo_root, source_ref
+                _literal_module_candidates(tree, relative_path, skipped_scopes),
+                import_roots,
+                repo_root,
+                source_ref,
             ),
             import_roots,
         )
@@ -1407,16 +1616,34 @@ def _has_governed_production_path(paths: Sequence[str]) -> bool:
 
 
 @functools.cache
+def _tree_entry_mode_at_ref(repo_root: Path, source_ref: str, test_path: str) -> str | None:
+    """Return the Git mode of a committed path, or ``None`` when the ref definitely lacks it.
+
+    Absence and failure are different answers and must not share one. ``git cat-file -e`` exits
+    non-zero for both a missing path and an unusable ref, and the Git wrapper reports a timeout
+    the same way, so a lookup that never ran would read as proof that a module is missing and
+    its imports would go untraversed. ``git ls-tree`` separates them: it succeeds with no output
+    for a path the ref does not contain, and fails only when it could not answer, which is
+    treated as stale because an unanswered lookup is not evidence of anything.
+    """
+    result = _git(repo_root, "ls-tree", source_ref, "--", test_path)
+    if result.returncode != 0:
+        raise ValueError("stale-red-proof")
+    entry = result.stdout.strip()
+    if not entry:
+        return None
+    mode, _, _ = entry.partition(" ")
+    return mode
+
+
 def _test_path_exists_at_ref(repo_root: Path, source_ref: str, test_path: str) -> bool:
     """Return whether a path exists at an immutable ref, caching the answer for the run."""
-    return _git(repo_root, "cat-file", "-e", f"{source_ref}:{test_path}").returncode == 0
+    return _tree_entry_mode_at_ref(repo_root, source_ref, test_path) is not None
 
 
-@functools.cache
 def _test_path_is_regular_at_ref(repo_root: Path, source_ref: str, test_path: str) -> bool:
     """Reject symlink selectors because pytest follows bytes not bound by their Git blob."""
-    result = _git(repo_root, "ls-tree", source_ref, "--", test_path)
-    return result.returncode == 0 and result.stdout.startswith(("100644 blob ", "100755 blob "))
+    return _tree_entry_mode_at_ref(repo_root, source_ref, test_path) in REGULAR_FILE_MODES
 
 
 def _blob_digest_at_ref(repo_root: Path, source_ref: str, test_path: str) -> str | None:
@@ -1482,7 +1709,12 @@ def _validate_execution_bindings(
             raise ValueError("prior-red-proof-invalid")
 
 
-def _proof_inputs(repo_root: Path, source_ref: str, selector_paths: Sequence[str]) -> set[str]:
+def _proof_inputs(
+    repo_root: Path,
+    source_ref: str,
+    selector_paths: Sequence[str],
+    selection: Mapping[str, frozenset[str]] | None = None,
+) -> set[str]:
     """Return every committed path whose change after the red source would invalidate the proof.
 
     Selectors are resolved together so their shared conftest, initializer, and import graph is
@@ -1515,12 +1747,14 @@ def _proof_inputs(repo_root: Path, source_ref: str, selector_paths: Sequence[str
     python_inputs = {
         *traversal_inputs,
         *(path for _, path in addopts_rooted),
-        *_imported_python_paths(repo_root, source_ref, seeds, plugin_module_roots=plugin_module_roots),
+        *_imported_python_paths(
+            repo_root, source_ref, seeds, plugin_module_roots=plugin_module_roots, selection=selection or {}
+        ),
     }
     return {
         *python_inputs,
         *_configuration_candidate_paths(configuration_directories),
-        *_referenced_data_paths(repo_root, source_ref, sorted(python_inputs), selector_paths),
+        *_referenced_data_paths(repo_root, source_ref, sorted(python_inputs), selector_paths, selection or {}),
     }
 
 
@@ -1539,7 +1773,8 @@ def validate_prior_red_proof(red_proof_path: Path, repo_root: Path, *, base_ref:
     try:
         report = _read_red_proof(red_proof_path)
         _validate_retained_red_junit(red_proof_path, report)
-        source_ref, selector_paths = _selector_paths(report)
+        source_ref, selection = _selector_paths(report)
+        selector_paths = sorted(selection)
     except ValueError as error:
         return [str(error)]
     if not _red_source_precedes_final(repo_root, base_ref, source_ref, final_ref):
@@ -1562,7 +1797,7 @@ def validate_prior_red_proof(red_proof_path: Path, repo_root: Path, *, base_ref:
         ):
             return ["prior-red-proof-invalid"]
     try:
-        proof_inputs = _proof_inputs(repo_root, source_ref, selector_paths)
+        proof_inputs = _proof_inputs(repo_root, source_ref, selector_paths, selection)
     except ValueError as error:
         return [str(error)]
     if not proof_inputs.isdisjoint(paths_after_red):

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -137,20 +137,86 @@ def _assigned_value(node: ast.AST, name: str) -> ast.AST | None:
     return None
 
 
-def _static_condition(test: ast.AST) -> bool | None:
+def _static_condition(test: ast.AST, type_checking_names: set[str], typing_module_names: set[str]) -> bool | None:
     """Return a known branch condition used during module loading."""
     if isinstance(test, ast.Constant) and isinstance(test.value, bool):
         return test.value
-    if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
+    if isinstance(test, ast.Name) and test.id in type_checking_names:
         return False
-    if isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING":
+    if (
+        isinstance(test, ast.Attribute)
+        and test.attr == "TYPE_CHECKING"
+        and isinstance(test.value, ast.Name)
+        and test.value.id in typing_module_names
+    ):
         return False
     return None
 
 
+def _simple_assignments(node: ast.AST) -> list[tuple[str, ast.AST]]:
+    """Return direct name assignments made by one module statement."""
+    if isinstance(node, ast.Assign):
+        return [(target.id, node.value) for target in node.targets if isinstance(target, ast.Name)]
+    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.value is not None:
+        return [(node.target.id, node.value)]
+    return []
+
+
+def _imported_type_checking_names(body: Sequence[ast.stmt]) -> set[str]:
+    """Return names imported from ``typing.TYPE_CHECKING``."""
+    return {
+        alias.asname or alias.name
+        for node in body
+        if isinstance(node, ast.ImportFrom) and node.module == "typing"
+        for alias in node.names
+        if alias.name == "TYPE_CHECKING"
+    }
+
+
+def _imported_typing_module_names(body: Sequence[ast.stmt]) -> set[str]:
+    """Return local names bound to the ``typing`` module."""
+    return {
+        alias.asname or "typing"
+        for node in body
+        if isinstance(node, ast.Import)
+        for alias in node.names
+        if alias.name == "typing"
+    }
+
+
+def _other_import_names(body: Sequence[ast.stmt]) -> set[str]:
+    """Return local names bound by imports other than typing guards."""
+    direct_imports = {
+        alias.asname or alias.name.split(".")[0]
+        for node in body
+        if isinstance(node, ast.Import)
+        for alias in node.names
+        if alias.name != "typing"
+    }
+    from_imports = {
+        alias.asname or alias.name
+        for node in body
+        if isinstance(node, ast.ImportFrom)
+        for alias in node.names
+        if node.module != "typing" or alias.name != "TYPE_CHECKING"
+    }
+    return direct_imports | from_imports
+
+
+def _verified_type_checking_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
+    """Return unrebound names imported from the typing module."""
+    body = tree.body if isinstance(tree, ast.Module) else []
+    rebound_names = _other_import_names(body) | {name for node in body for name, _ in _simple_assignments(node)}
+    return (
+        _imported_type_checking_names(body) - rebound_names,
+        _imported_typing_module_names(body) - rebound_names,
+    )
+
+
 def _module_scope_nodes(tree: ast.AST, *, include_class_bodies: bool = False) -> list[ast.AST]:
     """Return executable module nodes without entering deferred function scopes."""
-    pending = list(ast.iter_child_nodes(tree))
+    type_checking_names, typing_module_names = _verified_type_checking_bindings(tree)
+    pending = list(reversed(list(ast.iter_child_nodes(tree))))
     nodes: list[ast.AST] = []
     while pending:
         node = pending.pop()
@@ -159,52 +225,52 @@ def _module_scope_nodes(tree: ast.AST, *, include_class_bodies: bool = False) ->
         excluded_class_scope = isinstance(node, ast.ClassDef) and not include_class_bodies
         if deferred_scope or excluded_class_scope:
             continue
-        if isinstance(node, ast.If) and (condition := _static_condition(node.test)) is not None:
-            pending.extend(node.body if condition else node.orelse)
+        if (
+            isinstance(node, ast.If)
+            and (condition := _static_condition(node.test, type_checking_names, typing_module_names)) is not None
+        ):
+            pending.extend(reversed(node.body if condition else node.orelse))
             continue
-        pending.extend(ast.iter_child_nodes(node))
+        pending.extend(reversed(list(ast.iter_child_nodes(node))))
     return nodes
 
 
-def _literal_module_constants(nodes: Sequence[ast.AST]) -> dict[str, object]:
-    """Return simple module names whose assigned values are Python literals."""
-    constants: dict[str, object] = {}
-    for node in nodes:
-        assignments: list[tuple[str, ast.AST]] = []
-        if isinstance(node, ast.Assign):
-            assignments.extend((target.id, node.value) for target in node.targets if isinstance(target, ast.Name))
-        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.value is not None:
-            assignments.append((node.target.id, node.value))
-        for name, value_node in assignments:
-            try:
-                constants[name] = ast.literal_eval(value_node)
-            except (ValueError, TypeError):
-                continue
-    return constants
+def _resolved_literal(value_node: ast.AST, constants: dict[str, object]) -> object | None:
+    """Resolve a literal expression or a previously bound literal name."""
+    try:
+        return constants[value_node.id] if isinstance(value_node, ast.Name) else ast.literal_eval(value_node)
+    except (KeyError, ValueError, TypeError):
+        return None
+
+
+def _plugin_parts(value: object) -> list[list[str]]:
+    """Return normalized module parts from a supported plugin declaration value."""
+    declarations = [value] if isinstance(value, str) else value
+    if not isinstance(declarations, (list, tuple)):
+        return []
+    return [
+        plugin_name.strip().split(".")
+        for declaration in declarations
+        if isinstance(declaration, str)
+        for plugin_name in declaration.split(",")
+        if plugin_name.strip()
+    ]
 
 
 def _pytest_plugin_names(tree: ast.AST) -> list[list[str]]:
     """Return statically declared ``pytest_plugins`` module names."""
     plugin_names: list[list[str]] = []
     module_nodes = _module_scope_nodes(tree)
-    constants = _literal_module_constants(module_nodes)
+    constants: dict[str, object] = {}
     for node in module_nodes:
         value_node = _assigned_value(node, "pytest_plugins")
-        if value_node is None:
-            continue
-        try:
-            value = constants[value_node.id] if isinstance(value_node, ast.Name) else ast.literal_eval(value_node)
-        except (KeyError, ValueError, TypeError):
-            continue
-        declared_plugins = [value] if isinstance(value, str) else value
-        if isinstance(declared_plugins, (list, tuple)):
-            plugin_names.extend(
-                plugin_name.strip().split(".")
-                for declaration in declared_plugins
-                if isinstance(declaration, str)
-                for plugin_name in declaration.split(",")
-                if plugin_name.strip()
-            )
+        if value_node is not None:
+            plugin_names.extend(_plugin_parts(_resolved_literal(value_node, constants)))
+        for name, assigned_node in _simple_assignments(node):
+            try:
+                constants[name] = ast.literal_eval(assigned_node)
+            except (ValueError, TypeError):
+                constants.pop(name, None)
     return plugin_names
 
 

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -300,7 +300,8 @@ def _pytest_plugin_names(tree: ast.AST) -> list[list[str]]:
             try:
                 value = ast.literal_eval(assigned_node)
             except (ValueError, TypeError):
-                constants.pop(name, None)
+                if id(node) not in conditional_assignment_ids:
+                    constants.pop(name, None)
                 continue
             if id(node) in conditional_assignment_ids:
                 constants.setdefault(name, []).append(value)

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -153,9 +153,16 @@ def _ancestor_file_paths(path: str, filename: str) -> set[str]:
 
 
 def _pythonpath_entries(value: object) -> list[str]:
-    """Return the individual roots of a pytest ``pythonpath`` setting."""
+    """Return the individual roots of a pytest ``pythonpath`` setting.
+
+    A string form is split with ``shlex`` because pytest parses ``paths`` ini values that
+    way, so a quoted entry containing spaces stays one path.
+    """
     if isinstance(value, str):
-        return value.split()
+        try:
+            return shlex.split(value)
+        except ValueError:
+            return []
     if isinstance(value, list):
         return [entry for entry in cast(list[object], value) if isinstance(entry, str)]
     return []
@@ -676,58 +683,79 @@ def _python_tree_at_ref(repo_root: Path, source_ref: str, path: str) -> ast.AST 
         return None
 
 
-def _discovered_python_paths(module_names: Sequence[Sequence[str]], module_roots: Sequence[str]) -> set[str]:
-    """Return every repository path candidate for discovered module names."""
-    return {path for module_parts in module_names for path in _python_module_paths(module_parts, module_roots)}
+def _discovered_rooted_paths(
+    module_names: Sequence[Sequence[str]], module_roots: Sequence[str]
+) -> set[tuple[str, str]]:
+    """Return every (module root, repository path) candidate for discovered module names."""
+    return {
+        (root, path)
+        for module_parts in module_names
+        for root in module_roots
+        for path in _python_module_paths(module_parts, (root,))
+    }
+
+
+def _module_relative_path(path: str, module_root: str) -> str:
+    """Return a path relative to the module root it was discovered under."""
+    prefix = f"{module_root}/"
+    return path.removeprefix(prefix) if module_root and path.startswith(prefix) else path
+
+
+def _import_roots(module_root: str) -> tuple[str, ...]:
+    """Return the roots an import inside a module discovered under one root may resolve against."""
+    return ("",) if not module_root else ("", module_root)
 
 
 def _imported_python_paths(
     repo_root: Path,
     source_ref: str,
-    source_paths: Sequence[str],
+    seeds: Sequence[tuple[str, bool, str]],
     *,
-    pytest_plugin_source_paths: set[str],
     plugin_module_roots: Sequence[str],
 ) -> set[str]:
     """Return transitive repository-local Python imports used by pytest inputs.
 
-    Configured ``pythonpath`` roots widen plugin resolution only. Ordinary imports stay
-    anchored at the repository root, because resolving them through a root such as ``src``
-    would bind governed production modules that a red-to-green change is expected to edit.
+    Each traversal entry carries the module root it was discovered under, so a plugin loaded
+    from a configured ``pythonpath`` root resolves its own imports against that root as
+    pytest does. An input discovered at the repository root keeps repository-root resolution,
+    because resolving ordinary test imports through a root such as ``src`` would bind
+    governed production modules that a red-to-green change is expected to edit.
     """
-    pending = [(path, path in pytest_plugin_source_paths) for path in source_paths]
-    traversed_paths: set[tuple[str, bool]] = set()
+    pending = list(seeds)
+    traversed_paths: set[tuple[str, bool, str]] = set()
     imported_paths: set[str] = set()
     while pending:
-        current_path, inspect_pytest_plugins = pending.pop()
-        traversal = (current_path, inspect_pytest_plugins)
+        traversal = pending.pop()
         if traversal in traversed_paths:
             continue
         traversed_paths.add(traversal)
+        current_path, inspect_pytest_plugins, module_root = traversal
         tree = _python_tree_at_ref(repo_root, source_ref, current_path)
         if tree is None:
             if _test_path_is_regular_at_ref(repo_root, source_ref, current_path):
                 raise ValueError("stale-red-proof")
             continue
-        ordinary_paths = _discovered_python_paths(
-            _import_module_names(tree, current_path), REPOSITORY_ROOT_MODULE_ROOTS
+        ordinary_rooted = _discovered_rooted_paths(
+            _import_module_names(tree, _module_relative_path(current_path, module_root)),
+            _import_roots(module_root),
         )
         plugin_names = _pytest_plugin_names(tree) if inspect_pytest_plugins else []
-        plugin_paths = _discovered_python_paths(plugin_names, plugin_module_roots)
-        plugin_target_paths = {
-            path
+        plugin_rooted = _discovered_rooted_paths(plugin_names, plugin_module_roots)
+        plugin_targets = {
+            (root, path)
             for module_parts in plugin_names
-            for path in _python_module_target_paths(module_parts, plugin_module_roots)
+            for root in plugin_module_roots
+            for path in _python_module_target_paths(module_parts, (root,))
         }
-        imported_paths.update(ordinary_paths, plugin_paths)
+        imported_paths.update(path for _, path in ordinary_rooted | plugin_rooted)
         pending.extend(
-            (imported_path, False)
-            for imported_path in ordinary_paths
+            (imported_path, False, root)
+            for root, imported_path in ordinary_rooted
             if _test_path_exists_at_ref(repo_root, source_ref, imported_path)
         )
         pending.extend(
-            (plugin_path, plugin_path in plugin_target_paths)
-            for plugin_path in plugin_paths
+            (plugin_path, (root, plugin_path) in plugin_targets, root)
+            for root, plugin_path in plugin_rooted
             if _test_path_exists_at_ref(repo_root, source_ref, plugin_path)
         )
     return imported_paths
@@ -918,21 +946,23 @@ def _proof_inputs(repo_root: Path, source_ref: str, selector_paths: Sequence[str
     traversal_inputs = pytest_inputs | initializer_inputs
     plugin_module_roots = _pythonpath_roots(repo_root, source_ref)
     addopts_names = _addopts_plugin_module_names(repo_root, source_ref)
-    addopts_paths = _discovered_python_paths(addopts_names, plugin_module_roots)
+    addopts_rooted = _discovered_rooted_paths(addopts_names, plugin_module_roots)
     addopts_targets = {
-        path
+        (root, path)
         for module_parts in addopts_names
-        for path in _python_module_target_paths(module_parts, plugin_module_roots)
+        for root in plugin_module_roots
+        for path in _python_module_target_paths(module_parts, (root,))
     }
+    seeds = [(path, path in pytest_inputs, "") for path in sorted(traversal_inputs)]
+    seeds += [(path, (root, path) in addopts_targets, root) for root, path in sorted(addopts_rooted)]
     return {
         *traversal_inputs,
         *PYTEST_CONFIGURATION_FILES,
-        *addopts_paths,
+        *(path for _, path in addopts_rooted),
         *_imported_python_paths(
             repo_root,
             source_ref,
-            sorted(traversal_inputs | addopts_paths),
-            pytest_plugin_source_paths=pytest_inputs | addopts_targets,
+            seeds,
             plugin_module_roots=plugin_module_roots,
         ),
     }

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -675,14 +675,25 @@ def _verified_type_checking_bindings(tree: ast.AST, before_line: int | None = No
     )
 
 
-def _module_scope_nodes(tree: ast.AST, *, include_class_bodies: bool = False) -> list[ast.AST]:
-    """Return executable module nodes without entering deferred function scopes."""
+def _module_scope_nodes(
+    tree: ast.AST, *, include_class_bodies: bool = False, include_deferred_scopes: bool = False
+) -> list[ast.AST]:
+    """Return executable module nodes without entering deferred function scopes.
+
+    A caller collecting imports enters them anyway: a function invoked while the module
+    loads executes its imports at import time, and one invoked from a fixture executes them
+    while the selected test runs, so either way the imported file decides the outcome.
+    Static branch pruning still applies inside those bodies, so a guarded type-only import
+    stays unbound.
+    """
     pending = list(reversed(list(ast.iter_child_nodes(tree))))
     nodes: list[ast.AST] = []
     while pending:
         node = pending.pop()
         nodes.append(node)
-        deferred_scope = isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef, ast.Lambda))
+        deferred_scope = (
+            isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef, ast.Lambda)) and not include_deferred_scopes
+        )
         excluded_class_scope = isinstance(node, ast.ClassDef) and not include_class_bodies
         if deferred_scope or excluded_class_scope:
             # The body does not run here, but decorators, defaults, and bases do.
@@ -870,7 +881,11 @@ def _import_module_names(tree: ast.AST, current_path: str) -> list[list[str]]:
     """Return imported module names, including relative import candidates."""
     current_package = list(PurePosixPath(current_path).parent.parts)
     module_names: list[list[str]] = []
-    for node in _module_scope_nodes(tree, include_class_bodies=True):
+    # A function body runs only when something invokes it. A module that calls nothing while
+    # loading cannot reach one, so its bodies stay unbound; once the module does invoke
+    # something, which body that reaches cannot be decided, so every body counts.
+    reachable_bodies = _calls_during_module_load(tree)
+    for node in _module_scope_nodes(tree, include_class_bodies=True, include_deferred_scopes=reachable_bodies):
         if isinstance(node, ast.Import):
             module_names.extend(alias.name.split(".") for alias in node.names)
         elif isinstance(node, ast.ImportFrom):

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -61,6 +61,10 @@ PYTEST_INI_SECTIONS = {
     "setup.cfg": "tool:pytest",
 }
 REPOSITORY_ROOT_MODULE_ROOTS = ("",)
+# Plugins the executor early-loads with ``-p`` on every proof run. They are not declared in any
+# configuration this gate can read, so they are named here and held to the executor's own command
+# shape by a contract test rather than by these two files being edited together.
+EXECUTOR_PLUGIN_NAMES = (("scripts", "requirements_proof_pytest_plugin"),)
 GIT_TIMEOUT_SECONDS = 30
 UNRESOLVED_PLUGIN_VALUE = object()
 
@@ -1029,14 +1033,28 @@ def _literal_module_candidates(tree: ast.AST, current_path: str) -> list[list[st
     names: list[list[str]] = []
     reachable_bodies = _deferred_scopes_are_reachable(tree, current_path)
     for node in _module_scope_nodes(tree, include_class_bodies=True, include_deferred_scopes=reachable_bodies):
-        if not isinstance(node, ast.Call):
-            continue
-        arguments = [*node.args, *(keyword.value for keyword in node.keywords)]
-        for value in itertools.chain.from_iterable(_literal_strings(argument) for argument in arguments):
+        handed_over = _handed_over_expressions(node)
+        for value in itertools.chain.from_iterable(_literal_strings(argument) for argument in handed_over):
             parts = value.split(".")
             if len(parts) > 1 and all(part.isidentifier() for part in parts):
                 names.append(parts)
     return names
+
+
+def _handed_over_expressions(node: ast.AST) -> list[ast.expr]:
+    """Return the expressions a statement hands to something that consumes them.
+
+    A call receives its arguments and a loop or comprehension receives what it iterates. A value
+    in either position is used, unlike one that is only bound to a name, so this is the position
+    that separates a literal naming something the run reads from a literal written down.
+    """
+    if isinstance(node, ast.Call):
+        return [*node.args, *(keyword.value for keyword in node.keywords)]
+    if isinstance(node, (ast.AsyncFor, ast.For)):
+        return [node.iter]
+    if isinstance(node, ast.comprehension):
+        return [node.iter]
+    return []
 
 
 def _literal_strings(expression: ast.expr) -> list[str]:
@@ -1102,6 +1120,83 @@ def _discovered_rooted_paths(
         for module_parts in module_names
         for root in module_roots
         for path in _python_module_paths(module_parts, (root,))
+    }
+
+
+def _joined_path_literal(expression: ast.expr) -> str | None:
+    """Return the repository-relative path a chain of ``/`` joins spells, if it is fully literal.
+
+    ``REPO_ROOT / "tests" / "data" / "case.json"`` names a file as directly as a single string
+    does; the root the chain starts from is dropped because a path built inside the checkout is
+    only bindable relative to it.
+    """
+    parts: list[str] = []
+    node: ast.expr = expression
+    while isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+        if not isinstance(node.right, ast.Constant) or not isinstance(node.right.value, str):
+            return None
+        parts.insert(0, node.right.value)
+        node = node.left
+    return "/".join(parts) if parts else None
+
+
+def _literal_path_candidates(tree: ast.AST, current_path: str) -> list[str]:
+    """Return repository-relative paths a reachable body names as literals.
+
+    A harness reads a data file the same way it names a module: by handing a literal to a call,
+    or by joining literals onto a path root. Both are resolved, and nothing else is, because a
+    path assembled at runtime — ``tmp_path / name`` — cannot be bound to a committed file and
+    failing closed on it would reject every proof in a repository that uses temporary
+    directories, which is every repository.
+    """
+    candidates: list[str] = []
+    reachable_bodies = _deferred_scopes_are_reachable(tree, current_path)
+    for node in _module_scope_nodes(tree, include_class_bodies=True, include_deferred_scopes=reachable_bodies):
+        handed_over = _handed_over_expressions(node)
+        candidates.extend(itertools.chain.from_iterable(_literal_strings(argument) for argument in handed_over))
+        if isinstance(node, ast.BinOp) and (joined := _joined_path_literal(node)) is not None:
+            candidates.append(joined)
+    return [candidate.strip("/") for candidate in candidates if candidate.strip("/")]
+
+
+def _harness_directories(selector_paths: Sequence[str]) -> tuple[str, ...]:
+    """Return the top-level directories the selected tests live in.
+
+    Data beneath them belongs to the harness, so a red-to-green change may not edit it. Anything
+    outside is what the change is expected to edit — production source, documentation, packaging
+    — which is why ordinary imports already stop at the repository root rather than following
+    into it. A selector sitting at the repository root contributes no directory, so it widens
+    nothing.
+    """
+    return tuple(sorted({parts[0] for path in selector_paths if (parts := PurePosixPath(path).parts[:-1])}))
+
+
+def _is_harness_path(path: str, harness_directories: Sequence[str]) -> bool:
+    """Return whether a path names harness data rather than something the fix may change."""
+    if path in GOVERNED_PRODUCTION_FILES or path.startswith(GOVERNED_PRODUCTION_PREFIXES):
+        return False
+    return any(path.startswith(f"{directory}/") for directory in harness_directories)
+
+
+def _referenced_data_paths(
+    repo_root: Path, source_ref: str, python_paths: Sequence[str], selector_paths: Sequence[str]
+) -> set[str]:
+    """Return committed harness data the resolved Python proof inputs read by literal path.
+
+    Data files import nothing, so this pass runs once over the already-resolved Python inputs
+    rather than participating in their traversal.
+    """
+    harness_directories = _harness_directories(selector_paths)
+    if not harness_directories:
+        return set()
+    return {
+        candidate
+        for path in python_paths
+        if (tree := _python_tree_at_ref(repo_root, source_ref, path)) is not None
+        for candidate in _literal_path_candidates(tree, path)
+        if _is_harness_path(candidate, harness_directories)
+        and _test_path_exists_at_ref(repo_root, source_ref, candidate)
+        and _test_path_is_regular_at_ref(repo_root, source_ref, candidate)
     }
 
 
@@ -1378,8 +1473,9 @@ def _proof_inputs(repo_root: Path, source_ref: str, selector_paths: Sequence[str
     """Return every committed path whose change after the red source would invalidate the proof.
 
     Selectors are resolved together so their shared conftest, initializer, and import graph is
-    traversed once for the whole proof. Plugins early-loaded through configured ``addopts``
-    ``-p`` options are seeded alongside them, because pytest loads those modules too.
+    traversed once for the whole proof. Plugins early-loaded through ``-p`` are seeded alongside
+    them, because pytest loads those modules too, whether the option comes from configured
+    ``addopts`` or from the command the executor builds for every run.
     """
     pytest_inputs = {
         path for test_path in selector_paths for path in (test_path, *_ancestor_file_paths(test_path, "conftest.py"))
@@ -1390,7 +1486,10 @@ def _proof_inputs(repo_root: Path, source_ref: str, selector_paths: Sequence[str
     traversal_inputs = pytest_inputs | initializer_inputs
     configuration_directories = _configuration_directories(selector_paths)
     plugin_module_roots = _pythonpath_roots(repo_root, source_ref, configuration_directories)
-    addopts_names = _addopts_plugin_module_names(repo_root, source_ref, configuration_directories)
+    addopts_names = (
+        *_addopts_plugin_module_names(repo_root, source_ref, configuration_directories),
+        *EXECUTOR_PLUGIN_NAMES,
+    )
     addopts_rooted = _discovered_rooted_paths(addopts_names, plugin_module_roots)
     addopts_targets = {
         (root, path)
@@ -1400,16 +1499,15 @@ def _proof_inputs(repo_root: Path, source_ref: str, selector_paths: Sequence[str
     }
     seeds = [(path, path in pytest_inputs, "") for path in sorted(traversal_inputs)]
     seeds += [(path, (root, path) in addopts_targets, root) for root, path in sorted(addopts_rooted)]
-    return {
+    python_inputs = {
         *traversal_inputs,
-        *_configuration_candidate_paths(configuration_directories),
         *(path for _, path in addopts_rooted),
-        *_imported_python_paths(
-            repo_root,
-            source_ref,
-            seeds,
-            plugin_module_roots=plugin_module_roots,
-        ),
+        *_imported_python_paths(repo_root, source_ref, seeds, plugin_module_roots=plugin_module_roots),
+    }
+    return {
+        *python_inputs,
+        *_configuration_candidate_paths(configuration_directories),
+        *_referenced_data_paths(repo_root, source_ref, sorted(python_inputs), selector_paths),
     }
 
 

--- a/scripts/security_audit_gate.py
+++ b/scripts/security_audit_gate.py
@@ -165,7 +165,7 @@ def _read_exception_items(path: Path) -> tuple[list[JsonValue] | None, str | Non
     """Read the exception list, returning one fail-closed error on invalid input."""
     try:
         payload = cast(JsonValue, json.loads(path.read_text(encoding="utf-8")))
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         return None, f"could not read vulnerability exception register: {exc}"
     if not isinstance(payload, dict):
         return None, "vulnerability exception register must contain an exceptions list"

--- a/scripts/verify_safe_project_writes.py
+++ b/scripts/verify_safe_project_writes.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import ast
 import sys
 from pathlib import Path
+from typing import NamedTuple
 
 from beartype import beartype
 from icontract import ensure, require
@@ -42,24 +43,50 @@ def _register_json_from_func_alias(alias: ast.alias, func_aliases: dict[str, str
     func_aliases[local] = f"json.{alias.name}"
 
 
+def _defers_annotations(node: ast.Module) -> bool:
+    """Return whether PEP 563 leaves this module's annotations unevaluated."""
+    return any(
+        isinstance(stmt, ast.ImportFrom)
+        and stmt.module == "__future__"
+        and any(alias.name == "annotations" for alias in stmt.names)
+        for stmt in node.body
+    )
+
+
+def _argument_slots(args: ast.arguments) -> tuple[ast.arg, ...]:
+    named = (*args.posonlyargs, *args.args, *args.kwonlyargs)
+    variadic = tuple(slot for slot in (args.vararg, args.kwarg) if slot is not None)
+    return (*named, *variadic)
+
+
+class _Scope(NamedTuple):
+    """One name-binding frame; a class body is invisible to the scopes nested in it."""
+
+    is_class_body: bool
+    names: set[str]
+
+
 class _JsonIOShadowVisitor(ast.NodeVisitor):
     """Track json import aliases and whether call targets were shadowed by assignment."""
 
     def __init__(self) -> None:
         self.func_aliases: dict[str, str] = {}
         self.module_locals: set[str] = set()
-        self.shadow_stack: list[set[str]] = [set()]
+        self.scope_stack: list[_Scope] = [_Scope(is_class_body=False, names=set())]
+        self.annotations_evaluated = True
         self.offenders: list[tuple[int, str]] = []
 
-    def _union_shadowed(self) -> set[str]:
-        merged: set[str] = set()
-        for frame in self.shadow_stack:
-            merged |= frame
+    def _visible_shadowed(self) -> set[str]:
+        innermost, *enclosing = reversed(self.scope_stack)
+        merged = set(innermost.names)
+        for scope in enclosing:
+            if not scope.is_class_body:
+                merged |= scope.names
         return merged
 
     def _note_shadow(self, name: str) -> None:
         if name in self.func_aliases or name in self.module_locals:
-            self.shadow_stack[-1].add(name)
+            self.scope_stack[-1].names.add(name)
 
     def _note_optional_vars(self, node: ast.AST) -> None:
         if isinstance(node, ast.Name):
@@ -89,7 +116,8 @@ class _JsonIOShadowVisitor(ast.NodeVisitor):
                         self._note_shadow(elt.id)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
-        self.visit(node.annotation)
+        if self.annotations_evaluated:
+            self.visit(node.annotation)
         if node.value is not None:
             self.visit(node.value)
         if isinstance(node.target, ast.Name):
@@ -136,48 +164,91 @@ class _JsonIOShadowVisitor(ast.NodeVisitor):
     def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
         if node.type is not None:
             self.visit(node.type)
-        if node.name:
-            self._note_shadow(node.name)
+        name = node.name
+        # Python deletes the `as` target when the handler ends, so it only shadows inside the body.
+        unbinds = bool(name) and name not in self.scope_stack[-1].names
+        if name:
+            self._note_shadow(name)
         for stmt in node.body:
             self.visit(stmt)
+        if name and unbinds:
+            self.scope_stack[-1].names.discard(name)
+
+    def _visit_decorators(self, decorators: list[ast.expr]) -> None:
+        for decorator in decorators:
+            # A decorator that is not itself a call still invokes the name it references.
+            if not isinstance(decorator, ast.Call) and (target := self._json_io_target(decorator)) is not None:
+                self.offenders.append((decorator.lineno, target))
+            self.visit(decorator)
+
+    def _visit_argument_defaults(self, args: ast.arguments) -> None:
+        for default in (*args.defaults, *args.kw_defaults):
+            if default is not None:
+                self.visit(default)
+
+    def _note_parameters(self, args: ast.arguments) -> None:
+        for arg in _argument_slots(args):
+            self._note_shadow(arg.arg)
 
     def visit_FunctionDef(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
-        self.shadow_stack.append(set())
-        for arg in (*getattr(node.args, "posonlyargs", ()), *node.args.args, *node.args.kwonlyargs):
-            self._note_shadow(arg.arg)
-        if node.args.vararg:
-            self._note_shadow(node.args.vararg.arg)
-        if node.args.kwarg:
-            self._note_shadow(node.args.kwarg.arg)
+        # Decorators, defaults, and evaluated annotations run in the enclosing scope, not the body.
+        self._visit_decorators(node.decorator_list)
+        self._visit_argument_defaults(node.args)
+        if self.annotations_evaluated:
+            slots = _argument_slots(node.args)
+            for annotation in (*(slot.annotation for slot in slots), node.returns):
+                if annotation is not None:
+                    self.visit(annotation)
+        self.scope_stack.append(_Scope(is_class_body=False, names=set()))
+        self._note_parameters(node.args)
         for stmt in node.body:
             self.visit(stmt)
-        self.shadow_stack.pop()
+        self.scope_stack.pop()
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         self.visit_FunctionDef(node)  # type: ignore[arg-type]
 
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        self._visit_argument_defaults(node.args)
+        self.scope_stack.append(_Scope(is_class_body=False, names=set()))
+        self._note_parameters(node.args)
+        self.visit(node.body)
+        self.scope_stack.pop()
+
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
-        self.shadow_stack.append(set())
+        self._visit_decorators(node.decorator_list)
+        for base in node.bases:
+            self.visit(base)
+        for keyword in node.keywords:
+            self.visit(keyword.value)
+        self.scope_stack.append(_Scope(is_class_body=True, names=set()))
         for stmt in node.body:
             self.visit(stmt)
-        self.shadow_stack.pop()
+        self.scope_stack.pop()
 
-    def visit_Call(self, node: ast.Call) -> None:
-        shadowed = self._union_shadowed()
-        func = node.func
+    def _json_io_target(self, func: ast.expr) -> str | None:
+        """Return the canonical json I/O name this expression invokes, if any."""
+        shadowed = self._visible_shadowed()
         if isinstance(func, ast.Name) and func.id in self.func_aliases and func.id not in shadowed:
-            self.offenders.append((node.lineno, self.func_aliases[func.id]))
-        elif (
+            return self.func_aliases[func.id]
+        if (
             isinstance(func, ast.Attribute)
             and isinstance(func.value, ast.Name)
             and func.value.id in self.module_locals
             and func.value.id not in shadowed
             and func.attr in _JSON_IO_NAMES
         ):
-            self.offenders.append((node.lineno, f"json.{func.attr}"))
+            return f"json.{func.attr}"
+        return None
+
+    def visit_Call(self, node: ast.Call) -> None:
+        target = self._json_io_target(node.func)
+        if target is not None:
+            self.offenders.append((node.lineno, target))
         self.generic_visit(node)
 
     def visit_Module(self, node: ast.Module) -> None:
+        self.annotations_evaluated = not _defers_annotations(node)
         for stmt in node.body:
             self.visit(stmt)
 

--- a/tests/integration/scripts/observer_plugin.py
+++ b/tests/integration/scripts/observer_plugin.py
@@ -1,7 +1,12 @@
-"""Record the repository-local files a pytest run actually imported.
+"""Record the repository-local files a pytest run actually imports and reads.
 
 Loaded with ``-p`` from outside the repository under test, so the observation does not alter
 the layout being observed.
+
+Two things are recorded, because the gate binds two kinds of input. Imported modules are read
+off ``sys.modules`` at session finish. Files opened for reading are captured by an audit hook,
+which is the only way to see a fixture reading ``tests/data/case.json`` — that read leaves no
+trace in ``sys.modules`` and is precisely where the path-resolution rules are exercised.
 """
 
 from __future__ import annotations
@@ -12,16 +17,55 @@ import sys
 from typing import Any
 
 
+_OPENED: set[str] = set()
+_REPOSITORY_ROOT = os.path.realpath(os.environ["OBSERVE_ROOT"])
+# Directories a run writes to or populates itself. They are not repository inputs, and a gate
+# cannot bind them because they are not committed.
+_IGNORED_SEGMENTS = frozenset({".git", "__pycache__", ".pytest_cache"})
+
+
+def _repository_relative(path: str) -> str | None:
+    """Return a path relative to the observed repository, or ``None`` when it lies outside."""
+    try:
+        relative = os.path.relpath(os.path.realpath(path), _REPOSITORY_ROOT)
+    except (OSError, ValueError):
+        return None
+    if relative.startswith(os.pardir) or os.path.isabs(relative):
+        return None
+    posix = relative.replace(os.sep, "/")
+    if any(segment in _IGNORED_SEGMENTS for segment in posix.split("/")):
+        return None
+    return posix
+
+
+def _record_open(event: str, arguments: tuple[Any, ...]) -> None:
+    """Record repository files opened for reading."""
+    if event != "open" or not arguments:
+        return
+    path = arguments[0]
+    if not isinstance(path, (str, bytes, os.PathLike)):
+        return
+    mode = arguments[1] if len(arguments) > 1 else "r"
+    if isinstance(mode, str) and ("w" in mode or "a" in mode or "x" in mode):
+        return
+    relative = _repository_relative(os.fsdecode(path))
+    if relative is not None:
+        _OPENED.add(relative)
+
+
+sys.addaudithook(_record_open)
+
+
 def pytest_sessionfinish(session: Any, exitstatus: Any) -> None:
-    """Write every module file loaded from inside the observed repository."""
-    repository_root = os.path.realpath(os.environ["OBSERVE_ROOT"])
-    observed: set[str] = set()
+    """Write every repository-local file the run imported or read."""
+    imported: set[str] = set()
     for module in list(sys.modules.values()):
         file_name = getattr(module, "__file__", None)
         if not file_name:
             continue
-        relative = os.path.relpath(os.path.realpath(file_name), repository_root)
-        if not relative.startswith(os.pardir) and not os.path.isabs(relative):
-            observed.add(relative.replace(os.sep, "/"))
+        relative = _repository_relative(file_name)
+        if relative is not None:
+            imported.add(relative)
+    observation = {"imported": sorted(imported), "read": sorted(_OPENED)}
     with open(os.environ["OBSERVE_OUT"], "w", encoding="utf-8") as handle:
-        json.dump(sorted(observed), handle)
+        json.dump(observation, handle)

--- a/tests/integration/scripts/observer_plugin.py
+++ b/tests/integration/scripts/observer_plugin.py
@@ -1,0 +1,27 @@
+"""Record the repository-local files a pytest run actually imported.
+
+Loaded with ``-p`` from outside the repository under test, so the observation does not alter
+the layout being observed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+
+
+def pytest_sessionfinish(session: Any, exitstatus: Any) -> None:
+    """Write every module file loaded from inside the observed repository."""
+    repository_root = os.path.realpath(os.environ["OBSERVE_ROOT"])
+    observed: set[str] = set()
+    for module in list(sys.modules.values()):
+        file_name = getattr(module, "__file__", None)
+        if not file_name:
+            continue
+        relative = os.path.relpath(os.path.realpath(file_name), repository_root)
+        if not relative.startswith(os.pardir) and not os.path.isabs(relative):
+            observed.add(relative.replace(os.sep, "/"))
+    with open(os.environ["OBSERVE_OUT"], "w", encoding="utf-8") as handle:
+        json.dump(sorted(observed), handle)

--- a/tests/integration/scripts/test_requirements_proof_provenance_against_pytest.py
+++ b/tests/integration/scripts/test_requirements_proof_provenance_against_pytest.py
@@ -6,11 +6,17 @@ in. A model has no error bar. Each divergence found so far was found by a review
 rule, which makes review the only oracle, and review does not run on every change.
 
 These tests supply the missing oracle. For a set of repository layouts, pytest is run for real
-and every repository-local module it imports is recorded; the gate must bind all of them. A rule
-that stops matching how pytest actually resolves something fails here rather than surviving
-until someone reads it.
+and every repository-local file it imports *or reads* is recorded; the gate must bind all of
+them. A rule that stops matching how pytest actually resolves something fails here rather than
+surviving until someone reads it.
 
-The direction is deliberate: this asserts the gate binds at least what pytest loaded. It is a
+Reads are observed as well as imports because the two exercise different rule families. An
+import is visible in ``sys.modules``; a fixture reading ``tests/data/case.json`` is not, and the
+path-resolution rules — join notations, ``__file__``-relative bases, links — live entirely in
+that second family. Observing only imports would leave them checked by review alone, which is
+the condition this file exists to end.
+
+The direction is deliberate: this asserts the gate binds at least what pytest touched. It is a
 guard against binding too little. The companion measurement in
 ``test_requirements_proof_provenance_repository.py`` guards the other direction.
 """
@@ -36,10 +42,23 @@ SELECTOR = f"{SELECTED_TEST}::test_selected"
 
 
 class Layout(NamedTuple):
-    """One repository shape, described by the files it contains."""
+    """One repository shape, described by the files it contains and any links it needs."""
 
     name: str
     files: dict[str, str]
+    links: dict[str, str] = {}
+
+
+class Observation(NamedTuple):
+    """What one real pytest run touched inside the observed repository."""
+
+    imported: frozenset[str]
+    read: frozenset[str]
+
+    @property
+    def touched(self) -> frozenset[str]:
+        """Return every repository file the run depended on, however it reached it."""
+        return self.imported | self.read
 
 
 # Each layout puts the helper somewhere pytest can reach and the gate must therefore resolve.
@@ -101,6 +120,61 @@ LAYOUTS = [
             "tests/helper.py": "VALUE = False\n",
         },
     ),
+    # From here the run reads data rather than importing it. None of these appear in
+    # ``sys.modules``, so they exercise the path-resolution rules and nothing else does.
+    Layout(
+        "data read through a repository-relative literal",
+        {
+            "tests/conftest.py": 'from pathlib import Path\n\nCASE = Path("tests/data/case.json").read_text()\n',
+            "tests/data/case.json": '{"expected": false}\n',
+        },
+    ),
+    Layout(
+        "data read relative to the reading module",
+        {
+            "tests/conftest.py": (
+                'from pathlib import Path\n\nCASE = (Path(__file__).parent / "data" / "case.json").read_text()\n'
+            ),
+            "tests/data/case.json": '{"expected": false}\n',
+        },
+    ),
+    Layout(
+        "data read through a functional join",
+        {
+            "tests/conftest.py": (
+                "import os\n\nwith open(os.path.join(os.path.dirname(__file__), "
+                '"data", "case.json")) as handle:\n    CASE = handle.read()\n'
+            ),
+            "tests/data/case.json": '{"expected": false}\n',
+        },
+    ),
+    Layout(
+        "data read inside a fixture body",
+        {
+            "tests/conftest.py": (
+                "from pathlib import Path\n\nimport pytest\n\n\n@pytest.fixture\ndef case():\n"
+                '    return (Path(__file__).parent / "data" / "case.json").read_text()\n'
+            ),
+            "tests/data/case.json": '{"expected": false}\n',
+            "tests/test_proof.py": "def test_selected(case) -> None:\n    assert False\n",
+        },
+    ),
+    Layout(
+        "data read through a linked file",
+        {
+            "tests/conftest.py": 'from pathlib import Path\n\nCASE = Path("tests/data/case.json").read_text()\n',
+            "tests/data/real.json": '{"expected": false}\n',
+        },
+        {"tests/data/case.json": "real.json"},
+    ),
+    Layout(
+        "data read through a linked directory",
+        {
+            "tests/conftest.py": 'from pathlib import Path\n\nCASE = Path("tests/linked/case.json").read_text()\n',
+            "tests/real_data/case.json": '{"expected": false}\n',
+        },
+        {"tests/linked": "real_data"},
+    ),
 ]
 
 
@@ -129,9 +203,14 @@ def _build_repository(repository: Path, layout: Layout) -> str:
         path = repository / relative
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
+    for relative, target in layout.links.items():
+        link = repository / relative
+        link.parent.mkdir(parents=True, exist_ok=True)
+        link.symlink_to(target)
     selected = repository / SELECTED_TEST
-    selected.parent.mkdir(parents=True, exist_ok=True)
-    selected.write_text("def test_selected() -> None:\n    assert False\n", encoding="utf-8")
+    if SELECTED_TEST not in layout.files:
+        selected.parent.mkdir(parents=True, exist_ok=True)
+        selected.write_text("def test_selected() -> None:\n    assert False\n", encoding="utf-8")
     _git(repository, "init")
     _git(repository, "config", "user.email", "requirements@example.test")
     _git(repository, "config", "user.name", "Requirements proof")
@@ -140,8 +219,8 @@ def _build_repository(repository: Path, layout: Layout) -> str:
     return _git(repository, "rev-parse", "HEAD").strip()
 
 
-def _observed_repository_modules(repository: Path, observation_path: Path) -> set[str]:
-    """Run pytest for real and return the repository-local modules it imported."""
+def _observed_repository_files(repository: Path, observation_path: Path) -> Observation:
+    """Run pytest for real and return the repository-local files it imported and read."""
     environment = {
         **os.environ,
         "PYTHONPATH": str(OBSERVER_DIRECTORY),
@@ -161,29 +240,32 @@ def _observed_repository_modules(repository: Path, observation_path: Path) -> se
     )
     if not observation_path.exists():
         raise AssertionError(f"pytest did not reach session finish:\n{result.stdout}\n{result.stderr}")
-    observed = cast(list[str], json.loads(observation_path.read_text(encoding="utf-8")))
+    recorded = cast(dict[str, list[str]], json.loads(observation_path.read_text(encoding="utf-8")))
+    observation = Observation(frozenset(recorded["imported"]), frozenset(recorded["read"]))
     # The run must have collected the selected test, or it observed nothing meaningful.
-    assert SELECTED_TEST in observed, f"pytest did not import the selected test:\n{result.stdout}\n{result.stderr}"
-    return set(observed)
+    assert SELECTED_TEST in observation.imported, (
+        f"pytest did not import the selected test:\n{result.stdout}\n{result.stderr}"
+    )
+    return observation
 
 
 @pytest.mark.integration
 @pytest.mark.slow
 @pytest.mark.parametrize("layout", LAYOUTS, ids=lambda layout: layout.name)
-def test_the_gate_binds_every_module_pytest_actually_imported(tmp_path: Path, layout: Layout) -> None:
-    """Whatever pytest loaded decided the outcome, so a proof that omits it is not bound to it."""
+def test_the_gate_binds_every_file_pytest_actually_used(tmp_path: Path, layout: Layout) -> None:
+    """Whatever pytest loaded or read decided the outcome, so a proof that omits it is not bound."""
     module = _load_provenance_module()
     repository = tmp_path / "repository"
     repository.mkdir()
     source_ref = _build_repository(repository, layout)
 
-    observed = _observed_repository_modules(repository, tmp_path / "observed.json")
+    observed = _observed_repository_files(repository, tmp_path / "observed.json")
     bound = module._proof_inputs(
         repository, source_ref, (SELECTED_TEST,), {SELECTED_TEST: frozenset({"test_selected"})}
     )
 
-    unbound = sorted(observed - bound)
+    unbound = sorted(observed.touched - bound)
     assert not unbound, (
-        f"pytest imported these files while the gate bound none of them, so a change to any of "
+        f"pytest used these files while the gate bound none of them, so a change to any of "
         f"them after the red source would not invalidate the proof: {unbound}"
     )

--- a/tests/integration/scripts/test_requirements_proof_provenance_against_pytest.py
+++ b/tests/integration/scripts/test_requirements_proof_provenance_against_pytest.py
@@ -1,0 +1,189 @@
+"""Integration: the provenance gate's resolved inputs, checked against what pytest really loads.
+
+Every rule in the gate is a hand-derived model of pytest's behaviour — which files it reads to
+decide collection, which directories it puts on ``sys.path``, which modules a declaration pulls
+in. A model has no error bar. Each divergence found so far was found by a reviewer reading the
+rule, which makes review the only oracle, and review does not run on every change.
+
+These tests supply the missing oracle. For a set of repository layouts, pytest is run for real
+and every repository-local module it imports is recorded; the gate must bind all of them. A rule
+that stops matching how pytest actually resolves something fails here rather than surviving
+until someone reads it.
+
+The direction is deliberate: this asserts the gate binds at least what pytest loaded. It is a
+guard against binding too little. The companion measurement in
+``test_requirements_proof_provenance_repository.py`` guards the other direction.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, NamedTuple, cast
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PROVENANCE_SCRIPT = REPO_ROOT / "scripts" / "requirements_proof_provenance.py"
+OBSERVER_DIRECTORY = Path(__file__).resolve().parent
+SELECTED_TEST = "tests/test_proof.py"
+SELECTOR = f"{SELECTED_TEST}::test_selected"
+
+
+class Layout(NamedTuple):
+    """One repository shape, described by the files it contains."""
+
+    name: str
+    files: dict[str, str]
+
+
+# Each layout puts the helper somewhere pytest can reach and the gate must therefore resolve.
+# They differ in the mechanism, not in the outcome: `tests/helper.py` is loaded in every one.
+LAYOUTS = [
+    Layout(
+        "bare import through the prepended test directory",
+        {
+            "tests/conftest.py": "import helper\n",
+            "tests/helper.py": "VALUE = False\n",
+        },
+    ),
+    Layout(
+        "package-qualified import from a package test directory",
+        {
+            "tests/__init__.py": "",
+            "tests/conftest.py": "import tests.helper\n",
+            "tests/helper.py": "VALUE = False\n",
+        },
+    ),
+    Layout(
+        "conftest chain from the repository root",
+        {
+            "conftest.py": "import support\n",
+            "support.py": "VALUE = False\n",
+            "tests/conftest.py": "import helper\n",
+            "tests/helper.py": "VALUE = False\n",
+        },
+    ),
+    Layout(
+        "declared plugin importing its own helper",
+        {
+            "conftest.py": 'pytest_plugins = ["tests.localplugin"]\n',
+            "tests/__init__.py": "",
+            "tests/localplugin.py": "from tests import helper\n",
+            "tests/helper.py": "VALUE = False\n",
+        },
+    ),
+    Layout(
+        "plugin reached through a configured pythonpath root",
+        {
+            "pyproject.toml": '[tool.pytest.ini_options]\npythonpath = ["extra"]\n',
+            "conftest.py": 'pytest_plugins = ["rooted"]\n',
+            "extra/rooted.py": "import rooted_helper\n",
+            "extra/rooted_helper.py": "VALUE = False\n",
+        },
+    ),
+    Layout(
+        "import inside a fixture body",
+        {
+            "tests/conftest.py": "import pytest\n\n\n@pytest.fixture\ndef support():\n    import helper\n\n    return helper\n",
+            "tests/helper.py": "VALUE = False\n",
+        },
+    ),
+    Layout(
+        "package initializer importing at load time",
+        {
+            "tests/__init__.py": "from tests import helper\n",
+            "tests/helper.py": "VALUE = False\n",
+        },
+    ),
+]
+
+
+def _load_provenance_module() -> Any:
+    spec = importlib.util.spec_from_file_location("requirements_proof_provenance", PROVENANCE_SCRIPT)
+    if spec is None or spec.loader is None:
+        raise AssertionError("Requirements proof provenance validator must be importable")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", *arguments], cwd=str(repository), check=False, capture_output=True, text=True, timeout=120
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"git {' '.join(arguments)} failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def _build_repository(repository: Path, layout: Layout) -> str:
+    """Write a layout, add the selected failing test, and commit the result."""
+    for relative, content in layout.files.items():
+        path = repository / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    selected = repository / SELECTED_TEST
+    selected.parent.mkdir(parents=True, exist_ok=True)
+    selected.write_text("def test_selected() -> None:\n    assert False\n", encoding="utf-8")
+    _git(repository, "init")
+    _git(repository, "config", "user.email", "requirements@example.test")
+    _git(repository, "config", "user.name", "Requirements proof")
+    _git(repository, "add", ".")
+    _git(repository, "commit", "--no-gpg-sign", "-m", "test: layout under observation")
+    return _git(repository, "rev-parse", "HEAD").strip()
+
+
+def _observed_repository_modules(repository: Path, observation_path: Path) -> set[str]:
+    """Run pytest for real and return the repository-local modules it imported."""
+    environment = {
+        **os.environ,
+        "PYTHONPATH": str(OBSERVER_DIRECTORY),
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+        "OBSERVE_ROOT": str(repository),
+        "OBSERVE_OUT": str(observation_path),
+        "PYTEST_ADDOPTS": "",
+    }
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "-p", "observer_plugin", "-p", "no:cacheprovider", "-q", "--", SELECTOR],
+        cwd=str(repository),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=300,
+        env=environment,
+    )
+    if not observation_path.exists():
+        raise AssertionError(f"pytest did not reach session finish:\n{result.stdout}\n{result.stderr}")
+    observed = cast(list[str], json.loads(observation_path.read_text(encoding="utf-8")))
+    # The run must have collected the selected test, or it observed nothing meaningful.
+    assert SELECTED_TEST in observed, f"pytest did not import the selected test:\n{result.stdout}\n{result.stderr}"
+    return set(observed)
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.parametrize("layout", LAYOUTS, ids=lambda layout: layout.name)
+def test_the_gate_binds_every_module_pytest_actually_imported(tmp_path: Path, layout: Layout) -> None:
+    """Whatever pytest loaded decided the outcome, so a proof that omits it is not bound to it."""
+    module = _load_provenance_module()
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    source_ref = _build_repository(repository, layout)
+
+    observed = _observed_repository_modules(repository, tmp_path / "observed.json")
+    bound = module._proof_inputs(
+        repository, source_ref, (SELECTED_TEST,), {SELECTED_TEST: frozenset({"test_selected"})}
+    )
+
+    unbound = sorted(observed - bound)
+    assert not unbound, (
+        f"pytest imported these files while the gate bound none of them, so a change to any of "
+        f"them after the red source would not invalidate the proof: {unbound}"
+    )

--- a/tests/integration/scripts/test_requirements_proof_provenance_against_pytest.py
+++ b/tests/integration/scripts/test_requirements_proof_provenance_against_pytest.py
@@ -16,9 +16,12 @@ path-resolution rules — join notations, ``__file__``-relative bases, links —
 that second family. Observing only imports would leave them checked by review alone, which is
 the condition this file exists to end.
 
-The direction is deliberate: this asserts the gate binds at least what pytest touched. It is a
-guard against binding too little. The companion measurement in
-``test_requirements_proof_provenance_repository.py`` guards the other direction.
+Each layout is checked in both directions. The gate must bind everything pytest touched, and it
+must leave alone a production file the run never opened — because a rule that becomes too eager
+rejects valid proofs just as silently as a rule that misses an input accepts stale ones, and a
+layout is the cheapest place to catch either. The whole-repository measurement in
+``test_requirements_proof_provenance_repository.py`` bounds the same two directions over real
+code, where these bound them over shapes chosen to be awkward.
 """
 
 from __future__ import annotations
@@ -39,6 +42,9 @@ PROVENANCE_SCRIPT = REPO_ROOT / "scripts" / "requirements_proof_provenance.py"
 OBSERVER_DIRECTORY = Path(__file__).resolve().parent
 SELECTED_TEST = "tests/test_proof.py"
 SELECTOR = f"{SELECTED_TEST}::test_selected"
+# Added to every layout and touched by none of them. A red-to-green change edits exactly this
+# kind of file, so binding it would reject the proof of the fix it is meant to prove.
+UNTOUCHED_PRODUCTION = "src/product.py"
 
 
 class Layout(NamedTuple):
@@ -175,6 +181,40 @@ LAYOUTS = [
         },
         {"tests/linked": "real_data"},
     ),
+    # Shapes chosen to look like something the gate rejects while reaching nothing it reads.
+    # They carry no helper: the assertion that matters is that the proof stays resolvable and
+    # the untouched production file stays unbound.
+    Layout(
+        # Attribute-backed and keyed by ``__name__``, which is the shape of the module table
+        # without being it. A method is called on the result, so a predicate that matches the
+        # shape rather than the table reads this as a namespace rewrite.
+        "a mapping merely keyed by the module name",
+        {
+            "tests/registry.py": "entries = {}\n",
+            "tests/conftest.py": (
+                "import registry\n\nregistry.entries[__name__] = []\nregistry.entries[__name__].append(1)\n"
+            ),
+        },
+    ),
+    Layout(
+        "a path assembled from a fixture value",
+        {
+            "tests/conftest.py": (
+                "from pathlib import Path\n\nimport pytest\n\n\n@pytest.fixture\n"
+                'def case(tmp_path):\n    target = tmp_path / "tests" / "data" / "case.json"\n'
+                '    target.parent.mkdir(parents=True)\n    target.write_text("{}")\n'
+                "    return target.read_text()\n"
+            ),
+            "tests/data/case.json": '{"expected": false}\n',
+            "tests/test_proof.py": "def test_selected(case) -> None:\n    assert False\n",
+        },
+    ),
+    Layout(
+        "a namespace read that writes nothing",
+        {
+            "tests/conftest.py": 'MARKER = "value"\nCHOSEN = globals()["MARKER"]\n',
+        },
+    ),
 ]
 
 
@@ -207,6 +247,9 @@ def _build_repository(repository: Path, layout: Layout) -> str:
         link = repository / relative
         link.parent.mkdir(parents=True, exist_ok=True)
         link.symlink_to(target)
+    production = repository / UNTOUCHED_PRODUCTION
+    production.parent.mkdir(parents=True, exist_ok=True)
+    production.write_text("VALUE = 0\n", encoding="utf-8")
     selected = repository / SELECTED_TEST
     if SELECTED_TEST not in layout.files:
         selected.parent.mkdir(parents=True, exist_ok=True)
@@ -268,4 +311,8 @@ def test_the_gate_binds_every_file_pytest_actually_used(tmp_path: Path, layout: 
     assert not unbound, (
         f"pytest used these files while the gate bound none of them, so a change to any of "
         f"them after the red source would not invalidate the proof: {unbound}"
+    )
+    assert UNTOUCHED_PRODUCTION not in bound, (
+        "the gate bound a production file this run never opened, so the red-to-green change "
+        "that edits it would invalidate its own proof"
     )

--- a/tests/integration/scripts/test_requirements_proof_provenance_repository.py
+++ b/tests/integration/scripts/test_requirements_proof_provenance_repository.py
@@ -1,0 +1,163 @@
+"""Integration: the proof-input set the provenance gate resolves for this repository.
+
+Every other test in the provenance suite states what the gate must bind. These state what it
+must not, which is the axis those cannot cover: a rule that binds too much satisfies every
+positive expectation while rejecting valid proofs, and it only shows up against a real tree
+with real conftest chains, plugins, and path literals. That measurement used to be run by
+hand before each change to the gate; running it here removes the manual step.
+
+Failures name the offending paths, because the fix is always to narrow the rule that bound
+them, not to widen the expectation.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, NamedTuple, Protocol, cast
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PROVENANCE_SCRIPT = REPO_ROOT / "scripts" / "requirements_proof_provenance.py"
+
+# The product source a red-to-green change edits by definition. Binding any of it would reject
+# the proof for the very fix it is meant to prove, so this is stated separately from the
+# exception list below and must never gain an entry.
+PRODUCT_SOURCE_PREFIX = "src/specfact_cli/"
+
+# Files outside the test tree that the gate binds for a stated reason. Each is something pytest
+# genuinely loads for the selected tests, so a change to it can change their outcome.
+EXPECTED_OUTSIDE_TEST_TREE = {
+    # Early-loaded on every proof run through the executor's -p option.
+    "scripts/requirements_proof_pytest_plugin.py",
+    # Imported directly by the tests that exercise them.
+    "scripts/runtime_discovery_smoke.py",
+    "tools/smart_test_coverage.py",
+    "tools/validate_prompts.py",
+}
+
+# The resolved set grows with the test suite, so it is bounded per selector rather than
+# absolutely. The ceiling is generous against the measured ratio; it catches a rule that starts
+# pulling in whole directories, not ordinary growth.
+MAX_INPUTS_PER_SELECTOR = 15
+
+
+class ProvenanceModule(Protocol):
+    """The internals this measurement drives directly."""
+
+    def _proof_inputs(self, repo_root: Path, source_ref: str, selector_paths: tuple[str, ...]) -> set[str]: ...
+
+    def _configuration_candidate_paths(self, directories: tuple[str, ...]) -> set[str]: ...
+
+    def _configuration_directories(self, selector_paths: tuple[str, ...]) -> tuple[str, ...]: ...
+
+
+class Measurement(NamedTuple):
+    """The resolved proof inputs for every selectable test committed at HEAD."""
+
+    selectors: tuple[str, ...]
+    inputs: frozenset[str]
+    committed: frozenset[str]
+    configuration_candidates: frozenset[str]
+
+    @property
+    def existing_inputs(self) -> frozenset[str]:
+        """Return only inputs that exist, since absent candidates bind no content."""
+        return self.inputs & self.committed
+
+
+def _load_provenance_module() -> ProvenanceModule:
+    spec = importlib.util.spec_from_file_location("requirements_proof_provenance", PROVENANCE_SCRIPT)
+    if spec is None or spec.loader is None:
+        raise AssertionError("Requirements proof provenance validator must be importable")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return cast(ProvenanceModule, module)
+
+
+def _git(*arguments: str) -> str:
+    result = subprocess.run(
+        ["git", *arguments], cwd=str(REPO_ROOT), check=False, capture_output=True, text=True, timeout=120
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"git {' '.join(arguments)} failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+@pytest.fixture(scope="module")
+def measurement() -> Measurement:
+    """Resolve the proof inputs once for every test in this file."""
+    module = cast(Any, _load_provenance_module())
+    source_ref = _git("rev-parse", "HEAD").strip()
+    committed = frozenset(_git("ls-files").split())
+    selectors = tuple(
+        sorted(
+            path
+            for path in committed
+            if path.startswith("tests/") and path.endswith(".py") and Path(path).name.startswith("test_")
+        )
+    )
+    assert selectors, "the repository must contain selectable tests for this measurement to mean anything"
+    directories = module._configuration_directories(selectors)
+    return Measurement(
+        selectors=selectors,
+        inputs=frozenset(module._proof_inputs(REPO_ROOT, source_ref, selectors)),
+        committed=committed,
+        configuration_candidates=frozenset(module._configuration_candidate_paths(directories)),
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_no_product_source_file_is_a_proof_input(measurement: Measurement) -> None:
+    """A change to product source is the fix, so binding it would reject every proof of one."""
+    bound_product_source = sorted(path for path in measurement.inputs if path.startswith(PRODUCT_SOURCE_PREFIX))
+
+    assert not bound_product_source, (
+        f"the gate binds product source, so a red-to-green change would invalidate its own proof: "
+        f"{bound_product_source}"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_every_bound_file_outside_the_test_tree_is_a_recorded_exception(measurement: Measurement) -> None:
+    """Anything the harness does not own is something a change may edit, so binding it is a defect."""
+    escapes = sorted(
+        path
+        for path in measurement.existing_inputs
+        if not path.startswith("tests/")
+        and path not in measurement.configuration_candidates
+        and path not in EXPECTED_OUTSIDE_TEST_TREE
+    )
+
+    assert not escapes, (
+        f"the gate binds files outside the test tree with no recorded reason, which will reject valid "
+        f"proofs whenever they change: {escapes}"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_the_bound_set_stays_proportional_to_the_selectors(measurement: Measurement) -> None:
+    """A rule that pulls in whole directories stays inside the test tree and escapes the check above."""
+    inputs_per_selector = len(measurement.inputs) / len(measurement.selectors)
+
+    assert inputs_per_selector <= MAX_INPUTS_PER_SELECTOR, (
+        f"{len(measurement.inputs)} inputs for {len(measurement.selectors)} selectors "
+        f"({inputs_per_selector:.1f} each) exceeds the ceiling of {MAX_INPUTS_PER_SELECTOR}"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_the_selected_tests_themselves_are_bound(measurement: Measurement) -> None:
+    """The measurement is only evidence of restraint while it still resolves what it must bind."""
+    unbound_selectors = sorted(set(measurement.selectors) - measurement.inputs)
+
+    assert not unbound_selectors, f"selected tests missing from their own proof inputs: {unbound_selectors[:5]}"

--- a/tests/unit/scripts/test_dependency_trust_review.py
+++ b/tests/unit/scripts/test_dependency_trust_review.py
@@ -247,3 +247,29 @@ def test_semgrep_lock_below_reviewed_security_floor_fails_before_install(tmp_pat
     errors = checker.validate_frozen_dependency_policy(register_path, lock_path, today=date(2026, 7, 24))
 
     assert errors == ["semgrep==1.70.1 is below the reviewed security floor 1.171.0"]
+
+
+def test_read_exception_records_reports_undecodable_register(tmp_path: Path) -> None:
+    """An unreadable trust register must fail closed with an error, not abort the check."""
+    checker = _load_checker()
+    register_path = tmp_path / "register.json"
+    register_path.write_bytes(b'{"exceptions": ["caf\xe9"]}\n')
+
+    records, errors = checker._read_exception_records(register_path)
+
+    assert records == []
+    assert len(errors) == 1
+    assert "could not read dependency trust register" in errors[0]
+
+
+def test_read_security_tool_floors_reports_undecodable_policy(tmp_path: Path) -> None:
+    """An unreadable floor policy must fail closed with an error, not abort the check."""
+    checker = _load_checker()
+    policy_path = tmp_path / "floors.json"
+    policy_path.write_bytes(b'{"pip-audit": "caf\xe9"}\n')
+
+    floors, errors = checker._read_security_tool_floors(policy_path)
+
+    assert floors == {}
+    assert len(errors) == 1
+    assert "could not read security tool floor policy" in errors[0]

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -3374,3 +3374,117 @@ def test_a_fixture_body_stays_bound_beside_an_unselected_test(tmp_path: Path) ->
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
         "stale-red-proof"
     ]
+
+
+# Every way a module can create ``pytest_plugins`` without an assignment statement whose target
+# names it. Each reaches the namespace pytest reads, so none may be inspected as a mere target.
+NAMESPACE_REWRITE_SHAPES = (
+    'globals().update(pytest_plugins=["tests.localplugin"])',
+    'globals().update({"pytest_plugins": ["tests.localplugin"]})',
+    'globals().setdefault("pytest_plugins", ["tests.localplugin"])',
+    'globals().__setitem__("pytest_plugins", ["tests.localplugin"])',
+    'vars().update(pytest_plugins=["tests.localplugin"])',
+    "exec('pytest_plugins = [\"tests.localplugin\"]', globals())",
+    "_install(globals())",
+    'sys.modules[__name__].pytest_plugins = ["tests.localplugin"]',
+)
+
+
+@pytest.mark.parametrize("rewrite", NAMESPACE_REWRITE_SHAPES)
+def test_a_namespace_rewrite_leaves_the_plugin_set_unverifiable(tmp_path: Path, rewrite: str) -> None:
+    """A declaration created through the namespace mapping is not readable from assignment targets."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "localplugin.py").write_text("def pytest_configure(config):\n    return None\n", "utf-8")
+    (tmp_path / "conftest.py").write_text(
+        f"import sys\n\n\ndef _install(namespace):\n    return namespace\n\n\n{rewrite}\n", "utf-8"
+    )
+    base_ref = _commit(tmp_path, "test: declare a plugin through the namespace")
+    (tmp_path / "tests" / "test_proof.py").write_text("def test_selected() -> None: assert False\n", "utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tmp_path / "tests" / "localplugin.py").write_text("def pytest_configure(config):\n    config.x = 1\n", "utf-8")
+    final_ref = _commit(tmp_path, "fix: change the plugin loaded through the namespace")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+# Joins spelled as calls rather than with the ``/`` operator. All name tests/data/case.json.
+FUNCTIONAL_JOIN_SHAPES = (
+    'open(os.path.join(os.path.dirname(__file__), "data/case.json")).read()',
+    'open(os.path.join(os.path.dirname(__file__), "data", "case.json")).read()',
+    '(Path(__file__).parent.joinpath("data", "case.json")).read_text()',
+    'Path(os.path.join(os.path.dirname(__file__), "data")).joinpath("case.json").read_text()',
+    'open(os.path.abspath(os.path.join(os.path.dirname(__file__), "data/case.json"))).read()',
+    'open(os.path.join(os.path.dirname(os.path.dirname(__file__)), "tests", "data", "case.json")).read()',
+)
+
+
+@pytest.mark.parametrize("read", FUNCTIONAL_JOIN_SHAPES)
+def test_a_functional_join_resolves_like_an_operator_join(tmp_path: Path, read: str) -> None:
+    """How a path is spelled is not what decides whether the run reads the file."""
+    module = _load_provenance_module()
+    base_ref, red_proof_path = _repository_with_data_read(tmp_path, f"import os\n\nCASE = {read}")
+
+    (tmp_path / "tests" / "data" / "case.json").write_text('{"expected": true}\n', encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change the case the harness reads")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_a_functional_join_from_an_unknowable_base_binds_nothing(tmp_path: Path) -> None:
+    """A recognized join consumes its components, so they are not read as root-relative paths."""
+    module = _load_provenance_module()
+    body = 'import os\n\n\ndef fixture_case(tmp_path):\n    return open(os.path.join(tmp_path, "tests/data/case.json")).read()'
+    base_ref, red_proof_path = _repository_with_data_read(tmp_path, body)
+
+    (tmp_path / "tests" / "data" / "case.json").write_text('{"expected": true}\n', encoding="utf-8")
+    final_ref = _commit(tmp_path, "chore: change a case nothing reads")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+@pytest.mark.parametrize(
+    ("link_name", "link_text", "read_path", "changed"),
+    [
+        ("tests/data_link", "real_data", "tests/data_link/case.json", "tests/real_data/case.json"),
+        ("tests/deep_link", "data_link", "tests/deep_link/case.json", "tests/real_data/case.json"),
+    ],
+)
+def test_a_data_read_through_a_linked_directory_binds_the_target(
+    tmp_path: Path, link_name: str, link_text: str, read_path: str, changed: str
+) -> None:
+    """The filesystem follows a directory link exactly as it follows a file link."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / "tests" / "real_data").mkdir(parents=True)
+    (tmp_path / "tests" / "real_data" / "case.json").write_text('{"expected": false}\n', encoding="utf-8")
+    (tmp_path / "tests" / "data_link").symlink_to("real_data")
+    if link_name != "tests/data_link":
+        (tmp_path / link_name).symlink_to(link_text)
+    (tmp_path / "tests" / "conftest.py").write_text(
+        f'from pathlib import Path\n\nCASE = Path("{read_path}").read_text()\n', encoding="utf-8"
+    )
+    base_ref = _commit(tmp_path, "test: add linked data directory")
+    (tmp_path / "tests" / "test_proof.py").write_text("def test_selected() -> None: assert False\n", "utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tmp_path / changed).write_text('{"expected": true}\n', encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change the target behind the directory link")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -1745,3 +1745,88 @@ def test_git_bound_red_proof_rejects_symlinked_support_input(tmp_path: Path) -> 
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
         "stale-red-proof"
     ]
+
+
+def test_git_bound_red_proof_rejects_scope_header_plugin_binding(tmp_path: Path) -> None:
+    """A function default executes at import, so a plugin bound there is loaded by pytest."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    helpers_path = tests_path / "helpers"
+    helpers_path.mkdir(parents=True)
+    (helpers_path / "fixtures.py").write_text("VALUE = False\n", encoding="utf-8")
+    (tests_path / "conftest.py").write_text(
+        'def helper(arg: object = (pytest_plugins := ("tests.helpers.fixtures",))) -> object:\n    return arg\n',
+        encoding="utf-8",
+    )
+    base_ref = _commit(tmp_path, "test: bind plugins in a function default")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (helpers_path / "fixtures.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change plugin bound in a default")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_ignores_uncalled_global_guard_rebinding(tmp_path: Path) -> None:
+    """An uncalled function never runs, so its global rebinding must not drop the guard."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text(
+        "from typing import TYPE_CHECKING\n"
+        "def enable() -> None:\n    global TYPE_CHECKING\n    TYPE_CHECKING = True\n"
+        "if TYPE_CHECKING:\n    import tests.typing_only\n",
+        encoding="utf-8",
+    )
+    (tests_path / "typing_only.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add uncalled global rebinding")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "typing_only.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "chore: change type-only helper")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+def test_git_bound_red_proof_tracks_called_global_guard_rebinding(tmp_path: Path) -> None:
+    """A function invoked while the module loads does rebind the guard, so it must be tracked."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text(
+        "from typing import TYPE_CHECKING\n"
+        "def enable() -> None:\n    global TYPE_CHECKING\n    TYPE_CHECKING = True\n"
+        "enable()\n"
+        "if TYPE_CHECKING:\n    import tests.runtime_support\n",
+        encoding="utf-8",
+    )
+    (tests_path / "runtime_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add called global rebinding")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "runtime_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change runtime support")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -1658,3 +1658,90 @@ def test_git_bound_red_proof_rejects_changed_plugin_under_quoted_pythonpath_root
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
         "stale-red-proof"
     ]
+
+
+@pytest.mark.parametrize(
+    "plugin_declaration",
+    [
+        'pytest_plugins = []\npytest_plugins.append("tests.helpers.fixtures")\n',
+        'PLUGINS = []\nPLUGINS.extend(["tests.helpers.fixtures"])\npytest_plugins = PLUGINS\n',
+    ],
+)
+def test_git_bound_red_proof_rejects_mutated_pytest_plugins(tmp_path: Path, plugin_declaration: str) -> None:
+    """An in-place mutation leaves the declaration unknowable statically, so it fails closed."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    helpers_path = tests_path / "helpers"
+    helpers_path.mkdir(parents=True)
+    (helpers_path / "fixtures.py").write_text("VALUE = False\n", encoding="utf-8")
+    (tests_path / "conftest.py").write_text(plugin_declaration, encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add mutated plugin declaration")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "delivery.py").write_text("VALUE = 1\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: delivery")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_tracks_class_body_guard_mutation(tmp_path: Path) -> None:
+    """A class body executes during import, so a guard attribute written there is not static."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text(
+        "import typing\n"
+        "class Holder:\n    typing.TYPE_CHECKING = True\n"
+        "if typing.TYPE_CHECKING:\n    import tests.runtime_support\n",
+        encoding="utf-8",
+    )
+    (tests_path / "runtime_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add class-body guard mutation")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "runtime_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change runtime support")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_rejects_symlinked_support_input(tmp_path: Path) -> None:
+    """A symlinked pytest input executes bytes this gate never inspected, so it fails closed."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    support_path = tmp_path / "support"
+    support_path.mkdir()
+    (support_path / "real_conftest.py").write_text("VALUE = False\n", encoding="utf-8")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "conftest.py").symlink_to(Path("..") / "support" / "real_conftest.py")
+    base_ref = _commit(tmp_path, "test: add symlinked conftest")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "delivery.py").write_text("VALUE = 1\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: delivery")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -3643,3 +3643,118 @@ def test_a_package_directory_does_not_become_an_import_root(tmp_path: Path) -> N
     final_ref = _commit(tmp_path, "chore: change a module nothing imports")
 
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+# Receivers that still reach the aliased plugin list through a wrapper. The mutation happens to
+# the same object in each, so recognizing only a bare name misses all of them.
+WRAPPED_RECEIVER_SHAPES = (
+    '[PLUGINS][0].append("tests.localplugin")',
+    '(PLUGINS,)[0].append("tests.localplugin")',
+    '{"k": PLUGINS}["k"].append("tests.localplugin")',
+    '(PLUGINS if VERSION else PLUGINS).append("tests.localplugin")',
+    '_identity(PLUGINS).append("tests.localplugin")',
+    '[[PLUGINS]][0][0].append("tests.localplugin")',
+)
+
+
+@pytest.mark.parametrize("mutation", WRAPPED_RECEIVER_SHAPES)
+def test_a_mutation_through_a_wrapped_receiver_is_unverifiable(mutation: str) -> None:
+    """A wrapper around the receiver does not change which object the method mutates.
+
+    The resolver is driven directly rather than through a whole proof, because a dotted literal
+    handed to a call is bound by the dynamic-import rule as well. That masks this defect
+    end-to-end: the proof comes out stale for the wrong reason while the plugin set is still
+    resolved as empty.
+    """
+    module = _load_provenance_module()
+    source = (
+        "VERSION = 1\n\n\ndef _identity(value):\n    return value\n\n\n"
+        f"PLUGINS = []\npytest_plugins = PLUGINS\n{mutation}\n"
+    )
+
+    with pytest.raises(ValueError, match="stale-red-proof"):
+        module._pytest_plugin_names(ast.parse(source))
+
+
+def test_a_declaration_no_wrapper_touches_still_resolves() -> None:
+    """Reading every wrapped name as a mutation would make an ordinary declaration unverifiable."""
+    module = _load_provenance_module()
+    source = 'OTHER = []\npytest_plugins = ["tests.localplugin"]\n[OTHER][0].append("noise")\n'
+
+    assert module._pytest_plugin_names(ast.parse(source)) == [["tests", "localplugin"]]
+
+
+def test_an_ordinary_keyed_lookup_is_not_the_module_table(tmp_path: Path) -> None:
+    """A mapping that merely uses ``__name__`` as a key reaches nothing this gate reads."""
+    module = _load_provenance_module()
+    base_ref, red_proof_path = _repository_with_module_reference(
+        tmp_path, "class _Registry:\n    entries = {__name__: _install}\n\n\n_Registry.entries[__name__]('x')"
+    )
+
+    (tmp_path / "tests" / "localplugin.py").write_text("def pytest_configure(config):\n    config.x = 1\n", "utf-8")
+    final_ref = _commit(tmp_path, "chore: change a plugin nothing declares")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+def _failing_git_bytes(module: Any, matches: Any) -> Any:
+    """Return a Git wrapper that reports failure, as a timeout does, for matching commands."""
+    original = module._git_bytes
+
+    def wrapper(repo_root: Path, *arguments: str) -> Any:
+        if matches(arguments):
+            return subprocess.CompletedProcess(["git", *arguments], returncode=1, stdout=b"", stderr=b"")
+        return original(repo_root, *arguments)
+
+    return wrapper
+
+
+@pytest.mark.parametrize(
+    ("description", "matches", "expected"),
+    [
+        (
+            "the symlink inventory",
+            lambda arguments: arguments[:2] == ("ls-tree", "-r"),
+            ["stale-red-proof"],
+        ),
+        (
+            "the tracked-artifact check",
+            lambda arguments: arguments[0] == "ls-files",
+            ["prior-red-proof-invalid"],
+        ),
+    ],
+)
+def test_an_unanswered_git_command_is_never_read_as_an_answer(
+    tmp_path: Path, description: str, matches: Any, expected: list[str]
+) -> None:
+    """Every lookup this gate makes must distinguish a failure from a result."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "__init__.py").write_text("", encoding="utf-8")
+    (tmp_path / "tests" / "conftest.py").write_text("import tests.support\n", encoding="utf-8")
+    (tmp_path / "tests" / "support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add support")
+    (tmp_path / "tests" / "test_proof.py").write_text("def test_selected() -> None: assert False\n", "utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "product.py").write_text("VALUE = 1\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: change only product source")
+
+    original = module._git_bytes
+    module._git_bytes = _failing_git_bytes(module, matches)
+    try:
+        module._tree_entry_mode_at_ref.cache_clear()
+        module._python_tree_at_ref.cache_clear()
+        module._symlink_paths_at_ref.cache_clear()
+        findings = module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref)
+    finally:
+        module._git_bytes = original
+        module._tree_entry_mode_at_ref.cache_clear()
+        module._symlink_paths_at_ref.cache_clear()
+
+    assert findings == expected, description

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -300,6 +300,32 @@ def test_git_bound_red_proof_ignores_plugin_declaration_in_imported_helper(tmp_p
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
 
 
+def test_git_bound_red_proof_ignores_plugin_declaration_in_plugin_parent(tmp_path: Path) -> None:
+    """A registered plugin's parent initializer cannot register another plugin."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    plugins_path = tmp_path / "plugins"
+    plugins_path.mkdir()
+    (plugins_path / "__init__.py").write_text('pytest_plugins = ("tests.fake",)\n', encoding="utf-8")
+    (plugins_path / "foo.py").write_text("VALUE = False\n", encoding="utf-8")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "fake.py").write_text("VALUE = False\n", encoding="utf-8")
+    (tests_path / "conftest.py").write_text('pytest_plugins = ("plugins.foo",)\n', encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add packaged pytest plugin")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "fake.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change inactive parent plugin target")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
 def test_git_bound_red_proof_rejects_import_target_added_after_red(tmp_path: Path) -> None:
     """A missing local import added after red must invalidate collection-error proof."""
     module = _load_provenance_module()

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -276,6 +276,29 @@ def test_git_bound_red_proof_ignores_nested_pytest_plugin(tmp_path: Path, plugin
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
 
 
+def test_git_bound_red_proof_ignores_plugin_declaration_in_imported_helper(tmp_path: Path) -> None:
+    """An ordinary imported helper cannot register a pytest plugin."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "fake.py").write_text("VALUE = False\n", encoding="utf-8")
+    (tests_path / "helper.py").write_text('pytest_plugins: tuple[str, ...] = ("tests.fake",)\n', encoding="utf-8")
+    (tests_path / "conftest.py").write_text("import tests.helper\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add plugin-like helper annotation")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "fake.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change unrelated plugin-like target")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
 def test_git_bound_red_proof_rejects_import_target_added_after_red(tmp_path: Path) -> None:
     """A missing local import added after red must invalidate collection-error proof."""
     module = _load_provenance_module()
@@ -420,6 +443,29 @@ def test_git_bound_red_proof_rejects_added_selector_package_initializer(tmp_path
 
     (tests_path / "__init__.py").write_text("VALUE = True\n", encoding="utf-8")
     final_ref = _commit(tmp_path, "fix: initialize selector package")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_rejects_added_repository_root_initializer(tmp_path: Path) -> None:
+    """The repository-root package initializer remains bound to red."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / "README.md").write_text("# proof\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "chore: base")
+    test_path = tmp_path / "tests" / "test_proof.py"
+    test_path.parent.mkdir()
+    test_path.write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add root red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tmp_path / "__init__.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: initialize repository package")
 
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
         "stale-red-proof"

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -252,9 +252,7 @@ def test_git_bound_red_proof_rejects_changed_pytest_plugin(tmp_path: Path, plugi
         'class Helper:\n    pytest_plugins: tuple[str, ...] = ("tests.helpers.fixtures",)\n',
     ],
 )
-def test_git_bound_red_proof_ignores_nested_pytest_plugin(
-    tmp_path: Path, plugin_declaration: str
-) -> None:
+def test_git_bound_red_proof_ignores_nested_pytest_plugin(tmp_path: Path, plugin_declaration: str) -> None:
     """A local or class annotation does not declare a pytest plugin."""
     module = _load_provenance_module()
     _git(tmp_path, "init")

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -216,6 +216,7 @@ def test_git_bound_red_proof_rejects_changed_support_imported_by_conftest(tmp_pa
     [
         'pytest_plugins = ("tests.helpers.fixtures",)\n',
         'pytest_plugins: tuple[str, ...] = ("tests.helpers.fixtures",)\n',
+        'pytest_plugins: str = "tests.helpers.fixtures,tests.helpers.other"\n',
     ],
 )
 def test_git_bound_red_proof_rejects_changed_pytest_plugin(tmp_path: Path, plugin_declaration: str) -> None:

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -2087,3 +2087,82 @@ def test_git_bound_red_proof_tracks_guard_handed_to_a_call_inside_a_function(tmp
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
         "stale-red-proof"
     ]
+
+
+def test_git_bound_red_proof_rejects_symlinked_support_input_that_parses(tmp_path: Path) -> None:
+    """A link target that is valid Python parses, so parse failure cannot be the symlink check."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "real_conftest.py").write_text("VALUE = False\n", encoding="utf-8")
+    (tests_path / "conftest.py").symlink_to(Path("real_conftest.py"))
+    base_ref = _commit(tmp_path, "test: add a symlinked conftest whose link text parses")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "delivery.py").write_text("VALUE = 1\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: delivery")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_tracks_subscript_mutation_of_an_aliased_plugin_list(tmp_path: Path) -> None:
+    """A subscript write changes the aliased list in place without rebinding either name."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "conftest.py").write_text(
+        'PLUGINS = ["tests.old"]\npytest_plugins = PLUGINS\nPLUGINS[0] = "tests.active"\n', encoding="utf-8"
+    )
+    (tests_path / "old.py").write_text("VALUE = False\n", encoding="utf-8")
+    (tests_path / "active.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: mutate an aliased plugin list through a subscript")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "delivery.py").write_text("VALUE = 1\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: delivery")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_tracks_guard_written_through_a_module_alias(tmp_path: Path) -> None:
+    """A second reference to the guard module rewrites the guard the first name also sees."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text(
+        "import typing as t\nalias = t\nalias.TYPE_CHECKING = True\n"
+        "if t.TYPE_CHECKING:\n    import tests.runtime_support\n",
+        encoding="utf-8",
+    )
+    (tests_path / "runtime_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: rewrite the guard through a module alias")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "runtime_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change runtime support")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -1541,3 +1541,65 @@ def test_git_bound_red_proof_ignores_falsy_literal_guard_imports(tmp_path: Path,
     final_ref = _commit(tmp_path, "chore: change unexecuted helper")
 
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+@pytest.mark.parametrize(
+    "plugin_declaration",
+    [
+        "from tests.names import pytest_plugins\n",
+        "from tests.names import pytest_plugins as pytest_plugins\n",
+        "from tests.names import *\n",
+    ],
+)
+def test_git_bound_red_proof_rejects_imported_pytest_plugins(tmp_path: Path, plugin_declaration: str) -> None:
+    """A pytest_plugins value that lives in another module cannot be resolved, so it fails closed."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    helpers_path = tests_path / "helpers"
+    helpers_path.mkdir(parents=True)
+    (helpers_path / "fixtures.py").write_text("VALUE = False\n", encoding="utf-8")
+    (tests_path / "names.py").write_text('pytest_plugins = ("tests.helpers.fixtures",)\n', encoding="utf-8")
+    (tests_path / "conftest.py").write_text(plugin_declaration, encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add imported plugin declaration")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "delivery.py").write_text("VALUE = 1\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: delivery")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_binds_plugins_declared_after_an_import(tmp_path: Path) -> None:
+    """An unrelated import must not stale a conftest whose own plugin declaration is literal."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    helpers_path = tests_path / "helpers"
+    helpers_path.mkdir(parents=True)
+    (helpers_path / "fixtures.py").write_text("VALUE = False\n", encoding="utf-8")
+    (tests_path / "conftest.py").write_text(
+        'import os\nfrom tests.helpers import fixtures\npytest_plugins = ("tests.helpers.fixtures",)\n',
+        encoding="utf-8",
+    )
+    base_ref = _commit(tmp_path, "test: add literal declaration beside imports")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (helpers_path / "fixtures.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change declared plugin")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -3488,3 +3488,71 @@ def test_a_data_read_through_a_linked_directory_binds_the_target(
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
         "stale-red-proof"
     ]
+
+
+# Routes to this module's own namespace that do not go through ``globals()``. Each can create
+# the attribute pytest reads, so each must leave the declarations unknowable.
+MODULE_OBJECT_REWRITE_SHAPES = (
+    'setattr(sys.modules[__name__], "pytest_plugins", ["tests.localplugin"])',
+    'sys.modules[__name__].__dict__.update(pytest_plugins=["tests.localplugin"])',
+    'sys.modules[__name__].__dict__["pytest_plugins"] = ["tests.localplugin"]',
+    'vars(sys.modules[__name__])["pytest_plugins"] = ["tests.localplugin"]',
+    'vars(sys.modules[__name__]).update(pytest_plugins=["tests.localplugin"])',
+    "globals().__dict__ if False else _install(sys.modules[__name__])",
+    'sys.modules.get(__name__).pytest_plugins = ["tests.localplugin"]',
+    'setattr(importlib.import_module(__name__), "pytest_plugins", ["tests.localplugin"])',
+    "exec('pytest_plugins = [\"tests.localplugin\"]', sys.modules[__name__].__dict__)",
+)
+
+# Ordinary uses of ``__name__`` and of the module table that reach nothing this gate reads.
+# Treating these as rewrites would make almost every conftest unverifiable.
+INERT_MODULE_REFERENCE_SHAPES = (
+    "LOGGER = logging.getLogger(__name__)",
+    'PARTS = __name__.split(".")',
+    'sys.modules["tests.substitute"] = _install',
+    'setattr(sys.modules["tests.substitute"], "value", 1)',
+)
+
+
+def _repository_with_module_reference(tmp_path: Path, body: str) -> tuple[str, Path]:
+    """Commit a root conftest carrying ``body`` beside a declarable plugin."""
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "localplugin.py").write_text("def pytest_configure(config):\n    return None\n", "utf-8")
+    (tmp_path / "tests" / "substitute.py").write_text("value = 0\n", encoding="utf-8")
+    header = "import importlib\nimport logging\nimport sys\n\n\ndef _install(target):\n    return target\n"
+    (tmp_path / "conftest.py").write_text(f"{header}\n{body}\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add a module-level reference")
+    (tmp_path / "tests" / "test_proof.py").write_text("def test_selected() -> None: assert False\n", "utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    return base_ref, red_proof_path
+
+
+@pytest.mark.parametrize("rewrite", MODULE_OBJECT_REWRITE_SHAPES)
+def test_a_module_object_rewrite_leaves_the_plugin_set_unverifiable(tmp_path: Path, rewrite: str) -> None:
+    """The module object is another door to the namespace pytest reads, not a different rule."""
+    module = _load_provenance_module()
+    base_ref, red_proof_path = _repository_with_module_reference(tmp_path, rewrite)
+
+    (tmp_path / "tests" / "localplugin.py").write_text("def pytest_configure(config):\n    config.x = 1\n", "utf-8")
+    final_ref = _commit(tmp_path, "fix: change the plugin reached through the module object")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+@pytest.mark.parametrize("inert", INERT_MODULE_REFERENCE_SHAPES)
+def test_an_ordinary_module_reference_stays_verifiable(tmp_path: Path, inert: str) -> None:
+    """Naming ``__name__`` or another module's entry rewrites nothing this gate reads."""
+    module = _load_provenance_module()
+    base_ref, red_proof_path = _repository_with_module_reference(tmp_path, inert)
+
+    (tmp_path / "tests" / "localplugin.py").write_text("def pytest_configure(config):\n    config.x = 1\n", "utf-8")
+    final_ref = _commit(tmp_path, "chore: change a plugin nothing declares")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -1224,3 +1224,118 @@ def test_git_bound_red_proof_rejects_oversized_proof_input(tmp_path: Path) -> No
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
         "stale-red-proof"
     ]
+
+
+@pytest.mark.parametrize(
+    ("configuration_path", "configuration_body"),
+    [
+        ("pyproject.toml", '[tool.pytest.ini_options]\naddopts = "-ra -p tests.localplugin"\n'),
+        ("pyproject.toml", '[tool.pytest.ini_options]\naddopts = ["-ra", "-ptests.localplugin"]\n'),
+        ("pytest.ini", "[pytest]\naddopts = -ra -p tests.localplugin\n"),
+        ("tox.ini", "[pytest]\naddopts = -ra -p tests.localplugin\n"),
+        ("setup.cfg", "[tool:pytest]\naddopts = -ra -p tests.localplugin\n"),
+    ],
+)
+def test_git_bound_red_proof_rejects_changed_addopts_plugin(
+    tmp_path: Path, configuration_path: str, configuration_body: str
+) -> None:
+    """A plugin early-loaded through configured addopts decides collection and must stay bound."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / configuration_path).write_text(configuration_body, encoding="utf-8")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "localplugin.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add addopts plugin")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "localplugin.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change addopts plugin")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_ignores_disabled_addopts_plugin(tmp_path: Path) -> None:
+    """A `-p no:` entry disables a plugin rather than naming a repository module to bind."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.pytest.ini_options]\naddopts = "-p no:cacheprovider"\n', encoding="utf-8"
+    )
+    no_path = tmp_path / "no:cacheprovider.py"
+    no_path.write_text("VALUE = False\n", encoding="utf-8")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    base_ref = _commit(tmp_path, "test: add disabled plugin option")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    no_path.write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "chore: change unrelated module")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+def test_git_bound_red_proof_ignores_overwritten_plugin_declaration(tmp_path: Path) -> None:
+    """Only the final pytest_plugins binding loads, so an overwritten declaration must not bind."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    helpers_path = tests_path / "helpers"
+    helpers_path.mkdir(parents=True)
+    (helpers_path / "obsolete.py").write_text("VALUE = False\n", encoding="utf-8")
+    (helpers_path / "active.py").write_text("VALUE = False\n", encoding="utf-8")
+    (tests_path / "conftest.py").write_text(
+        'pytest_plugins = ("tests.helpers.obsolete",)\npytest_plugins = ("tests.helpers.active",)\n',
+        encoding="utf-8",
+    )
+    base_ref = _commit(tmp_path, "test: overwrite plugin declaration")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (helpers_path / "obsolete.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "chore: change never-loaded plugin")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+def test_git_bound_red_proof_ignores_function_local_type_checking_rebinding(tmp_path: Path) -> None:
+    """A function-local name cannot rebind the module typing guard, so its branch stays pruned."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text(
+        "from typing import TYPE_CHECKING\n"
+        "def helper() -> None:\n    TYPE_CHECKING = True\n    return None\n"
+        "if TYPE_CHECKING:\n    import tests.typing_only\n",
+        encoding="utf-8",
+    )
+    (tests_path / "typing_only.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add function-local guard name")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "typing_only.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "chore: change type-only helper")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import hashlib
 import importlib.util
 import json
@@ -2408,3 +2409,298 @@ def test_git_bound_red_proof_ignores_type_only_import_inside_a_function(tmp_path
     final_ref = _commit(tmp_path, "chore: change type-only helper")
 
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+def test_git_bound_red_proof_binds_imports_inside_a_selected_test_body(tmp_path: Path) -> None:
+    """Pytest executes a test body, so its imports run even with no import-time call."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "runtime_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add support imported by the selected test")
+    (tests_path / "test_proof.py").write_text(
+        "def test_selected() -> None:\n    import tests.runtime_support\n\n    assert False\n", encoding="utf-8"
+    )
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "runtime_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change runtime support")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_reads_pytest_configuration_from_selector_ancestors(tmp_path: Path) -> None:
+    """Pytest searches upward from the selector, so a nested configuration decides collection."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "pytest.ini").write_text("[pytest]\naddopts = -p tests.localplugin\n", encoding="utf-8")
+    (tests_path / "localplugin.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add nested pytest configuration")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "localplugin.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change nested-config plugin")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_tracks_augmented_mutation_of_an_aliased_plugin_list(tmp_path: Path) -> None:
+    """List `+=` mutates the shared object rather than rebinding the name."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "conftest.py").write_text(
+        'PLUGINS = []\npytest_plugins = PLUGINS\nPLUGINS += ["tests.localplugin"]\n', encoding="utf-8"
+    )
+    (tests_path / "localplugin.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: extend an aliased plugin list in place")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "delivery.py").write_text("VALUE = 1\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: delivery")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_rejects_imports_through_a_symlinked_package_directory(tmp_path: Path) -> None:
+    """Python follows a directory link, so the resolved candidate is not the Git path."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    support_path = tests_path / "support"
+    support_path.mkdir(parents=True)
+    (support_path / "__init__.py").write_text("", encoding="utf-8")
+    (support_path / "helper.py").write_text("VALUE = False\n", encoding="utf-8")
+    (tmp_path / "support").symlink_to(Path("tests") / "support")
+    (tests_path / "conftest.py").write_text("from support import helper\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: import through a symlinked package directory")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (support_path / "helper.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change helper behind the directory link")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_tracks_guard_written_through_a_module_dictionary(tmp_path: Path) -> None:
+    """A write through `__dict__` changes the same attribute the guard reads."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text(
+        'import typing\ntyping.__dict__["TYPE_CHECKING"] = True\n'
+        "if typing.TYPE_CHECKING:\n    import tests.runtime_support\n",
+        encoding="utf-8",
+    )
+    (tests_path / "runtime_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: rewrite the guard through a module dictionary")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "runtime_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change runtime support")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_fails_closed_when_configuration_cannot_be_read(tmp_path: Path) -> None:
+    """An unreadable configuration is not an absent one; a Git failure must not silently skip it."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / "pytest.ini").write_text("[pytest]\naddopts = -p tests.localplugin\n", encoding="utf-8")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "localplugin.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add configuration that will be unreadable")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "delivery.py").write_text("VALUE = 1\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: delivery")
+
+    original_git_bytes = module._git_bytes
+
+    def _failing_git_bytes(repo_root: Path, *arguments: str):  # type: ignore[no-untyped-def]
+        if arguments[:1] == ("show",) and arguments[1].endswith(":pytest.ini"):
+            return subprocess.CompletedProcess(["git", *arguments], returncode=1, stdout=b"", stderr=b"timeout")
+        return original_git_bytes(repo_root, *arguments)
+
+    module._git_bytes = _failing_git_bytes  # type: ignore[attr-defined]
+    try:
+        findings = module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref)
+    finally:
+        module._git_bytes = original_git_bytes  # type: ignore[attr-defined]
+
+    assert findings == ["stale-red-proof"]
+
+
+GUARD_REWRITE_SHAPES = (
+    "typing.TYPE_CHECKING = True",
+    'setattr(typing, "TYPE_CHECKING", True)',
+    'from builtins import setattr as _s\n_s(typing, "TYPE_CHECKING", True)',
+    'setattr([typing][0], "TYPE_CHECKING", True)',
+    'vars(typing)["TYPE_CHECKING"] = True',
+    'typing.__dict__["TYPE_CHECKING"] = True',
+    'getattr(typing, "__dict__")["TYPE_CHECKING"] = True',
+    "alias = typing\nalias.TYPE_CHECKING = True",
+    'a = typing\nb = a\nb.__dict__["TYPE_CHECKING"] = True',
+    "_rewrite(typing)",
+    'def _e() -> None:\n    setattr(typing, "TYPE_CHECKING", True)\n_e()',
+    "def _e() -> None:\n    typing.TYPE_CHECKING = True\nactivate = _e\nactivate()",
+    '_e = lambda: setattr(typing, "TYPE_CHECKING", True)\n_e()',
+    "def _d(f):\n    typing.TYPE_CHECKING = True\n    return f\n@_d\ndef _c() -> None:\n    return None",
+    "class _C:\n    global typing\n    typing = _fake",
+    'globals()["TYPE_CHECKING"] = True',
+)
+
+
+@pytest.mark.parametrize("mutation", GUARD_REWRITE_SHAPES)
+def test_typing_guard_is_never_trusted_after_any_rewrite_shape(mutation: str) -> None:
+    """No syntactic wrapper may leave the guard trusted.
+
+    This battery exists because every review round found another wrapper around the same
+    idea. Asserting the family rather than the instance means a newly invented shape has to
+    defeat the structural rules, not merely differ from the shapes already listed.
+    """
+    module = cast(Any, _load_provenance_module())
+    tree = ast.parse(f"import typing\n{mutation}\nif typing.TYPE_CHECKING:\n    import tests.support\n")
+    _type_checking_names, typing_module_names = module._verified_type_checking_bindings(tree)
+    assert "typing" not in typing_module_names, f"guard stayed trusted after: {mutation!r}"
+
+
+UNRESOLVABLE_PLUGIN_SHAPES = (
+    'pytest_plugins = []\npytest_plugins.append("tests.p")',
+    'P = []\npytest_plugins = P\nP.append("tests.p")',
+    'P = []\npytest_plugins = P\nP += ["tests.p"]',
+    'P = ["tests.old"]\npytest_plugins = P\nP[0] = "tests.p"',
+    'P = ["tests.old"]\npytest_plugins = P\ndel P[0]',
+    'P = pytest_plugins = []\nP.append("tests.p")',
+    'P = {}\npytest_plugins = P\nP.setdefault("a", "b")',
+    'globals()["pytest_plugins"] = ["tests.p"]',
+    'vars()["pytest_plugins"] = ["tests.p"]',
+    'class _C:\n    global pytest_plugins\n    pytest_plugins = ("tests.p",)',
+    'def _f() -> None:\n    global pytest_plugins\n    pytest_plugins = ("tests.p",)\n_f()',
+    "from tests.other import pytest_plugins",
+    'for pytest_plugins in [("tests.p",)]:\n    pass',
+    'with open("f") as pytest_plugins:\n    pass',
+    "try:\n    pass\nexcept OSError as pytest_plugins:\n    pass",
+    "pytest_plugins = _dynamic()",
+)
+
+
+@pytest.mark.parametrize("declaration", UNRESOLVABLE_PLUGIN_SHAPES)
+def test_unresolvable_plugin_declaration_always_fails_closed(declaration: str) -> None:
+    """A plugin declaration this gate cannot resolve must never resolve to nothing.
+
+    Reporting no plugins for an unresolvable declaration is the fail-open shape every plugin
+    finding shared, so the whole family is asserted rather than each shape as it is reported.
+    """
+    module = cast(Any, _load_provenance_module())
+    with pytest.raises(ValueError, match="stale-red-proof"):
+        module._pytest_plugin_names(ast.parse(declaration))
+
+
+def test_root_name_resolves_through_arbitrary_wrapper_nesting() -> None:
+    """The single resolver behind every "which name does this touch" rule must not bottom out."""
+    module = cast(Any, _load_provenance_module())
+    resolve = module._root_name
+    expressions = (
+        "typing",
+        "typing.a",
+        "typing.a.b.c",
+        "typing['a']",
+        "typing.__dict__['x']['y']",
+        "typing.a['b'].c['d']",
+        "typing()",
+        "typing().a['b']",
+    )
+    for source in expressions:
+        assert resolve(ast.parse(source, mode="eval").body) == "typing", source
+    assert resolve(ast.parse("[typing][0]", mode="eval").body) is None
+
+
+def test_statically_resolvable_declarations_still_resolve() -> None:
+    """The batteries must not be satisfiable by rejecting everything."""
+    module = cast(Any, _load_provenance_module())
+    assert module._pytest_plugin_names(ast.parse('pytest_plugins = ("tests.p",)')) == [["tests", "p"]]
+    assert module._pytest_plugin_names(ast.parse('pytest_plugins = "tests.p"')) == [["tests", "p"]]
+    assert module._pytest_plugin_names(ast.parse("VALUE = 1\n")) == []
+    # A later explicit assignment overwrites whatever a star import may have bound, so the
+    # final value is knowable even though the star import alone is not.
+    star_then_assign = 'from tests.other import *\npytest_plugins = ("tests.p",)'
+    assert module._pytest_plugin_names(ast.parse(star_then_assign)) == [["tests", "p"]]
+    # A conditional declaration binds the union of its possible values, which is the
+    # fail-closed direction: the plugin is bound whether or not the branch ran.
+    conditional = 'if _flag:\n    pytest_plugins = ("tests.p",)'
+    assert module._pytest_plugin_names(ast.parse(conditional)) == [["tests", "p"]]
+    tree = ast.parse("from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n    import tests.support\n")
+    type_checking_names, _typing_module_names = module._verified_type_checking_bindings(tree)
+    assert "TYPE_CHECKING" in type_checking_names
+
+
+def test_ordinary_mapping_writes_do_not_make_a_module_unverifiable() -> None:
+    """Fail-closed rules must not fire on code that touches nothing this gate depends on.
+
+    Broadening guard-write detection to every subscript target once made almost every real
+    conftest unverifiable, because `mapping[key] = value` inside any helper marked the module
+    as state-mutating. The whole-repository measurement caught it; this pins the boundary.
+    """
+    module = cast(Any, _load_provenance_module())
+    benign = (
+        'CACHE = {}\ndef _store(key, value):\n    CACHE[key] = value\n_store("a", 1)\npytest_plugins = ("tests.p",)\n'
+    )
+    assert module._pytest_plugin_names(ast.parse(benign)) == [["tests", "p"]]
+    assert not module._unverifiable_module_state(ast.parse(benign))
+
+
+def test_guard_survives_unrelated_module_load_activity() -> None:
+    """A typing guard stays trusted when nothing can reach the module it names."""
+    module = cast(Any, _load_provenance_module())
+    tree = ast.parse(
+        "import typing\nimport json\nVALUES = {}\nVALUES['a'] = json.dumps({})\n"
+        "if typing.TYPE_CHECKING:\n    import tests.support\n"
+    )
+    _type_checking_names, typing_module_names = module._verified_type_checking_bindings(tree)
+    assert "typing" in typing_module_names

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -1457,3 +1457,87 @@ def test_git_bound_red_proof_reads_percent_literal_configuration(tmp_path: Path,
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
         "stale-red-proof"
     ]
+
+
+@pytest.mark.parametrize(
+    "initializer_source",
+    [
+        "import typing\ntyping.TYPE_CHECKING = True\nif typing.TYPE_CHECKING:\n    import tests.runtime_support\n",
+        "import typing\ntyping.TYPE_CHECKING |= True\nif typing.TYPE_CHECKING:\n    import tests.runtime_support\n",
+        "from typing import TYPE_CHECKING\n"
+        "class Holder:\n    global TYPE_CHECKING\n    TYPE_CHECKING = True\n"
+        "if TYPE_CHECKING:\n    import tests.runtime_support\n",
+    ],
+)
+def test_git_bound_red_proof_tracks_mutated_type_checking_guard(tmp_path: Path, initializer_source: str) -> None:
+    """An attribute write or a global declaration mutates the module guard, so it is not static."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text(initializer_source, encoding="utf-8")
+    (tests_path / "runtime_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add mutated type-checking guard")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "runtime_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change runtime support")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_rejects_oversized_pytest_configuration(tmp_path: Path) -> None:
+    """An unreadable configuration could declare plugins or roots, so it must fail closed."""
+    module = _load_provenance_module()
+    # Kept above the selected test blob so only the configuration exceeds the read bound.
+    cast(Any, module).MAX_TEST_BLOB_BYTES = 256
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / "pyproject.toml").write_text(
+        f'[tool.pytest.ini_options]\nfilterwarnings = ["{"x" * 512}"]\n', encoding="utf-8"
+    )
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    base_ref = _commit(tmp_path, "chore: add oversized pytest configuration")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "delivery.py").write_text("VALUE = 1\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: delivery")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+@pytest.mark.parametrize("guard_literal", ["0", "None", '""', "()"])
+def test_git_bound_red_proof_ignores_falsy_literal_guard_imports(tmp_path: Path, guard_literal: str) -> None:
+    """Any falsy literal guard is as unreachable as `if False`, so its import is not executed."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text(f"if {guard_literal}:\n    import tests.typing_only\n", encoding="utf-8")
+    (tests_path / "typing_only.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add falsy literal guard")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "typing_only.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "chore: change unexecuted helper")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -2058,3 +2058,32 @@ def test_git_bound_red_proof_tracks_setattr_guard_write_from_a_function(tmp_path
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
         "stale-red-proof"
     ]
+
+
+def test_git_bound_red_proof_tracks_guard_handed_to_a_call_inside_a_function(tmp_path: Path) -> None:
+    """A callee that receives the guard module can rewrite it however it is named."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text(
+        "from builtins import setattr as _set\nimport typing\n\n\ndef _enable() -> None:\n"
+        '    _set(typing, "TYPE_CHECKING", True)\n\n\n_enable()\n'
+        "if typing.TYPE_CHECKING:\n    import tests.runtime_support\n",
+        encoding="utf-8",
+    )
+    (tests_path / "runtime_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: rewrite the guard through an aliased builtin")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "runtime_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change runtime support")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -1076,3 +1076,70 @@ def test_git_bound_red_proof_binds_non_utf8_support_module(tmp_path: Path) -> No
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
         "stale-red-proof"
     ]
+
+
+@pytest.mark.parametrize(
+    ("configuration_path", "configuration_body"),
+    [
+        ("pyproject.toml", '[tool.pytest.ini_options]\npythonpath = ["source"]\n'),
+        ("pytest.ini", "[pytest]\npythonpath = source\n"),
+        ("tox.ini", "[pytest]\npythonpath = source\n"),
+        ("setup.cfg", "[tool:pytest]\npythonpath = source\n"),
+    ],
+)
+def test_git_bound_red_proof_rejects_changed_plugin_under_pythonpath_root(
+    tmp_path: Path, configuration_path: str, configuration_body: str
+) -> None:
+    """A plugin resolvable only through a configured pythonpath root stays bound to the red failure."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / configuration_path).write_text(configuration_body, encoding="utf-8")
+    plugin_path = tmp_path / "source" / "rooted_plugin"
+    plugin_path.mkdir(parents=True)
+    (plugin_path / "__init__.py").write_text("", encoding="utf-8")
+    (plugin_path / "fixtures.py").write_text("VALUE = False\n", encoding="utf-8")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "conftest.py").write_text('pytest_plugins = ("rooted_plugin.fixtures",)\n', encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add plugin under a pythonpath root")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (plugin_path / "fixtures.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change plugin under a pythonpath root")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_allows_production_change_under_pythonpath_root(tmp_path: Path) -> None:
+    """A pythonpath root must not bind ordinary production imports, which red-to-green work edits."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / "pyproject.toml").write_text('[tool.pytest.ini_options]\npythonpath = ["src"]\n', encoding="utf-8")
+    delivery_path = tmp_path / "src" / "delivery"
+    delivery_path.mkdir(parents=True)
+    (delivery_path / "__init__.py").write_text("", encoding="utf-8")
+    (delivery_path / "feature.py").write_text("VALUE = False\n", encoding="utf-8")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    base_ref = _commit(tmp_path, "chore: add production module under a pythonpath root")
+    (tests_path / "test_proof.py").write_text(
+        "from delivery.feature import VALUE\n\ndef test_selected() -> None: assert VALUE\n",
+        encoding="utf-8",
+    )
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (delivery_path / "feature.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: implement delivery behavior")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -220,6 +220,7 @@ def test_git_bound_red_proof_rejects_changed_support_imported_by_conftest(tmp_pa
         'PLUGINS = ("tests.helpers.fixtures",)\npytest_plugins: tuple[str, ...] = PLUGINS\n',
         'PLUGINS = ("tests.helpers.other",)\nPLUGINS = ("tests.helpers.fixtures",)\npytest_plugins = PLUGINS\n',
         'FLAG = True\nif FLAG:\n    PLUGINS = ("tests.helpers.fixtures",)\nelse:\n    PLUGINS = ("tests.helpers.other",)\npytest_plugins = PLUGINS\n',
+        'PLUGINS = ("tests.helpers.fixtures",)\nfor _ in ():\n    PLUGINS = ("tests.helpers.other",)\npytest_plugins = PLUGINS\n',
     ],
 )
 def test_git_bound_red_proof_rejects_changed_pytest_plugin(tmp_path: Path, plugin_declaration: str) -> None:

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -3556,3 +3556,90 @@ def test_an_ordinary_module_reference_stays_verifiable(tmp_path: Path, inert: st
     final_ref = _commit(tmp_path, "chore: change a plugin nothing declares")
 
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+def _repository_with_prepend_layout(
+    tmp_path: Path, importer: str, statement: str, addopts: str = ""
+) -> tuple[str, Path]:
+    """Commit a non-package test directory whose ``importer`` imports a sibling module."""
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / "pyproject.toml").write_text(f"[tool.pytest.ini_options]\n{addopts}\n", encoding="utf-8")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "helper.py").write_text("VALUE = False\n", encoding="utf-8")
+    (tmp_path / "tests" / "helper").mkdir()
+    (tmp_path / "tests" / "helper" / "__init__.py").write_text("", encoding="utf-8")
+    (tmp_path / "tests" / "helper" / "sub.py").write_text("VALUE = False\n", encoding="utf-8")
+    selected_path = "tests/test_proof.py"
+    (tmp_path / importer).parent.mkdir(parents=True, exist_ok=True)
+    if importer != selected_path:
+        (tmp_path / importer).write_text(f"{statement}\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add a sibling helper")
+    # When the selected test is itself the importer, its import must survive into the red commit.
+    selected_source = statement if importer == selected_path else "def test_selected() -> None: assert False"
+    (tmp_path / selected_path).write_text(f"{selected_source}\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    return base_ref, red_proof_path
+
+
+@pytest.mark.parametrize(
+    ("importer", "statement", "changed"),
+    [
+        ("tests/conftest.py", "import helper", "tests/helper.py"),
+        ("tests/conftest.py", "from helper import VALUE", "tests/helper.py"),
+        ("tests/conftest.py", "import helper.sub", "tests/helper/sub.py"),
+        ("tests/test_proof.py", "import helper\n\n\ndef test_selected() -> None: assert False", "tests/helper.py"),
+    ],
+)
+def test_an_import_through_the_prepended_directory_is_bound(
+    tmp_path: Path, importer: str, statement: str, changed: str
+) -> None:
+    """Pytest prepends a non-package test directory, so a bare name there is a sibling module."""
+    module = _load_provenance_module()
+    base_ref, red_proof_path = _repository_with_prepend_layout(tmp_path, importer, statement)
+
+    (tmp_path / changed).write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change the sibling helper")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_the_prepended_directory_is_not_used_when_the_import_mode_forbids_it(tmp_path: Path) -> None:
+    """Importlib mode inserts nothing on sys.path, so a bare name cannot reach a sibling."""
+    module = _load_provenance_module()
+    base_ref, red_proof_path = _repository_with_prepend_layout(
+        tmp_path, "tests/conftest.py", "import helper", addopts='addopts = "--import-mode=importlib"'
+    )
+
+    (tmp_path / "tests" / "helper.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "chore: change a module this mode cannot reach")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+def test_a_package_directory_does_not_become_an_import_root(tmp_path: Path) -> None:
+    """Pytest walks up past every directory holding __init__.py before prepending one."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "__init__.py").write_text("", encoding="utf-8")
+    (tmp_path / "tests" / "conftest.py").write_text("import tests.helper\n", encoding="utf-8")
+    (tmp_path / "tests" / "helper.py").write_text("VALUE = False\n", encoding="utf-8")
+    (tmp_path / "unrelated.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add a package helper")
+    (tmp_path / "tests" / "test_proof.py").write_text("def test_selected() -> None: assert False\n", "utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tmp_path / "unrelated.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "chore: change a module nothing imports")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -322,6 +322,30 @@ def test_git_bound_red_proof_rejects_changed_parent_package_initializer(tmp_path
     ]
 
 
+def test_git_bound_red_proof_rejects_changed_initializer_import(tmp_path: Path) -> None:
+    """Repository-local imports from package initializers remain bound to red."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text("from tests.support import VALUE\n", encoding="utf-8")
+    (tests_path / "support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add packaged pytest support")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change initializer support import")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
 def test_git_bound_red_proof_rejects_added_parent_package_initializer(tmp_path: Path) -> None:
     """A namespace package cannot gain executable initialization after the red run."""
     module = _load_provenance_module()

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -221,6 +221,7 @@ def test_git_bound_red_proof_rejects_changed_support_imported_by_conftest(tmp_pa
         'PLUGINS = ("tests.helpers.other",)\nPLUGINS = ("tests.helpers.fixtures",)\npytest_plugins = PLUGINS\n',
         'FLAG = True\nif FLAG:\n    PLUGINS = ("tests.helpers.fixtures",)\nelse:\n    PLUGINS = ("tests.helpers.other",)\npytest_plugins = PLUGINS\n',
         'PLUGINS = ("tests.helpers.fixtures",)\nfor _ in ():\n    PLUGINS = ("tests.helpers.other",)\npytest_plugins = PLUGINS\n',
+        'FLAG = False\nPLUGINS = ("tests.helpers.fixtures",)\nif FLAG:\n    PLUGINS = load_plugins()\npytest_plugins = PLUGINS\n',
     ],
 )
 def test_git_bound_red_proof_rejects_changed_pytest_plugin(tmp_path: Path, plugin_declaration: str) -> None:

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -218,6 +218,7 @@ def test_git_bound_red_proof_rejects_changed_support_imported_by_conftest(tmp_pa
         'pytest_plugins: tuple[str, ...] = ("tests.helpers.fixtures",)\n',
         'pytest_plugins: str = "tests.helpers.fixtures,tests.helpers.other"\n',
         'PLUGINS = ("tests.helpers.fixtures",)\npytest_plugins: tuple[str, ...] = PLUGINS\n',
+        'PLUGINS = ("tests.helpers.other",)\nPLUGINS = ("tests.helpers.fixtures",)\npytest_plugins = PLUGINS\n',
     ],
 )
 def test_git_bound_red_proof_rejects_changed_pytest_plugin(tmp_path: Path, plugin_declaration: str) -> None:
@@ -479,6 +480,36 @@ def test_git_bound_red_proof_ignores_unreachable_initializer_imports(tmp_path: P
     final_ref = _commit(tmp_path, "fix: change unreachable initializer support")
 
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+def _validate_rebound_type_checking_branch(tmp_path: Path) -> list[str]:
+    """Build and validate a proof whose typing guard is rebound at runtime."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text(
+        "from typing import TYPE_CHECKING\nTYPE_CHECKING = True\nif TYPE_CHECKING:\n    import tests.runtime_support\n",
+        encoding="utf-8",
+    )
+    (tests_path / "runtime_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add rebound type-checking import")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "runtime_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change runtime type-checking support")
+
+    return module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref)
+
+
+def test_git_bound_red_proof_tracks_rebound_type_checking_branch(tmp_path: Path) -> None:
+    """A rebound TYPE_CHECKING name cannot make a runtime branch unreachable."""
+    assert _validate_rebound_type_checking_branch(tmp_path) == ["stale-red-proof"]
 
 
 def test_git_bound_red_proof_rejects_added_parent_package_initializer(tmp_path: Path) -> None:

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -8,7 +8,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
-from typing import Protocol, cast
+from typing import Any, Protocol, cast
 
 import pytest
 
@@ -1143,3 +1143,84 @@ def test_git_bound_red_proof_allows_production_change_under_pythonpath_root(tmp_
     final_ref = _commit(tmp_path, "feat: implement delivery behavior")
 
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+@pytest.mark.parametrize(
+    "plugin_declaration",
+    [
+        'PLUGINS = ("tests.helpers.other",)\nfor PLUGINS in [("tests.helpers.fixtures",)]:\n    pass\npytest_plugins = PLUGINS\n',
+        'PLUGINS = ("tests.helpers.other",)\nwith open("x") as PLUGINS:\n    pass\npytest_plugins = PLUGINS\n',
+        'PLUGINS = ("tests.helpers.other",)\ntry:\n    pass\nexcept ValueError as PLUGINS:\n    pass\npytest_plugins = PLUGINS\n',
+        'PLUGINS = ("tests.helpers.other",)\nmatch object():\n    case PLUGINS:\n        pass\npytest_plugins = PLUGINS\n',
+        'PLUGINS = ("tests.helpers.other",)\nif (PLUGINS := load()):\n    pass\npytest_plugins = PLUGINS\n',
+    ],
+)
+def test_git_bound_red_proof_rejects_compound_target_plugin_rebinding(tmp_path: Path, plugin_declaration: str) -> None:
+    """A plugin constant rebound by a compound statement target cannot be treated as still known."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "conftest.py").write_text(plugin_declaration, encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add compound-target plugin rebinding")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "delivery.py").write_text("VALUE = 1\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: delivery")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_rejects_unparsable_proof_input(tmp_path: Path) -> None:
+    """An existing proof input that cannot be parsed must fail closed, not be skipped as absent."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "conftest.py").write_text("def broken(:\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add unparsable conftest")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "delivery.py").write_text("VALUE = 1\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: delivery")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_rejects_oversized_proof_input(tmp_path: Path) -> None:
+    """An existing proof input beyond the parse bound must fail closed rather than be skipped."""
+    module = _load_provenance_module()
+    # Kept above the selected test blob so only the conftest exceeds the parse bound.
+    cast(Any, module).MAX_TEST_BLOB_BYTES = 256
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "conftest.py").write_text(f"VALUE = '{'x' * 512}'\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add oversized conftest")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "delivery.py").write_text("VALUE = 1\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: delivery")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -1603,3 +1603,58 @@ def test_git_bound_red_proof_binds_plugins_declared_after_an_import(tmp_path: Pa
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
         "stale-red-proof"
     ]
+
+
+def test_git_bound_red_proof_rejects_changed_plugin_import_under_pythonpath_root(tmp_path: Path) -> None:
+    """A plugin loaded from a pythonpath root resolves its own imports against that root."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / "pytest.ini").write_text("[pytest]\npythonpath = source\naddopts = -p plugin\n", encoding="utf-8")
+    source_path = tmp_path / "source"
+    source_path.mkdir()
+    (source_path / "plugin.py").write_text("import helper\n", encoding="utf-8")
+    (source_path / "helper.py").write_text("VALUE = False\n", encoding="utf-8")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    base_ref = _commit(tmp_path, "test: add rooted plugin and its helper")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (source_path / "helper.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change helper imported by the rooted plugin")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_rejects_changed_plugin_under_quoted_pythonpath_root(tmp_path: Path) -> None:
+    """Pytest splits an ini path list with shlex, so a quoted root containing a space is one path."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / "pytest.ini").write_text(
+        '[pytest]\npythonpath = "test support"\naddopts = -p rooted_plugin\n', encoding="utf-8"
+    )
+    support_path = tmp_path / "test support"
+    support_path.mkdir()
+    (support_path / "rooted_plugin.py").write_text("VALUE = False\n", encoding="utf-8")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    base_ref = _commit(tmp_path, "test: add plugin under a quoted pythonpath root")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (support_path / "rooted_plugin.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change plugin under a quoted root")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -427,6 +427,30 @@ def test_git_bound_red_proof_rejects_changed_initializer_import(tmp_path: Path) 
     ]
 
 
+def test_git_bound_red_proof_ignores_lazy_initializer_import(tmp_path: Path) -> None:
+    """An import inside an uncalled initializer function is not a proof input."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text(
+        "def load_support() -> None:\n    import tests.lazy_support\n", encoding="utf-8"
+    )
+    (tests_path / "lazy_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add lazy initializer support")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "lazy_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change lazy initializer support")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
 def test_git_bound_red_proof_rejects_added_parent_package_initializer(tmp_path: Path) -> None:
     """A namespace package cannot gain executable initialization after the red run."""
     module = _load_provenance_module()

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -2166,3 +2166,193 @@ def test_git_bound_red_proof_tracks_guard_written_through_a_module_alias(tmp_pat
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
         "stale-red-proof"
     ]
+
+
+def test_git_bound_red_proof_tracks_mutation_through_a_chained_assignment(tmp_path: Path) -> None:
+    """Chained targets share one runtime object, so a mutation reaches both names."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "conftest.py").write_text(
+        'PLUGINS = pytest_plugins = []\nPLUGINS.append("tests.localplugin")\n', encoding="utf-8"
+    )
+    (tests_path / "localplugin.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: mutate a chained plugin assignment")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "delivery.py").write_text("VALUE = 1\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: delivery")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_binds_repository_contained_absolute_pythonpath_root(tmp_path: Path) -> None:
+    """An absolute pythonpath entry inside the checkout still names a repository root."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    plugins_path = tmp_path / "plugins"
+    plugins_path.mkdir()
+    (plugins_path / "localplugin.py").write_text("VALUE = False\n", encoding="utf-8")
+    (tmp_path / "pytest.ini").write_text(
+        f"[pytest]\npythonpath = {plugins_path}\naddopts = -p localplugin\n", encoding="utf-8"
+    )
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    base_ref = _commit(tmp_path, "test: add plugin under an absolute pythonpath root")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (plugins_path / "localplugin.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change plugin under an absolute root")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_tracks_called_lambda_guard_mutation(tmp_path: Path) -> None:
+    """A lambda body runs when it is called, so it mutates module state like a function."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text(
+        'import typing\nactivate = lambda: setattr(typing, "TYPE_CHECKING", True)\nactivate()\n'
+        "if typing.TYPE_CHECKING:\n    import tests.runtime_support\n",
+        encoding="utf-8",
+    )
+    (tests_path / "runtime_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: rewrite the guard from a called lambda")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "runtime_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change runtime support")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_rejects_module_namespace_plugin_write(tmp_path: Path) -> None:
+    """A write through globals() creates the attribute pytest reads without a name target."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "conftest.py").write_text('globals()["pytest_plugins"] = ["tests.localplugin"]\n', encoding="utf-8")
+    (tests_path / "localplugin.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: declare plugins through the module namespace")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "delivery.py").write_text("VALUE = 1\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: delivery")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_rejects_class_body_global_plugin_binding(tmp_path: Path) -> None:
+    """A class body executes at import, so a global plugin binding there is what pytest reads."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "conftest.py").write_text(
+        'class _Configure:\n    global pytest_plugins\n    pytest_plugins = ("tests.localplugin",)\n',
+        encoding="utf-8",
+    )
+    (tests_path / "localplugin.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: declare plugins from a class body")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "delivery.py").write_text("VALUE = 1\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: delivery")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_tracks_guard_nested_in_a_call_argument(tmp_path: Path) -> None:
+    """A guard reached through a nested argument expression is still handed to the call."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text(
+        'import typing\nsetattr([typing][0], "TYPE_CHECKING", True)\n'
+        "if typing.TYPE_CHECKING:\n    import tests.runtime_support\n",
+        encoding="utf-8",
+    )
+    (tests_path / "runtime_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: rewrite the guard through a nested argument")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "runtime_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change runtime support")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_treats_a_bare_decorator_as_a_module_load_call(tmp_path: Path) -> None:
+    """Applying a decorator invokes it during import even without a call expression."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "conftest.py").write_text(
+        "def activate(function):\n    global pytest_plugins\n"
+        '    pytest_plugins = ("tests.localplugin",)\n    return function\n\n\n'
+        "@activate\ndef _configure() -> None:\n    return None\n",
+        encoding="utf-8",
+    )
+    (tests_path / "localplugin.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: declare plugins from a bare decorator")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "delivery.py").write_text("VALUE = 1\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: delivery")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -2841,3 +2841,125 @@ def test_a_plugin_reached_through_a_nested_root_is_bound_with_its_imports(tmp_pa
     assert "tests/plugins/localplugin.py" in inputs
     assert "tests/plugins/helper.py" in inputs
     assert "tests/support.py" in inputs
+
+
+# Every way a conftest can hand ``tests.runtime_support`` to something that loads it. The
+# mechanism differs in each; what they share is that the target is named by a literal, so a rule
+# that resolves the literal covers the family rather than the spellings enumerated here.
+DYNAMIC_LOADER_SHAPES = (
+    'importlib.import_module("tests.runtime_support")',
+    '__import__("tests.runtime_support")',
+    'importlib.__import__("tests.runtime_support")',
+    'from importlib import import_module\nimport_module("tests.runtime_support")',
+    'from importlib import import_module as _load\n_load("tests.runtime_support")',
+    'importlib.import_module(name="tests.runtime_support")',
+    'importlib.util.find_spec("tests.runtime_support")',
+    'def _bring_in(name):\n    return importlib.import_module(name)\n\n\n_bring_in("tests.runtime_support")',
+    'for _name in _collect(["tests.runtime_support"]):\n    importlib.import_module(_name)',
+    'functools.partial(importlib.import_module, "tests.runtime_support")()',
+    'if VERSION:\n    importlib.import_module("tests.runtime_support")',
+    'try:\n    importlib.import_module("tests.runtime_support")\nexcept ImportError:\n    pass',
+    'class Support:\n    module = importlib.import_module("tests.runtime_support")',
+    '@pytest.fixture\ndef support():\n    return importlib.import_module("tests.runtime_support")',
+    'def test_local() -> None:\n    importlib.import_module("tests.runtime_support")',
+    '_preload({"support": "tests.runtime_support"})',
+)
+
+# Literals shaped like a module name that are never handed to a loader, or that name nothing
+# importable. Binding these would reject valid proofs whenever an unrelated file changes.
+INERT_LITERAL_SHAPES = (
+    'NAMES = ("tests.runtime_support",)',
+    'def helper():\n    names = ["tests.runtime_support"]\n    return names',
+    'class Helper:\n    names = ("tests.runtime_support",)',
+    'assert ARGUMENTS == ["-p", "tests.runtime_support"]',
+    'importlib.import_module("tests.absent_support")',
+    'Path("tests")\nPath("runtime_support")',
+)
+
+_DYNAMIC_LOADER_HEADER = (
+    "import functools\n"
+    "import importlib\n"
+    "import importlib.util\n"
+    "from pathlib import Path\n"
+    "\n"
+    "import pytest\n"
+    "\n"
+    "VERSION = 1\n"
+    "ARGUMENTS = []\n"
+    "\n"
+    "\n"
+    "def _collect(names):\n"
+    "    return names\n"
+    "\n"
+    "\n"
+    "def _preload(mapping):\n"
+    "    return mapping\n"
+)
+
+
+def _repository_with_dynamic_loader(tmp_path: Path, body: str) -> tuple[str, Path]:
+    """Commit a conftest carrying ``body`` beside a support module, and return the red proof."""
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "conftest.py").write_text(f"{_DYNAMIC_LOADER_HEADER}\n\n{body}\n", encoding="utf-8")
+    (tests_path / "runtime_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add support module")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    return base_ref, red_proof_path
+
+
+@pytest.mark.parametrize("loader", DYNAMIC_LOADER_SHAPES)
+def test_git_bound_red_proof_binds_a_literal_dynamic_import_target(tmp_path: Path, loader: str) -> None:
+    """A statically known dynamic-import target is an ordinary proof input, however it is spelled."""
+    module = _load_provenance_module()
+    base_ref, red_proof_path = _repository_with_dynamic_loader(tmp_path, loader)
+
+    (tmp_path / "tests" / "runtime_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change dynamically loaded support")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+@pytest.mark.parametrize("inert", INERT_LITERAL_SHAPES)
+def test_a_name_shaped_literal_that_loads_nothing_does_not_bind_a_file(tmp_path: Path, inert: str) -> None:
+    """Reading every module-shaped string as an import would fail proofs on unrelated edits."""
+    module = _load_provenance_module()
+    base_ref, red_proof_path = _repository_with_dynamic_loader(tmp_path, inert)
+
+    (tmp_path / "tests" / "runtime_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "chore: edit a module nothing loads")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+def test_a_dynamic_import_in_an_uncalled_initializer_is_not_bound(tmp_path: Path) -> None:
+    """A deferred body no one invokes never runs, so its target is not an input pytest reads."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    package_path = tmp_path / "tests" / "helpers"
+    package_path.mkdir(parents=True)
+    (tmp_path / "tests" / "__init__.py").write_text("", encoding="utf-8")
+    (tmp_path / "tests" / "conftest.py").write_text("from tests import helpers\n", encoding="utf-8")
+    initializer = 'import importlib\n\n\ndef load():\n    return importlib.import_module("tests.helpers.support")\n'
+    (package_path / "__init__.py").write_text(initializer, encoding="utf-8")
+    (package_path / "support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add lazy loader")
+    (tmp_path / "tests" / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (package_path / "support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "chore: edit the never-loaded support")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -1389,3 +1389,71 @@ def test_git_bound_red_proof_tracks_compound_target_type_checking_rebinding(tmp_
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
         "stale-red-proof"
     ]
+
+
+@pytest.mark.parametrize(
+    "initializer_source",
+    [
+        "from typing import TYPE_CHECKING\n"
+        "def helper(x: object = (TYPE_CHECKING := True)) -> None:\n    return None\n"
+        "if TYPE_CHECKING:\n    import tests.runtime_support\n",
+        "from typing import TYPE_CHECKING\n"
+        "handler = lambda x=(TYPE_CHECKING := True): x\n"
+        "if TYPE_CHECKING:\n    import tests.runtime_support\n",
+        "from typing import TYPE_CHECKING\n"
+        "class Holder(list[(TYPE_CHECKING := True) and int]):\n    pass\n"
+        "if TYPE_CHECKING:\n    import tests.runtime_support\n",
+    ],
+)
+def test_git_bound_red_proof_tracks_scope_header_type_checking_rebinding(
+    tmp_path: Path, initializer_source: str
+) -> None:
+    """A scope header executes where it appears, so a rebinding there is not deferred."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text(initializer_source, encoding="utf-8")
+    (tests_path / "runtime_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add scope-header guard rebinding")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "runtime_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change runtime support")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+@pytest.mark.parametrize("configuration_path", ["pytest.ini", ".pytest.ini", "tox.ini", "setup.cfg"])
+def test_git_bound_red_proof_reads_percent_literal_configuration(tmp_path: Path, configuration_path: str) -> None:
+    """A literal percent sign is valid in a pytest option and must not abort the gate."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    section = "tool:pytest" if configuration_path == "setup.cfg" else "pytest"
+    (tmp_path / configuration_path).write_text(
+        f"[{section}]\naddopts = --junit-prefix=foo%bar -p tests.localplugin\n", encoding="utf-8"
+    )
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "localplugin.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add percent-literal configuration")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "localplugin.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change addopts plugin")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -211,7 +211,14 @@ def test_git_bound_red_proof_rejects_changed_support_imported_by_conftest(tmp_pa
     ]
 
 
-def test_git_bound_red_proof_rejects_changed_pytest_plugin(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "plugin_declaration",
+    [
+        'pytest_plugins = ("tests.helpers.fixtures",)\n',
+        'pytest_plugins: tuple[str, ...] = ("tests.helpers.fixtures",)\n',
+    ],
+)
+def test_git_bound_red_proof_rejects_changed_pytest_plugin(tmp_path: Path, plugin_declaration: str) -> None:
     """A repository-local pytest plugin must remain bound to the red failure."""
     module = _load_provenance_module()
     _git(tmp_path, "init")
@@ -222,7 +229,7 @@ def test_git_bound_red_proof_rejects_changed_pytest_plugin(tmp_path: Path) -> No
     helpers_path.mkdir(parents=True)
     plugin_path = helpers_path / "fixtures.py"
     plugin_path.write_text("VALUE = False\n", encoding="utf-8")
-    (tests_path / "conftest.py").write_text('pytest_plugins = ("tests.helpers.fixtures",)\n', encoding="utf-8")
+    (tests_path / "conftest.py").write_text(plugin_declaration, encoding="utf-8")
     base_ref = _commit(tmp_path, "test: add pytest plugin")
     test_path = tests_path / "test_proof.py"
     test_path.write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
@@ -335,6 +342,29 @@ def test_git_bound_red_proof_rejects_added_parent_package_initializer(tmp_path: 
 
     (support_path / "__init__.py").write_text("VALUE = True\n", encoding="utf-8")
     final_ref = _commit(tmp_path, "fix: initialize support package")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_rejects_added_selector_package_initializer(tmp_path: Path) -> None:
+    """A selected test directory cannot become an executable package after red."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / "README.md").write_text("# proof\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "chore: base")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "__init__.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: initialize selector package")
 
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
         "stale-red-proof"

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -2762,3 +2762,82 @@ def test_git_bound_red_proof_fails_closed_when_a_call_receives_an_aliased_plugin
     declaration = 'P = []\npytest_plugins = P\nlist.append(P, "tests.localplugin")\n'
     with pytest.raises(ValueError, match="stale-red-proof"):
         module._pytest_plugin_names(ast.parse(declaration))
+
+
+def _repository_with_nested_pytest_layout(tmp_path: Path) -> str:
+    """Build a repository exercising nested configuration, roots, plugins, and imports."""
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    unit_path = tests_path / "unit"
+    plugins_path = tests_path / "plugins"
+    unit_path.mkdir(parents=True)
+    plugins_path.mkdir(parents=True)
+    (tmp_path / "pytest.ini").write_text("[pytest]\nfilterwarnings = error\n", encoding="utf-8")
+    (tests_path / "pytest.ini").write_text(
+        "[pytest]\npythonpath = plugins\naddopts = -p localplugin\n", encoding="utf-8"
+    )
+    (plugins_path / "localplugin.py").write_text("import helper\n", encoding="utf-8")
+    (plugins_path / "helper.py").write_text("VALUE = False\n", encoding="utf-8")
+    (tests_path / "__init__.py").write_text("", encoding="utf-8")
+    (tests_path / "conftest.py").write_text("import tests.support\n", encoding="utf-8")
+    (tests_path / "support.py").write_text("VALUE = False\n", encoding="utf-8")
+    (unit_path / "__init__.py").write_text("", encoding="utf-8")
+    (unit_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    return _commit(tmp_path, "test: nested pytest layout")
+
+
+def test_every_file_whose_content_is_read_is_bound_as_a_proof_input(tmp_path: Path) -> None:
+    """Anything the gate reads to decide collection must also be bound as a proof input.
+
+    Two review rounds found the same shape: a source was *discovered and read* to derive
+    plugins or roots, but never added to the returned set, so changing it after the red
+    source did not intersect the changed paths. The AST batteries cannot catch that, because
+    the defect lives in the path plumbing rather than in a rule. This asserts the invariant
+    directly by recording every content read the gate performs.
+    """
+    module = cast(Any, _load_provenance_module())
+    source_ref = _repository_with_nested_pytest_layout(tmp_path)
+
+    read_paths: list[str] = []
+    original_git_bytes = module._git_bytes
+
+    def _recording_git_bytes(repo_root: Path, *arguments: str):  # type: ignore[no-untyped-def]
+        if arguments[:1] == ("show",) and ":" in arguments[1]:
+            read_paths.append(arguments[1].partition(":")[2])
+        return original_git_bytes(repo_root, *arguments)
+
+    module._git_bytes = _recording_git_bytes
+    try:
+        inputs = module._proof_inputs(tmp_path, source_ref, ("tests/unit/test_proof.py",))
+    finally:
+        module._git_bytes = original_git_bytes
+
+    read_and_present = {path for path in read_paths if (tmp_path / path).is_file()}
+    assert read_and_present, "the layout must exercise real content reads"
+    unbound = sorted(read_and_present - inputs)
+    assert not unbound, f"read to decide collection but never bound as proof input: {unbound}"
+
+
+def test_every_configuration_candidate_is_bound_including_absent_ones(tmp_path: Path) -> None:
+    """A configuration added after the red source must invalidate the proof, so absent candidates bind."""
+    module = cast(Any, _load_provenance_module())
+    source_ref = _repository_with_nested_pytest_layout(tmp_path)
+    inputs = module._proof_inputs(tmp_path, source_ref, ("tests/unit/test_proof.py",))
+
+    directories = module._configuration_directories(("tests/unit/test_proof.py",))
+    assert set(directories) == {"", "tests", "tests/unit"}
+    unbound = sorted(module._configuration_candidate_paths(directories) - inputs)
+    assert not unbound, f"configuration candidates not bound: {unbound}"
+
+
+def test_a_plugin_reached_through_a_nested_root_is_bound_with_its_imports(tmp_path: Path) -> None:
+    """A root declared by a nested configuration must bind the plugin and what the plugin imports."""
+    module = cast(Any, _load_provenance_module())
+    source_ref = _repository_with_nested_pytest_layout(tmp_path)
+    inputs = module._proof_inputs(tmp_path, source_ref, ("tests/unit/test_proof.py",))
+
+    assert "tests/plugins/localplugin.py" in inputs
+    assert "tests/plugins/helper.py" in inputs
+    assert "tests/support.py" in inputs

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -968,15 +968,32 @@ def test_git_bound_red_proof_tracks_rebound_type_checking_import(tmp_path: Path,
     ]
 
 
-@pytest.mark.parametrize("configuration_path", ["pyproject.toml", "pytest.ini", "tox.ini", "setup.cfg"])
-def test_git_bound_red_proof_rejects_changed_pytest_configuration(tmp_path: Path, configuration_path: str) -> None:
-    """Pytest ini options decide collection and outcome, so they must stay bound to the red failure."""
+@pytest.mark.parametrize(
+    ("configuration_path", "red_body", "final_body"),
+    [
+        ("pytest.toml", '[pytest]\nfilterwarnings = ["error"]\n', '[pytest]\nfilterwarnings = ["ignore"]\n'),
+        (".pytest.toml", '[pytest]\nfilterwarnings = ["error"]\n', '[pytest]\nfilterwarnings = ["ignore"]\n'),
+        ("pytest.ini", "[pytest]\nfilterwarnings =\n    error\n", "[pytest]\nfilterwarnings =\n    ignore\n"),
+        (".pytest.ini", "[pytest]\nfilterwarnings =\n    error\n", "[pytest]\nfilterwarnings =\n    ignore\n"),
+        (
+            "pyproject.toml",
+            '[tool.pytest.ini_options]\nfilterwarnings = ["error"]\n',
+            '[tool.pytest.ini_options]\nfilterwarnings = ["ignore"]\n',
+        ),
+        ("tox.ini", "[pytest]\nfilterwarnings =\n    error\n", "[pytest]\nfilterwarnings =\n    ignore\n"),
+        ("setup.cfg", "[tool:pytest]\nfilterwarnings =\n    error\n", "[tool:pytest]\nfilterwarnings =\n    ignore\n"),
+    ],
+)
+def test_git_bound_red_proof_rejects_changed_pytest_configuration(
+    tmp_path: Path, configuration_path: str, red_body: str, final_body: str
+) -> None:
+    """Pytest configuration decides collection and outcome, so it must stay bound to the red failure."""
     module = _load_provenance_module()
     _git(tmp_path, "init")
     _git(tmp_path, "config", "user.email", "requirements@example.test")
     _git(tmp_path, "config", "user.name", "Requirements proof")
     configuration = tmp_path / configuration_path
-    configuration.write_text("[pytest]\nfilterwarnings =\n    error\n", encoding="utf-8")
+    configuration.write_text(red_body, encoding="utf-8")
     base_ref = _commit(tmp_path, "chore: add pytest configuration")
     test_path = tmp_path / "tests" / "test_proof.py"
     test_path.parent.mkdir()
@@ -985,7 +1002,7 @@ def test_git_bound_red_proof_rejects_changed_pytest_configuration(tmp_path: Path
     red_proof_path = tmp_path / ".git" / "red.json"
     _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
 
-    configuration.write_text("[pytest]\nfilterwarnings =\n    ignore\n", encoding="utf-8")
+    configuration.write_text(final_body, encoding="utf-8")
     final_ref = _commit(tmp_path, "fix: relax pytest configuration")
 
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
@@ -1085,6 +1102,8 @@ def test_git_bound_red_proof_binds_non_utf8_support_module(tmp_path: Path) -> No
         ("pytest.ini", "[pytest]\npythonpath = source\n"),
         ("tox.ini", "[pytest]\npythonpath = source\n"),
         ("setup.cfg", "[tool:pytest]\npythonpath = source\n"),
+        ("pytest.toml", '[pytest]\npythonpath = ["source"]\n'),
+        ("pyproject.toml", '[tool.pytest]\npythonpath = ["source"]\n'),
     ],
 )
 def test_git_bound_red_proof_rejects_changed_plugin_under_pythonpath_root(
@@ -1234,6 +1253,10 @@ def test_git_bound_red_proof_rejects_oversized_proof_input(tmp_path: Path) -> No
         ("pytest.ini", "[pytest]\naddopts = -ra -p tests.localplugin\n"),
         ("tox.ini", "[pytest]\naddopts = -ra -p tests.localplugin\n"),
         ("setup.cfg", "[tool:pytest]\naddopts = -ra -p tests.localplugin\n"),
+        ("pytest.toml", '[pytest]\naddopts = "-ra -p tests.localplugin"\n'),
+        (".pytest.toml", '[pytest]\naddopts = ["-ra", "-p", "tests.localplugin"]\n'),
+        ("pyproject.toml", '[tool.pytest]\naddopts = "-ra -p tests.localplugin"\n'),
+        (".pytest.ini", "[pytest]\naddopts = -ra -p tests.localplugin\n"),
     ],
 )
 def test_git_bound_red_proof_rejects_changed_addopts_plugin(
@@ -1339,3 +1362,30 @@ def test_git_bound_red_proof_ignores_function_local_type_checking_rebinding(tmp_
     final_ref = _commit(tmp_path, "chore: change type-only helper")
 
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+def test_git_bound_red_proof_tracks_compound_target_type_checking_rebinding(tmp_path: Path) -> None:
+    """A module-scope compound target can rebind the typing alias, so its guard is not static."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text(
+        "import typing\nfor typing in []:\n    pass\nif typing.TYPE_CHECKING:\n    import tests.runtime_support\n",
+        encoding="utf-8",
+    )
+    (tests_path / "runtime_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add compound-target typing rebinding")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "runtime_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change runtime support")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -219,6 +219,7 @@ def test_git_bound_red_proof_rejects_changed_support_imported_by_conftest(tmp_pa
         'pytest_plugins: str = "tests.helpers.fixtures,tests.helpers.other"\n',
         'PLUGINS = ("tests.helpers.fixtures",)\npytest_plugins: tuple[str, ...] = PLUGINS\n',
         'PLUGINS = ("tests.helpers.other",)\nPLUGINS = ("tests.helpers.fixtures",)\npytest_plugins = PLUGINS\n',
+        'FLAG = True\nif FLAG:\n    PLUGINS = ("tests.helpers.fixtures",)\nelse:\n    PLUGINS = ("tests.helpers.other",)\npytest_plugins = PLUGINS\n',
     ],
 )
 def test_git_bound_red_proof_rejects_changed_pytest_plugin(tmp_path: Path, plugin_declaration: str) -> None:
@@ -491,7 +492,9 @@ def _validate_rebound_type_checking_branch(tmp_path: Path) -> list[str]:
     tests_path = tmp_path / "tests"
     tests_path.mkdir()
     (tests_path / "__init__.py").write_text(
-        "from typing import TYPE_CHECKING\nTYPE_CHECKING = True\nif TYPE_CHECKING:\n    import tests.runtime_support\n",
+        "from typing import TYPE_CHECKING\n"
+        "if True:\n    TYPE_CHECKING = True\n"
+        "if TYPE_CHECKING:\n    import tests.runtime_support\n",
         encoding="utf-8",
     )
     (tests_path / "runtime_support.py").write_text("VALUE = False\n", encoding="utf-8")

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -1830,3 +1830,93 @@ def test_git_bound_red_proof_tracks_called_global_guard_rebinding(tmp_path: Path
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
         "stale-red-proof"
     ]
+
+
+@pytest.mark.parametrize(
+    "initializer_source",
+    [
+        # An invoked setter assigns the declaration through `global`.
+        'def configure() -> None:\n    global pytest_plugins\n    pytest_plugins = ("tests.helpers.fixtures",)\nconfigure()\n',
+        # An invoked function mutates the typing guard by attribute.
+        "import typing\ndef enable() -> None:\n    typing.TYPE_CHECKING = True\nenable()\n",
+        # The invoked function is reached through an alias rather than its own name.
+        "from typing import TYPE_CHECKING\n"
+        "def enable() -> None:\n    global TYPE_CHECKING\n    TYPE_CHECKING = True\n"
+        "activate = enable\nactivate()\n",
+    ],
+)
+def test_git_bound_red_proof_rejects_invoked_module_state_mutation(tmp_path: Path, initializer_source: str) -> None:
+    """An invoked function that can change module state leaves it unverifiable, so it fails closed."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    helpers_path = tests_path / "helpers"
+    helpers_path.mkdir(parents=True)
+    (helpers_path / "fixtures.py").write_text("VALUE = False\n", encoding="utf-8")
+    (tests_path / "conftest.py").write_text(initializer_source, encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add invoked module-state mutation")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "delivery.py").write_text("VALUE = 1\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: delivery")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_ignores_guard_rebound_after_its_branch(tmp_path: Path) -> None:
+    """A rebinding cannot invalidate a branch that already ran before it."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text(
+        "from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n    import tests.type_support\nTYPE_CHECKING = True\n",
+        encoding="utf-8",
+    )
+    (tests_path / "type_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: rebind the guard after its branch")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "type_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "chore: change type-only helper")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+def test_git_bound_red_proof_tracks_guard_rebound_before_its_branch(tmp_path: Path) -> None:
+    """A rebinding that precedes the branch still invalidates the guard."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text(
+        "from typing import TYPE_CHECKING\nTYPE_CHECKING = True\nif TYPE_CHECKING:\n    import tests.runtime_support\n",
+        encoding="utf-8",
+    )
+    (tests_path / "runtime_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: rebind the guard before its branch")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "runtime_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change runtime support")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -217,6 +217,7 @@ def test_git_bound_red_proof_rejects_changed_support_imported_by_conftest(tmp_pa
         'pytest_plugins = ("tests.helpers.fixtures",)\n',
         'pytest_plugins: tuple[str, ...] = ("tests.helpers.fixtures",)\n',
         'pytest_plugins: str = "tests.helpers.fixtures,tests.helpers.other"\n',
+        'PLUGINS = ("tests.helpers.fixtures",)\npytest_plugins: tuple[str, ...] = PLUGINS\n',
     ],
 )
 def test_git_bound_red_proof_rejects_changed_pytest_plugin(tmp_path: Path, plugin_declaration: str) -> None:
@@ -447,6 +448,35 @@ def test_git_bound_red_proof_ignores_lazy_initializer_import(tmp_path: Path) -> 
 
     (tests_path / "lazy_support.py").write_text("VALUE = True\n", encoding="utf-8")
     final_ref = _commit(tmp_path, "fix: change lazy initializer support")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+def test_git_bound_red_proof_ignores_unreachable_initializer_imports(tmp_path: Path) -> None:
+    """Statically false initializer branches do not execute their imports."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text(
+        "from typing import TYPE_CHECKING\n"
+        "if False:\n    import tests.false_support\n"
+        "if TYPE_CHECKING:\n    import tests.typed_support\n",
+        encoding="utf-8",
+    )
+    (tests_path / "false_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    (tests_path / "typed_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add unreachable initializer imports")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "false_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    (tests_path / "typed_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change unreachable initializer support")
 
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
 

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -2356,3 +2356,55 @@ def test_git_bound_red_proof_treats_a_bare_decorator_as_a_module_load_call(tmp_p
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
         "stale-red-proof"
     ]
+
+
+def test_git_bound_red_proof_binds_imports_inside_an_invoked_function(tmp_path: Path) -> None:
+    """A function body called during module load executes its imports at import time."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "conftest.py").write_text(
+        "def _load() -> None:\n    import tests.runtime_support\n\n\n_load()\n", encoding="utf-8"
+    )
+    (tests_path / "runtime_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: import support from an invoked function")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "runtime_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change runtime support")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_ignores_type_only_import_inside_a_function(tmp_path: Path) -> None:
+    """Widening to function bodies must not bind imports a typing guard keeps unexecuted."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "conftest.py").write_text(
+        "from typing import TYPE_CHECKING\n\n\ndef _load() -> None:\n"
+        "    if TYPE_CHECKING:\n        import tests.type_support\n",
+        encoding="utf-8",
+    )
+    (tests_path / "type_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: guard a function-body import")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "type_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "chore: change type-only helper")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import hashlib
 import importlib.util
+import itertools
 import json
 import subprocess
 import sys
@@ -2961,5 +2962,136 @@ def test_a_dynamic_import_in_an_uncalled_initializer_is_not_bound(tmp_path: Path
 
     (package_path / "support.py").write_text("VALUE = True\n", encoding="utf-8")
     final_ref = _commit(tmp_path, "chore: edit the never-loaded support")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+def _executor_early_loaded_plugin_names() -> set[str]:
+    """Return the plugin names the executor early-loads, read from its own command shape."""
+    tree = ast.parse((Path(__file__).resolve().parents[3] / "scripts" / "requirements_proof_executor.py").read_bytes())
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.List, ast.Tuple)):
+            continue
+        literals = [element.value if isinstance(element, ast.Constant) else None for element in node.elts]
+        names.update(
+            following
+            for token, following in itertools.pairwise(literals)
+            if token == "-p" and isinstance(following, str)
+        )
+    return names
+
+
+def test_every_plugin_the_executor_early_loads_is_a_proof_input(tmp_path: Path) -> None:
+    """A plugin the proof run always loads decides collection, so changing it invalidates the proof."""
+    module = _load_provenance_module()
+    early_loaded = _executor_early_loaded_plugin_names()
+    assert early_loaded, "the executor no longer early-loads any plugin; this guard needs updating"
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    plugin_paths = [Path(*name.split(".")).with_suffix(".py") for name in sorted(early_loaded)]
+    for relative in plugin_paths:
+        (tmp_path / relative).parent.mkdir(parents=True, exist_ok=True)
+        (tmp_path / relative).write_text(
+            "def pytest_collection_modifyitems(items):\n    return None\n", encoding="utf-8"
+        )
+    (tmp_path / "tests").mkdir()
+    base_ref = _commit(tmp_path, "test: add the early-loaded plugin")
+    (tmp_path / "tests" / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tmp_path / plugin_paths[0]).write_text(
+        "def pytest_collection_modifyitems(items):\n    items.clear()\n", encoding="utf-8"
+    )
+    final_ref = _commit(tmp_path, "fix: change the early-loaded plugin")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_the_gate_seeds_every_plugin_the_executor_early_loads() -> None:
+    """The two scripts must not drift: a plugin added to the command must be bound by the gate."""
+    module = _load_provenance_module()
+    seeded = {".".join(parts) for parts in module.EXECUTOR_PLUGIN_NAMES}
+
+    assert _executor_early_loaded_plugin_names() <= seeded
+
+
+def _repository_with_data_read(tmp_path: Path, body: str, extra: dict[str, str] | None = None) -> tuple[str, Path]:
+    """Commit a conftest whose ``body`` reads repository data, and return the red proof."""
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / "tests" / "data").mkdir(parents=True)
+    (tmp_path / "tests" / "data" / "case.json").write_text('{"expected": false}\n', encoding="utf-8")
+    for relative, text in (extra or {}).items():
+        (tmp_path / relative).parent.mkdir(parents=True, exist_ok=True)
+        (tmp_path / relative).write_text(text, encoding="utf-8")
+    header = "from pathlib import Path\n\nREPO_ROOT = Path(__file__).resolve().parents[1]\n"
+    (tmp_path / "tests" / "conftest.py").write_text(f"{header}\n{body}\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add data the harness reads")
+    (tmp_path / "tests" / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    return base_ref, red_proof_path
+
+
+# Every way the harness can name ``tests/data/case.json`` as a file it reads.
+DATA_READ_SHAPES = (
+    'CASE = Path("tests/data/case.json").read_text()',
+    'CASE = open("tests/data/case.json").read()',
+    'CASE = (REPO_ROOT / "tests" / "data" / "case.json").read_text()',
+    'CASE = (REPO_ROOT / "tests/data/case.json").read_text()',
+    'def fixture_case():\n    return Path("tests/data/case.json").read_bytes()',
+    'CASES = [Path(name) for name in ["tests/data/case.json"]]',
+)
+
+
+@pytest.mark.parametrize("read", DATA_READ_SHAPES)
+def test_repository_data_the_harness_reads_is_a_proof_input(tmp_path: Path, read: str) -> None:
+    """Data inside the test tree decides the outcome, so changing it invalidates the proof."""
+    module = _load_provenance_module()
+    base_ref, red_proof_path = _repository_with_data_read(tmp_path, read)
+
+    (tmp_path / "tests" / "data" / "case.json").write_text('{"expected": true}\n', encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change the case the harness reads")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("read", "changed"),
+    [
+        ('CASE = Path("src/product.py").read_text()', "src/product.py"),
+        ('CASE = Path("README.md").read_text()', "README.md"),
+        ('CASE = Path("docs/index.md").read_text()', "docs/index.md"),
+    ],
+)
+def test_a_file_the_fix_is_expected_to_change_is_not_bound_by_a_read(tmp_path: Path, read: str, changed: str) -> None:
+    """Production source and documentation are what a red-to-green change edits, not the harness."""
+    module = _load_provenance_module()
+    base_ref, red_proof_path = _repository_with_data_read(tmp_path, read, {changed: "before\n"})
+
+    (tmp_path / changed).write_text("after\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change the file under test")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+def test_a_read_that_cannot_be_resolved_does_not_fail_the_proof(tmp_path: Path) -> None:
+    """Harnesses read paths built at runtime constantly; failing closed on those rejects every proof."""
+    module = _load_provenance_module()
+    body = 'def fixture_case(tmp_path):\n    return (tmp_path / "case.json").read_text()'
+    base_ref, red_proof_path = _repository_with_data_read(tmp_path, body)
+
+    (tmp_path / "tests" / "data" / "case.json").write_text('{"expected": true}\n', encoding="utf-8")
+    final_ref = _commit(tmp_path, "chore: change data nothing reads")
 
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -2704,3 +2704,61 @@ def test_guard_survives_unrelated_module_load_activity() -> None:
     )
     _type_checking_names, typing_module_names = module._verified_type_checking_bindings(tree)
     assert "typing" in typing_module_names
+
+
+def test_git_bound_red_proof_binds_a_nested_configuration_path(tmp_path: Path) -> None:
+    """A nested configuration decides collection, so changing it after red invalidates proof."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "pytest.ini").write_text("[pytest]\nfilterwarnings = error\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add nested configuration")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "pytest.ini").write_text("[pytest]\nfilterwarnings = ignore\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change nested configuration")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_resolves_pythonpath_against_its_configuration(tmp_path: Path) -> None:
+    """Pytest joins a relative `pythonpath` entry to the directory of the file declaring it."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    plugins_path = tests_path / "plugins"
+    plugins_path.mkdir(parents=True)
+    (plugins_path / "localplugin.py").write_text("VALUE = False\n", encoding="utf-8")
+    (tests_path / "pytest.ini").write_text(
+        "[pytest]\npythonpath = plugins\naddopts = -p localplugin\n", encoding="utf-8"
+    )
+    base_ref = _commit(tmp_path, "test: declare a nested pythonpath root")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (plugins_path / "localplugin.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change the nested-root plugin")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_fails_closed_when_a_call_receives_an_aliased_plugin_list() -> None:
+    """An unbound-method call mutates the argument, not the receiver."""
+    module = cast(Any, _load_provenance_module())
+    declaration = 'P = []\npytest_plugins = P\nlist.append(P, "tests.localplugin")\n'
+    with pytest.raises(ValueError, match="stale-red-proof"):
+        module._pytest_plugin_names(ast.parse(declaration))

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -245,6 +245,39 @@ def test_git_bound_red_proof_rejects_changed_pytest_plugin(tmp_path: Path, plugi
     ]
 
 
+@pytest.mark.parametrize(
+    "plugin_declaration",
+    [
+        'def helper() -> None:\n    pytest_plugins: tuple[str, ...] = ("tests.helpers.fixtures",)\n',
+        'class Helper:\n    pytest_plugins: tuple[str, ...] = ("tests.helpers.fixtures",)\n',
+    ],
+)
+def test_git_bound_red_proof_ignores_nested_pytest_plugin(
+    tmp_path: Path, plugin_declaration: str
+) -> None:
+    """A local or class annotation does not declare a pytest plugin."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    helpers_path = tests_path / "helpers"
+    helpers_path.mkdir(parents=True)
+    plugin_path = helpers_path / "fixtures.py"
+    plugin_path.write_text("VALUE = False\n", encoding="utf-8")
+    (tests_path / "conftest.py").write_text(plugin_declaration, encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add nested plugin-like annotation")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    plugin_path.write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change unrelated plugin-like target")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
 def test_git_bound_red_proof_rejects_import_target_added_after_red(tmp_path: Path) -> None:
     """A missing local import added after red must invalidate collection-error proof."""
     module = _load_provenance_module()

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -222,6 +222,9 @@ def test_git_bound_red_proof_rejects_changed_support_imported_by_conftest(tmp_pa
         'FLAG = True\nif FLAG:\n    PLUGINS = ("tests.helpers.fixtures",)\nelse:\n    PLUGINS = ("tests.helpers.other",)\npytest_plugins = PLUGINS\n',
         'PLUGINS = ("tests.helpers.fixtures",)\nfor _ in ():\n    PLUGINS = ("tests.helpers.other",)\npytest_plugins = PLUGINS\n',
         'FLAG = False\nPLUGINS = ("tests.helpers.fixtures",)\nif FLAG:\n    PLUGINS = load_plugins()\npytest_plugins = PLUGINS\n',
+        'pytest_plugins = ()\npytest_plugins += ("tests.helpers.fixtures",)\n',
+        'pytest_plugins, _unused = ("tests.helpers.fixtures",), 1\n',
+        'PLUGINS = ()\nPLUGINS += ("tests.helpers.fixtures",)\npytest_plugins = PLUGINS\n',
     ],
 )
 def test_git_bound_red_proof_rejects_changed_pytest_plugin(tmp_path: Path, plugin_declaration: str) -> None:
@@ -926,4 +929,150 @@ def test_git_bound_red_proof_rejects_test_digest_not_present_at_source(tmp_path:
 
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
         "prior-red-proof-invalid"
+    ]
+
+
+@pytest.mark.parametrize(
+    "initializer_source",
+    [
+        "from typing import TYPE_CHECKING\n"
+        "if True:\n    from tests.guard import TYPE_CHECKING\n"
+        "if TYPE_CHECKING:\n    import tests.runtime_support\n",
+        "import typing\n"
+        "if True:\n    import tests.guard as typing\n"
+        "if typing.TYPE_CHECKING:\n    import tests.runtime_support\n",
+    ],
+)
+def test_git_bound_red_proof_tracks_rebound_type_checking_import(tmp_path: Path, initializer_source: str) -> None:
+    """A nested import rebinding the guard name or the typing module cannot prune a runtime branch."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "guard.py").write_text("TYPE_CHECKING = True\n", encoding="utf-8")
+    (tests_path / "__init__.py").write_text(initializer_source, encoding="utf-8")
+    (tests_path / "runtime_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add rebound type-checking import")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "runtime_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change runtime type-checking support")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+@pytest.mark.parametrize("configuration_path", ["pyproject.toml", "pytest.ini", "tox.ini", "setup.cfg"])
+def test_git_bound_red_proof_rejects_changed_pytest_configuration(tmp_path: Path, configuration_path: str) -> None:
+    """Pytest ini options decide collection and outcome, so they must stay bound to the red failure."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    configuration = tmp_path / configuration_path
+    configuration.write_text("[pytest]\nfilterwarnings =\n    error\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "chore: add pytest configuration")
+    test_path = tmp_path / "tests" / "test_proof.py"
+    test_path.parent.mkdir()
+    test_path.write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    configuration.write_text("[pytest]\nfilterwarnings =\n    ignore\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: relax pytest configuration")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+@pytest.mark.parametrize(
+    "plugin_declaration",
+    [
+        'BASE = ("tests.helpers.fixtures",)\npytest_plugins = list(BASE)\n',
+        'BASE = ("tests.helpers.fixtures",)\nEXTRA = ("tests.helpers.other",)\npytest_plugins = BASE + EXTRA\n',
+        'BASE = ("tests.helpers.fixtures",)\npytest_plugins = [*BASE, "tests.helpers.other"]\n',
+        "pytest_plugins = _discover_plugins()\n",
+        'FLAG = True\nPLUGINS = ("tests.helpers.fixtures",)\nif FLAG:\n    PLUGINS = _load()\npytest_plugins = PLUGINS\n',
+    ],
+)
+def test_git_bound_red_proof_rejects_unresolvable_pytest_plugins(tmp_path: Path, plugin_declaration: str) -> None:
+    """An active plugin declaration that cannot be resolved statically must fail closed."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "conftest.py").write_text(plugin_declaration, encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add unresolvable plugin declaration")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "delivery.py").write_text("VALUE = 1\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: delivery")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+@pytest.mark.parametrize("selectors", [[{"path": "tests/test_proof.py"}], [["tests/test_proof.py::test_selected"]]])
+def test_git_bound_red_proof_rejects_unhashable_selector_entry(tmp_path: Path, selectors: list[object]) -> None:
+    """A malformed selector entry yields a deterministic finding instead of an unhandled error."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / "README.md").write_text("# proof\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "chore: base")
+    test_path = tmp_path / "tests" / "test_proof.py"
+    test_path.parent.mkdir()
+    test_path.write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    report = json.loads(red_proof_path.read_text(encoding="utf-8"))
+    report["execution_proof"]["selectors"] = selectors
+    red_proof_path.write_text(json.dumps(report), encoding="utf-8")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "delivery.py").write_text("VALUE = 1\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: delivery")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "prior-red-proof-invalid"
+    ]
+
+
+def test_git_bound_red_proof_binds_non_utf8_support_module(tmp_path: Path) -> None:
+    """A legally encoded non-UTF-8 support module must be parsed, not crash the gate."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "support.py").write_bytes(b"# -*- coding: latin-1 -*-\nLABEL = 'caf\xe9'\nVALUE = False\n")
+    (tests_path / "conftest.py").write_bytes(b"# -*- coding: latin-1 -*-\n# caf\xe9\nimport tests.support\n")
+    (tests_path / "__init__.py").write_text("", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add latin-1 support module")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "support.py").write_bytes(b"# -*- coding: latin-1 -*-\nLABEL = 'caf\xe9'\nVALUE = True\n")
+    final_ref = _commit(tmp_path, "fix: change latin-1 support module")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
     ]

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -3095,3 +3095,24 @@ def test_a_read_that_cannot_be_resolved_does_not_fail_the_proof(tmp_path: Path) 
     final_ref = _commit(tmp_path, "chore: change data nothing reads")
 
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+@pytest.mark.parametrize(
+    "literal",
+    [
+        "tests/data/case.json\x00truncated",
+        "tests/data/case.json\tinjected",
+        "tests/data/case.json\ninjected",
+        "tests/../src/product.py",
+    ],
+)
+def test_a_literal_that_cannot_name_a_committed_path_is_discarded(tmp_path: Path, literal: str) -> None:
+    """Arbitrary strings become Git arguments, and a null byte cannot even reach a subprocess."""
+    module = _load_provenance_module()
+    body = f"CASE = Path({literal!r}).read_text()"
+    base_ref, red_proof_path = _repository_with_data_read(tmp_path, body)
+
+    (tmp_path / "tests" / "data" / "case.json").write_text('{"expected": true}\n', encoding="utf-8")
+    final_ref = _commit(tmp_path, "chore: change data the malformed literal does not name")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -1920,3 +1920,141 @@ def test_git_bound_red_proof_tracks_guard_rebound_before_its_branch(tmp_path: Pa
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
         "stale-red-proof"
     ]
+
+
+def test_git_bound_red_proof_normalizes_traversing_pythonpath_root(tmp_path: Path) -> None:
+    """Pytest resolves a `pythonpath` entry, so a root spelled with `..` still binds its plugin."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / "pytest.ini").write_text(
+        "[pytest]\npythonpath = tests/helpers/../plugins\naddopts = -p localplugin\n", encoding="utf-8"
+    )
+    plugins_path = tmp_path / "tests" / "plugins"
+    plugins_path.mkdir(parents=True)
+    (plugins_path / "localplugin.py").write_text("VALUE = False\n", encoding="utf-8")
+    (tmp_path / "tests" / "helpers").mkdir()
+    (tmp_path / "tests" / "helpers" / "keep.py").write_text("VALUE = True\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add plugin under a traversing pythonpath root")
+    (tmp_path / "tests" / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (plugins_path / "localplugin.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change plugin under a traversing root")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_rejects_symlinked_pytest_configuration(tmp_path: Path) -> None:
+    """Pytest reads a symlinked configuration target whose bytes this gate never inspected."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    config_path = tmp_path / "config"
+    config_path.mkdir()
+    (config_path / "real-pytest.ini").write_text("[pytest]\naddopts = -p tests.localplugin\n", encoding="utf-8")
+    (tmp_path / "pytest.ini").symlink_to(Path("config") / "real-pytest.ini")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "localplugin.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add symlinked pytest configuration")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "delivery.py").write_text("VALUE = 1\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: delivery")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_tracks_mutation_through_an_earlier_alias(tmp_path: Path) -> None:
+    """Aliasing a list binds the same object, so a later mutation changes the declared plugins."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "conftest.py").write_text(
+        'PLUGINS = []\npytest_plugins = PLUGINS\nPLUGINS.append("tests.localplugin")\n', encoding="utf-8"
+    )
+    (tests_path / "localplugin.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: alias the plugin list before mutating it")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "delivery.py").write_text("VALUE = 1\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "feat: delivery")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_tracks_setattr_written_typing_guard(tmp_path: Path) -> None:
+    """A guard handed to a call can be rewritten, so its branch is no longer type-only."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text(
+        'import typing\nsetattr(typing, "TYPE_CHECKING", True)\n'
+        "if typing.TYPE_CHECKING:\n    import tests.runtime_support\n",
+        encoding="utf-8",
+    )
+    (tests_path / "runtime_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: rewrite the typing guard through setattr")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "runtime_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change runtime support")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_git_bound_red_proof_tracks_setattr_guard_write_from_a_function(tmp_path: Path) -> None:
+    """A function that rewrites an attribute makes module state unverifiable once it is called."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text(
+        "import typing\n\n\ndef _enable() -> None:\n"
+        '    setattr(typing, "TYPE_CHECKING", True)\n\n\n_enable()\n'
+        "if typing.TYPE_CHECKING:\n    import tests.runtime_support\n",
+        encoding="utf-8",
+    )
+    (tests_path / "runtime_support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: rewrite the typing guard from a called function")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "runtime_support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change runtime support")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -3116,3 +3116,261 @@ def test_a_literal_that_cannot_name_a_committed_path_is_discarded(tmp_path: Path
     final_ref = _commit(tmp_path, "chore: change data the malformed literal does not name")
 
     assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+def test_a_file_relative_data_read_resolves_against_the_reading_module(tmp_path: Path) -> None:
+    """``Path(__file__).parent / "data"`` names a directory beside the module, not beside the root."""
+    module = _load_provenance_module()
+    body = 'CASE = (Path(__file__).parent / "data" / "case.json").read_text()'
+    base_ref, red_proof_path = _repository_with_data_read(tmp_path, body)
+
+    (tmp_path / "tests" / "data" / "case.json").write_text('{"expected": true}\n', encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change the case the harness reads")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_a_data_read_through_a_symlink_binds_the_target(tmp_path: Path) -> None:
+    """Pytest follows the link and consumes the target's bytes, which Git records separately."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    data_path = tmp_path / "tests" / "data"
+    data_path.mkdir(parents=True)
+    (data_path / "real.json").write_text('{"expected": false}\n', encoding="utf-8")
+    (data_path / "case.json").symlink_to("real.json")
+    (tmp_path / "tests" / "conftest.py").write_text(
+        'from pathlib import Path\n\nCASE = Path("tests/data/case.json").read_text()\n', encoding="utf-8"
+    )
+    base_ref = _commit(tmp_path, "test: add linked data")
+    (tmp_path / "tests" / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (data_path / "real.json").write_text('{"expected": true}\n', encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change the link target")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_an_undetermined_existence_check_is_stale_rather_than_absent(tmp_path: Path) -> None:
+    """A Git call that could not answer is not evidence that a module is missing."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "conftest.py").write_text("import tests.support\n", encoding="utf-8")
+    (tmp_path / "tests" / "__init__.py").write_text("", encoding="utf-8")
+    (tmp_path / "tests" / "support.py").write_text("import tests.helper\n", encoding="utf-8")
+    (tmp_path / "tests" / "helper.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add support")
+    (tmp_path / "tests" / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    # Only the helper reached *through* the unreadable module changes, so accepting the proof
+    # depends entirely on whether the unanswerable lookup was read as "absent".
+    (tmp_path / "tests" / "helper.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change the transitively imported helper")
+
+    original_git_bytes = module._git_bytes
+
+    def timing_out_git_bytes(repo_root: Path, *arguments: str) -> Any:
+        # A timeout reaches callers as an ordinary failure, whichever command was issued.
+        if any("tests/support.py" in argument for argument in arguments):
+            return subprocess.CompletedProcess(["git", *arguments], returncode=1, stdout=b"", stderr=b"")
+        return original_git_bytes(repo_root, *arguments)
+
+    module._git_bytes = timing_out_git_bytes
+    try:
+        module._tree_entry_mode_at_ref.cache_clear()
+        module._python_tree_at_ref.cache_clear()
+        findings = module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref)
+    finally:
+        module._git_bytes = original_git_bytes
+
+    assert findings == ["stale-red-proof"]
+
+
+# Every way a harness names data beside itself. The base differs in each; what they share is
+# that it resolves to the reading module's own directory rather than to the repository root.
+FILE_RELATIVE_BASE_SHAPES = (
+    '(Path(__file__).parent / "data" / "case.json").read_text()',
+    '(Path(__file__).resolve().parent / "data" / "case.json").read_text()',
+    '(Path(__file__).parents[0] / "data" / "case.json").read_text()',
+    '(Path(__file__).parent.parent / "tests" / "data" / "case.json").read_text()',
+    '(Path(__file__).resolve().parents[1] / "tests" / "data" / "case.json").read_text()',
+    'HERE = Path(__file__).parent\nCASE = (HERE / "data" / "case.json").read_text()',
+    'ROOT = Path(__file__).resolve().parents[1]\nCASE = (ROOT / "tests" / "data" / "case.json").read_text()',
+    '(Path(os.path.dirname(__file__)) / "data" / "case.json").read_text()',
+)
+
+# Joins whose base is decided at runtime. Reading them as root-relative would bind whatever
+# committed file happens to share the remaining components, failing proofs on unrelated edits.
+UNKNOWABLE_BASE_SHAPES = (
+    'def fixture_case(tmp_path):\n    return (tmp_path / "tests" / "data" / "case.json").read_text()',
+    'def fixture_case(request):\n    return (request.config.rootpath / "tests" / "data" / "case.json").read_text()',
+    'def fixture_case(base):\n    return (base / "tests" / "data" / "case.json").read_text()',
+)
+
+
+@pytest.mark.parametrize("read", FILE_RELATIVE_BASE_SHAPES)
+def test_a_data_read_resolves_every_knowable_path_base(tmp_path: Path, read: str) -> None:
+    """The reading module's own directory is the base a harness names its data from."""
+    module = _load_provenance_module()
+    base_ref, red_proof_path = _repository_with_data_read(tmp_path, f"import os\n\nCASE = {read}")
+
+    (tmp_path / "tests" / "data" / "case.json").write_text('{"expected": true}\n', encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change the case the harness reads")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+@pytest.mark.parametrize("read", UNKNOWABLE_BASE_SHAPES)
+def test_a_join_from_an_unknowable_base_binds_nothing(tmp_path: Path, read: str) -> None:
+    """A runtime base names no committed file, so treating it as root-relative binds the wrong one."""
+    module = _load_provenance_module()
+    base_ref, red_proof_path = _repository_with_data_read(tmp_path, read)
+
+    (tmp_path / "tests" / "data" / "case.json").write_text('{"expected": true}\n', encoding="utf-8")
+    final_ref = _commit(tmp_path, "chore: change a case nothing reads")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+def _repository_with_linked_data(tmp_path: Path, link_text: str) -> tuple[str, Path]:
+    """Commit ``tests/data/case.json`` as a link to ``link_text`` beside a real target."""
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    data_path = tmp_path / "tests" / "data"
+    data_path.mkdir(parents=True)
+    (data_path / "real.json").write_text('{"expected": false}\n', encoding="utf-8")
+    (data_path / "hop.json").symlink_to("real.json")
+    (data_path / "case.json").symlink_to(link_text)
+    (tmp_path / "tests" / "conftest.py").write_text(
+        'from pathlib import Path\n\nCASE = Path("tests/data/case.json").read_text()\n', encoding="utf-8"
+    )
+    base_ref = _commit(tmp_path, "test: add linked data")
+    (tmp_path / "tests" / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    return base_ref, red_proof_path
+
+
+def test_a_data_read_follows_a_chain_of_links_to_its_target(tmp_path: Path) -> None:
+    """Each hop is bound, because editing any of them changes the bytes the read returns."""
+    module = _load_provenance_module()
+    base_ref, red_proof_path = _repository_with_linked_data(tmp_path, "hop.json")
+
+    (tmp_path / "tests" / "data" / "real.json").write_text('{"expected": true}\n', encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change the far end of the chain")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+@pytest.mark.parametrize("link_text", ["../../../outside.json", "/etc/hostname", "missing.json", "case.json"])
+def test_a_link_that_cannot_be_bound_is_stale(tmp_path: Path, link_text: str) -> None:
+    """A link out of the checkout, at nothing, or at itself binds no bytes and is not proof."""
+    module = _load_provenance_module()
+    base_ref, red_proof_path = _repository_with_linked_data(tmp_path, link_text)
+
+    (tmp_path / "tests" / "data" / "real.json").write_text('{"expected": true}\n', encoding="utf-8")
+    final_ref = _commit(tmp_path, "chore: touch the repository after the red source")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def _repository_with_two_tests(
+    tmp_path: Path, other_body: str, selected_body: str = "assert False"
+) -> tuple[str, Path]:
+    """Commit a selected test beside an unselected one, and return the red proof."""
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "__init__.py").write_text("", encoding="utf-8")
+    (tmp_path / "tests" / "helper.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add helper")
+    (tmp_path / "tests" / "test_proof.py").write_text(
+        f"def test_selected() -> None:\n    {selected_body}\n\n\ndef test_other() -> None:\n    {other_body}\n",
+        encoding="utf-8",
+    )
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+    return base_ref, red_proof_path
+
+
+def test_an_import_only_inside_an_unselected_test_body_is_not_bound(tmp_path: Path) -> None:
+    """Exact selection runs one node, so another test's body never executes its imports."""
+    module = _load_provenance_module()
+    base_ref, red_proof_path = _repository_with_two_tests(tmp_path, "import tests.helper")
+
+    (tmp_path / "tests" / "helper.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "chore: change a helper only the unselected test imports")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == []
+
+
+@pytest.mark.parametrize(
+    ("other_body", "selected_body"),
+    [
+        # The selected body imports it, so it runs.
+        ("pass", "import tests.helper"),
+        # The unselected function is called by the selected one, so its body runs after all.
+        ("import tests.helper", "test_other()"),
+    ],
+)
+def test_an_import_a_selected_run_can_reach_stays_bound(tmp_path: Path, other_body: str, selected_body: str) -> None:
+    """Narrowing may only drop bodies nothing invokes; anything reachable still binds."""
+    module = _load_provenance_module()
+    base_ref, red_proof_path = _repository_with_two_tests(tmp_path, other_body, selected_body)
+
+    (tmp_path / "tests" / "helper.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change a helper the selected run reaches")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
+def test_a_fixture_body_stays_bound_beside_an_unselected_test(tmp_path: Path) -> None:
+    """Which fixtures a run activates is not statically decidable, so fixtures are never dropped."""
+    module = _load_provenance_module()
+    body = (
+        "import pytest\n\n\n@pytest.fixture\ndef support():\n    import tests.helper\n\n    return tests.helper\n\n\n"
+        "def test_selected(support) -> None:\n    assert False\n\n\ndef test_other() -> None:\n    pass\n"
+    )
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "__init__.py").write_text("", encoding="utf-8")
+    (tmp_path / "tests" / "helper.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add helper")
+    (tmp_path / "tests" / "test_proof.py").write_text(body, encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tmp_path / "tests" / "helper.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change a helper the fixture imports")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]

--- a/tests/unit/scripts/test_security_audit_gate.py
+++ b/tests/unit/scripts/test_security_audit_gate.py
@@ -171,3 +171,15 @@ def test_main_allows_only_a_matching_unexpired_reviewed_exception(gate_mod, tmp_
     with patch.object(gate_mod.subprocess, "run", return_value=proc):
         assert gate_mod.main(["--exceptions", str(exceptions_path)]) == 0
     assert "WAIVED" in capsys.readouterr().out
+
+
+def test_load_reviewed_exceptions_reports_undecodable_file(gate_mod, tmp_path: Path) -> None:
+    """An unreadable exception list must fail closed with an error, not abort the gate."""
+    exceptions_path = tmp_path / "exceptions.json"
+    exceptions_path.write_bytes(b'{"exceptions": ["caf\xe9"]}\n')
+
+    approved, errors = gate_mod._load_reviewed_exceptions(exceptions_path)
+
+    assert not approved
+    assert len(errors) == 1
+    assert "could not read vulnerability exception register" in errors[0]

--- a/tests/unit/scripts/test_verify_safe_project_writes.py
+++ b/tests/unit/scripts/test_verify_safe_project_writes.py
@@ -51,3 +51,116 @@ def test_collect_json_io_ignores_shadowed_json_dump_alias() -> None:
     tree = ast.parse('from json import dump as dumper\ndumper = 1\ndef f():\n    dumper(1, open("f","w"))\n')
     offenders = mod._collect_json_io_offenders(tree)
     assert not any(name == "json.dump" for _, name in offenders)
+
+
+def test_collect_json_io_ignores_shadow_from_enclosing_function() -> None:
+    mod = _load_verify_module()
+    source = "import json\ndef outer():\n    json = {}\n    def inner():\n        json.dump(1, None)\n"
+    offenders = mod._collect_json_io_offenders(ast.parse(source))
+    assert not offenders
+
+
+def test_collect_json_io_flags_method_call_under_class_attribute() -> None:
+    mod = _load_verify_module()
+    source = "import json\nclass C:\n    json = None\n    def m(self, path):\n        json.dump({}, path)\n"
+    offenders = mod._collect_json_io_offenders(ast.parse(source))
+    assert any(name == "json.dump" for _, name in offenders)
+
+
+def test_collect_json_io_ignores_class_body_call_on_class_attribute() -> None:
+    mod = _load_verify_module()
+    source = "import json\nclass C:\n    json = None\n    value = json.dump({}, None)\n"
+    offenders = mod._collect_json_io_offenders(ast.parse(source))
+    assert not offenders
+
+
+def test_collect_json_io_flags_call_after_except_alias_unbinds() -> None:
+    mod = _load_verify_module()
+    source = "import json\ntry:\n    pass\nexcept OSError as json:\n    pass\njson.dump({}, None)\n"
+    offenders = mod._collect_json_io_offenders(ast.parse(source))
+    assert any(name == "json.dump" for _, name in offenders)
+
+
+def test_collect_json_io_ignores_call_inside_except_alias_body() -> None:
+    mod = _load_verify_module()
+    source = "import json\ntry:\n    pass\nexcept OSError as json:\n    json.dump({}, None)\n"
+    offenders = mod._collect_json_io_offenders(ast.parse(source))
+    assert not offenders
+
+
+def test_collect_json_io_flags_call_in_function_default() -> None:
+    mod = _load_verify_module()
+    offenders = mod._collect_json_io_offenders(ast.parse("import json\ndef f(x=json.dumps({})):\n    return x\n"))
+    assert any(name == "json.dumps" for _, name in offenders)
+
+
+def test_collect_json_io_flags_call_in_keyword_only_default() -> None:
+    mod = _load_verify_module()
+    source = "import json\ndef f(*, x=json.dumps({})):\n    return x\n"
+    offenders = mod._collect_json_io_offenders(ast.parse(source))
+    assert any(name == "json.dumps" for _, name in offenders)
+
+
+def test_collect_json_io_flags_call_in_decorator() -> None:
+    mod = _load_verify_module()
+    offenders = mod._collect_json_io_offenders(ast.parse("import json\n@json.loads\ndef f():\n    return None\n"))
+    assert any(name == "json.loads" for _, name in offenders)
+
+
+def test_collect_json_io_flags_call_in_decorator_factory() -> None:
+    mod = _load_verify_module()
+    source = 'import json\n@json.loads("{}")\ndef f():\n    return None\n'
+    offenders = mod._collect_json_io_offenders(ast.parse(source))
+    assert any(name == "json.loads" for _, name in offenders)
+
+
+def test_collect_json_io_ignores_shadowed_bare_decorator() -> None:
+    mod = _load_verify_module()
+    source = "import json\njson = None\n@json.loads\ndef f():\n    return None\n"
+    offenders = mod._collect_json_io_offenders(ast.parse(source))
+    assert not offenders
+
+
+def test_collect_json_io_flags_call_in_class_base() -> None:
+    mod = _load_verify_module()
+    offenders = mod._collect_json_io_offenders(ast.parse('import json\nclass C(json.loads("{}")):\n    pass\n'))
+    assert any(name == "json.loads" for _, name in offenders)
+
+
+def test_collect_json_io_flags_call_in_method_default() -> None:
+    mod = _load_verify_module()
+    source = "import json\nclass C:\n    def m(self, x=json.dumps({})):\n        return x\n"
+    offenders = mod._collect_json_io_offenders(ast.parse(source))
+    assert any(name == "json.dumps" for _, name in offenders)
+
+
+def test_collect_json_io_ignores_method_default_under_class_attribute() -> None:
+    mod = _load_verify_module()
+    source = "import json\nclass C:\n    json = None\n    def m(self, x=json.dumps({})):\n        return x\n"
+    offenders = mod._collect_json_io_offenders(ast.parse(source))
+    assert not offenders
+
+
+def test_collect_json_io_flags_evaluated_annotation_call() -> None:
+    mod = _load_verify_module()
+    offenders = mod._collect_json_io_offenders(ast.parse('import json\ndef f(x: json.loads("{}")):\n    return x\n'))
+    assert any(name == "json.loads" for _, name in offenders)
+
+
+def test_collect_json_io_ignores_deferred_annotation_call() -> None:
+    mod = _load_verify_module()
+    source = 'from __future__ import annotations\nimport json\ndef f(x: json.loads("{}")):\n    return x\n'
+    offenders = mod._collect_json_io_offenders(ast.parse(source))
+    assert not offenders
+
+
+def test_collect_json_io_ignores_lambda_parameter_shadow() -> None:
+    mod = _load_verify_module()
+    offenders = mod._collect_json_io_offenders(ast.parse("import json\nf = lambda json: json.dump({}, None)\n"))
+    assert not offenders
+
+
+def test_collect_json_io_flags_call_in_lambda_default() -> None:
+    mod = _load_verify_module()
+    offenders = mod._collect_json_io_offenders(ast.parse("import json\nf = lambda x=json.dumps({}): x\n"))
+    assert any(name == "json.dumps" for _, name in offenders)

--- a/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
+++ b/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
+import re
 import subprocess
+import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -381,3 +385,139 @@ def test_requirements_evidence_workflow_blocks_each_final_verdict(
 
     assert review[review_field] == review_value
     assert terminal_failure in enforce["if"]  # type: ignore[index]
+
+
+def _legacy_ledger_digest(ledger_bytes: bytes, line_count: int) -> str:
+    """Digest the approved ledger prefix exactly as the workflow's inline Python does."""
+    lines = ledger_bytes.splitlines(keepends=True)
+    if len(lines) < line_count:
+        raise ValueError("Approved legacy TDD ledger is incomplete")
+    return f"sha256:{hashlib.sha256(b''.join(lines[:line_count])).hexdigest()}"
+
+
+def _pinned_legacy_ledger_binding() -> tuple[int, str]:
+    """Return the line count and digest the workflow pins, parsed rather than restated."""
+    command = _run_evidence_command()
+    line_count = re.search(r"legacy_tdd_line_count=(\d+)", command)
+    digest = re.search(r'legacy_tdd_ledger_digest="(sha256:[0-9a-f]{64})"', command)
+    assert line_count is not None, "workflow must pin a legacy ledger line count"
+    assert digest is not None, "workflow must pin a legacy ledger digest"
+    return int(line_count.group(1)), digest.group(1)
+
+
+def _committed_legacy_ledger() -> Path:
+    return REPO_ROOT / "openspec" / "changes" / "requirements-07-runtime-proof-delivery" / "TDD_EVIDENCE.md"
+
+
+def test_workflow_legacy_ledger_digest_matches_the_committed_ledger() -> None:
+    """The pinned digest must be recomputed from the ledger, not restated as a constant.
+
+    A prior break appended evidence inside the pinned window without re-pinning; the
+    workflow and its contract test held the same stale constant, so both stayed green while
+    the gate rejected every run.
+    """
+    line_count, pinned_digest = _pinned_legacy_ledger_binding()
+    actual_digest = _legacy_ledger_digest(_committed_legacy_ledger().read_bytes(), line_count)
+    assert actual_digest == pinned_digest, (
+        f"Legacy ledger drifted from its pin: committed prefix digests to {actual_digest}, "
+        f"workflow pins {pinned_digest}. Re-pin legacy_tdd_ledger_digest after editing the "
+        f"first {line_count} lines of TDD_EVIDENCE.md."
+    )
+
+
+def test_workflow_legacy_ledger_line_count_is_within_the_committed_ledger() -> None:
+    """A pin longer than the ledger makes the gate reject the binding as incomplete."""
+    line_count, _ = _pinned_legacy_ledger_binding()
+    committed_lines = len(_committed_legacy_ledger().read_bytes().splitlines(keepends=True))
+    assert line_count <= committed_lines
+
+
+def test_legacy_ledger_digest_detects_an_edit_inside_the_pinned_window() -> None:
+    """Prove the guard is sensitive to the edit shape that broke the gate.
+
+    The regression inserted lines at 1086 of a 1143-line window. An append past the window
+    must stay valid, so both directions are asserted.
+    """
+    ledger = b"".join(f"line {index}\n".encode() for index in range(1, 21))
+    baseline = _legacy_ledger_digest(ledger, 10)
+
+    inside_window = ledger.replace(b"line 5\n", b"line 5\ninserted\n")
+    assert _legacy_ledger_digest(inside_window, 10) != baseline
+
+    past_window = ledger + b"appended evidence\n"
+    assert _legacy_ledger_digest(past_window, 10) == baseline
+
+
+def test_workflow_pinned_plan_digests_match_a_regenerated_plan() -> None:
+    """The pinned mapping and plan digests must match what the module actually emits."""
+    fixture_root_text = os.environ.get("SPECFACT_MODULES_REPO")
+    if fixture_root_text is None or not Path(fixture_root_text).is_dir():
+        pytest.skip("requires the pinned modules fixture")
+    command = _run_evidence_command()
+    pinned = {
+        key: match.group(1)
+        for key in ("legacy_tdd_mapping_digest", "legacy_tdd_plan_digest")
+        if (match := re.search(rf'{key}="(sha256:[0-9a-f]{{64}})"', command)) is not None
+    }
+    assert set(pinned) == {"legacy_tdd_mapping_digest", "legacy_tdd_plan_digest"}
+
+    # The plan selects cases from the diff, so it must be regenerated against the same base
+    # the workflow uses; an empty range emits no plan at all.
+    if (
+        subprocess.run(
+            ["git", "rev-parse", "--verify", "origin/dev"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            check=False,
+        ).returncode
+        != 0
+    ):
+        pytest.skip("requires origin/dev to resolve the workflow's evidence base")
+
+    with tempfile.TemporaryDirectory() as directory:
+        plan_path = Path(directory) / "plan.json"
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "specfact_cli",
+                "requirements",
+                "evidence",
+                "--repo-root",
+                str(REPO_ROOT),
+                "--base-ref",
+                "origin/dev",
+                "--required-maturity",
+                "test-authored",
+                "--review-evidence",
+                str(
+                    REPO_ROOT
+                    / "openspec"
+                    / "changes"
+                    / "requirements-07-runtime-proof-delivery"
+                    / "requirements-proof"
+                    / "review-evidence.json"
+                ),
+                "--plan-output",
+                str(plan_path),
+                "--output",
+                str(Path(directory) / "evidence.json"),
+                "--summary",
+                str(Path(directory) / "evidence.md"),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if not plan_path.is_file():
+            pytest.skip(f"planning did not emit a plan in this environment: {result.stdout[-400:]}")
+        plan = json.loads(plan_path.read_text(encoding="utf-8")).get("plan")
+
+    assert isinstance(plan, dict)
+    assert plan.get("mapping_digest") == pinned["legacy_tdd_mapping_digest"], (
+        "requirements-evidence.yaml changed without re-pinning legacy_tdd_mapping_digest"
+    )
+    assert plan.get("plan_digest") == pinned["legacy_tdd_plan_digest"], (
+        "the emitted plan changed without re-pinning legacy_tdd_plan_digest"
+    )

--- a/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
+++ b/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
@@ -299,7 +299,7 @@ def test_requirements_evidence_workflow_uses_digest_bound_legacy_tdd_ledger_for_
         'selected_change" == "requirements-07-runtime-proof-delivery"',
         "TDD_EVIDENCE.md",
         "legacy_tdd_line_count=1143",
-        'legacy_tdd_ledger_digest="sha256:1df90efd2402f14879da7705ab8afbf054eafc0fa71ff7a788df9f3db97b428c"',
+        'legacy_tdd_ledger_digest="sha256:d6e35c934757c08fd1f3e3071fc02b92b080c009ba5e428f6ea2888e7cd5e8c3"',
         f'legacy_tdd_mapping_digest="{legacy_tdd_mapping_digest}"',
         'legacy_tdd_plan_digest="sha256:27ea6e6bcea0d68d68688b89fc8f89315d213b96918f4f76979484756fd8335e"',
         "read_bytes().splitlines(keepends=True)",

--- a/tools/smart_test_coverage.py
+++ b/tools/smart_test_coverage.py
@@ -119,10 +119,15 @@ class SmartCoverageManager:
         self.config_files = [
             "pyproject.toml",
             "setup.py",
+            "setup.cfg",
             "requirements.txt",
             "requirements-dev.txt",
             ".pre-commit-config.yaml",
+            # Every implicit pytest configuration name, matching pytest's discovery order.
+            "pytest.toml",
+            ".pytest.toml",
             "pytest.ini",
+            ".pytest.ini",
             "tox.ini",
             "conftest.py",
         ]


### PR DESCRIPTION
## Summary

This follow-up fixes the two high-priority provenance findings from release PR #665 on top of its current head:

- include every possible parent `__init__.py` for selected tests and applicable conftests in retained red-proof freshness inputs, including initializers absent at the red commit
- recognize static annotated `pytest_plugins` assignments (`ast.AnnAssign`) as well as ordinary assignments
- add regression coverage, clarify the OpenSpec scenario, and record failing-before/passing-after TDD evidence

## Review findings addressed

1. **[P1] Include package initializers for selector modules** — adding `tests/__init__.py` after red now returns `stale-red-proof`.
2. **[P1] Handle annotated pytest_plugins declarations** — changing a plugin declared with `pytest_plugins: tuple[str, ...] = (...)` after red now returns `stale-red-proof`.

## Validation

- `uv run --python 3.11 --locked --extra dev python -m pytest tests/unit/scripts/test_requirements_proof_provenance.py -q` (33 passed)
- `uv run --python 3.11 --locked --extra dev basedpyright --project pyproject.toml scripts/requirements_proof_provenance.py tests/unit/scripts/test_requirements_proof_provenance.py` (0 errors, 0 warnings)
- `uv run --python 3.11 --locked --extra dev ruff check scripts/requirements_proof_provenance.py tests/unit/scripts/test_requirements_proof_provenance.py`
- `uv run --python 3.11 --locked --extra dev openspec validate requirements-07-runtime-proof-delivery --strict`
- SpecFact changed-scope code review completed with 0 blocking findings; remaining reports are pre-existing, unchanged-scope warnings/info.

Relates to #665.
