### PR TITLE
fix(requirements): traverse package initializer imports

### DIFF
--- a/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/TDD_EVIDENCE.md
@@ -1190,3 +1190,22 @@
 - **Internal wiki follow-up:** the sibling `specfact-cli-internal` checkout was
   unavailable. Update `wiki/sources/requirements-07-runtime-proof-delivery.md`
   and run `python3 scripts/wiki_rebuild_graph.py` from that repository root.
+
+## Codex package-initializer import traversal remediation
+
+- **Recorded:** 2026-08-10 (UTC)
+- **Review finding:** PR #671 identified that retained parent package
+  initializers were proof inputs but were not traversal roots, allowing a
+  repository-local module imported only by an initializer to change after red.
+- **Failing-before command:** `uv run --python 3.11 --locked --extra dev python -m pytest tests/unit/scripts/test_requirements_proof_provenance.py::test_git_bound_red_proof_rejects_changed_initializer_import -q`
+- **Failing result:** the regression failed because changing
+  `tests/support.py`, imported by `tests/__init__.py`, returned no provenance
+  finding.
+- **Passing-after command:** `uv run --python 3.11 --locked --extra dev python -m pytest tests/unit/scripts/test_requirements_proof_provenance.py -q`
+- **Passing result:** all 34 provenance tests passed after package initializer
+  paths became transitive import traversal roots.
+- **Skipped:** 0 tests.
+- **Environment:** Linux, Python 3.11.15, pytest 9.1.1.
+- **Internal wiki follow-up:** the sibling `specfact-cli-internal` checkout was
+  unavailable. Update `wiki/sources/requirements-07-runtime-proof-delivery.md`
+  and run `python3 scripts/wiki_rebuild_graph.py` from that repository root.

--- a/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
+++ b/openspec/changes/requirements-07-runtime-proof-delivery/specs/requirements-runtime-proof-delivery/spec.md
@@ -168,9 +168,9 @@ retain deterministic JUnit results for module-owned reconciliation.
 #### Scenario: Retained proof inputs or output are missing or stale
 
 - **GIVEN** a retained red proof whose selected test, one of its possible parent
-  package initializers, an applicable pytest `conftest.py`, or a statically
-  declared pytest plugin changes after the red source, or an executor run that
-  leaves no non-empty JUnit artifact
+  package initializers or their repository-local imports, an applicable pytest
+  `conftest.py`, or a statically declared pytest plugin changes after the red
+  source, or an executor run that leaves no non-empty JUnit artifact
 - **WHEN** pull-request CI validates or executes the Requirements proof
 - **THEN** the proof remains stale or unproven
 - **AND** the Requirements evidence gate exits nonzero after retaining its

--- a/scripts/requirements_proof_provenance.py
+++ b/scripts/requirements_proof_provenance.py
@@ -425,10 +425,13 @@ def validate_prior_red_proof(red_proof_path: Path, repo_root: Path, *, base_ref:
         ):
             return ["prior-red-proof-invalid"]
         pytest_inputs = {test_path, *_applicable_conftest_paths(test_path)}
+        initializer_inputs = {
+            initializer for path in pytest_inputs for initializer in _parent_package_initializer_paths(path)
+        }
+        traversal_inputs = pytest_inputs | initializer_inputs
         proof_inputs = {
-            *pytest_inputs,
-            *(initializer for path in pytest_inputs for initializer in _parent_package_initializer_paths(path)),
-            *_imported_python_paths(repo_root, source_ref, sorted(pytest_inputs)),
+            *traversal_inputs,
+            *_imported_python_paths(repo_root, source_ref, sorted(traversal_inputs)),
         }
         if not proof_inputs.isdisjoint(paths_after_red):
             return ["stale-red-proof"]

--- a/tests/unit/scripts/test_requirements_proof_provenance.py
+++ b/tests/unit/scripts/test_requirements_proof_provenance.py
@@ -322,6 +322,30 @@ def test_git_bound_red_proof_rejects_changed_parent_package_initializer(tmp_path
     ]
 
 
+def test_git_bound_red_proof_rejects_changed_initializer_import(tmp_path: Path) -> None:
+    """Repository-local imports from package initializers remain bound to red."""
+    module = _load_provenance_module()
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "requirements@example.test")
+    _git(tmp_path, "config", "user.name", "Requirements proof")
+    tests_path = tmp_path / "tests"
+    tests_path.mkdir()
+    (tests_path / "__init__.py").write_text("from tests.support import VALUE\n", encoding="utf-8")
+    (tests_path / "support.py").write_text("VALUE = False\n", encoding="utf-8")
+    base_ref = _commit(tmp_path, "test: add packaged pytest support")
+    (tests_path / "test_proof.py").write_text("def test_selected() -> None: assert False\n", encoding="utf-8")
+    red_ref = _commit(tmp_path, "test: add red proof")
+    red_proof_path = tmp_path / ".git" / "red.json"
+    _write_red_proof(red_proof_path, tmp_path, red_ref, base_ref)
+
+    (tests_path / "support.py").write_text("VALUE = True\n", encoding="utf-8")
+    final_ref = _commit(tmp_path, "fix: change initializer support import")
+
+    assert module.validate_prior_red_proof(red_proof_path, tmp_path, base_ref=base_ref, final_ref=final_ref) == [
+        "stale-red-proof"
+    ]
+
+
 def test_git_bound_red_proof_rejects_added_parent_package_initializer(tmp_path: Path) -> None:
     """A namespace package cannot gain executable initialization after the red run."""
     module = _load_provenance_module()


### PR DESCRIPTION
## Summary

This follow-up addresses the remaining high-priority Codex review finding on PR #671:

- seed retained-proof import traversal with selected tests, applicable conftests, and their possible package initializers
- reject retained red proof when repository-local support imported only by a package initializer changes after red
- add an OpenSpec clarification, focused regression coverage, and failing-before/passing-after TDD evidence

## Validation

- `uv run --python 3.11 --locked --extra dev python -m pytest tests/unit/scripts/test_requirements_proof_provenance.py -q` (34 passed)
- `uv run --python 3.11 --locked --extra dev basedpyright --project pyproject.toml scripts/requirements_proof_provenance.py tests/unit/scripts/test_requirements_proof_provenance.py` (0 errors, 0 warnings)
- `uv run --python 3.11 --locked --extra dev ruff check scripts/requirements_proof_provenance.py tests/unit/scripts/test_requirements_proof_provenance.py`
- `uv run --python 3.11 --locked --extra dev openspec validate requirements-07-runtime-proof-delivery --strict`
- SpecFact changed-scope code review passed with 0 blocking findings; reported warnings are pre-existing and outside the changed lines.

Follow-up to #671.