### PR TITLE
docs(openspec): close release review findings

### DIFF
--- a/openspec/changes/ai-integration-01-agent-skill/proposal.md
+++ b/openspec/changes/ai-integration-01-agent-skill/proposal.md
@@ -32,7 +32,9 @@ SpecFact modules can own focused agent workflows, but users need one core instal
 ## Dependencies
 
 - Retains parent Feature [#372](https://github.com/nold-ai/specfact-cli/issues/372), under Epic [#257](https://github.com/nold-ai/specfact-cli/issues/257).
-- Blocked by the signed modules `preflight-05-implementation-conformance` handoff so the first installed identity includes both preflight and seal-bound implementation-check workflows.
+- Blocked first by core `preflight-05-implementation-conformance` #684, then by
+  the signed modules handoff #434, so the first installed identity includes
+  both preflight and seal-bound implementation-check workflows.
 - Blocks `ai-integration-03-instruction-files` [#253](https://github.com/nold-ai/specfact-cli/issues/253).
 
 ## Explicit Non-Goals

--- a/openspec/changes/ai-integration-01-agent-skill/tasks.md
+++ b/openspec/changes/ai-integration-01-agent-skill/tasks.md
@@ -10,9 +10,21 @@ All tasks below are future implementation work. This rescope completes none of t
 
 ## 2. Specification and failing-first evidence
 
-- [ ] 2.1 Finalize descriptor, discovery, trust, canonical `.agents/skills`, inventory, collision, update, and uninstall deltas without adding workflow content or adapters.
-- [ ] 2.2 Add tests mapped to all discovery/export/idempotency/drift/collision/uninstall scenarios.
-- [ ] 2.3 Run targeted tests before production edits and record failing-first results in a newly created `TDD_EVIDENCE.md`.
+- [ ] 2.1 Finalize descriptor, discovery, trust, canonical `.agents/skills`,
+  inventory, collision, update, and uninstall deltas without adding workflow
+  content or adapters. Include a combined first-installed-identity scenario for
+  the signed #434 handoff that preserves both `specfact-preflight` and the
+  seal-bound implementation-check workflow from #684.
+- [ ] 2.2 Before any Section 3 implementation, add success and failure tests
+  mapped in `requirements-evidence.yaml` to every discovery, export,
+  inventory, idempotency, update, drift, collision, uninstall, trust, integrity,
+  compatibility, digest-mismatch, and unchanged signed-module pass-through
+  scenario, including success and failure coverage for the combined identity
+  and its exact signed provenance, workflow identities, digests, and bytes.
+- [ ] 2.3 After the scenario mapping is complete, run the targeted tests before
+  production edits and record the exact failing-first command, execution
+  timestamp and timezone, failure and test counts, and expected skip reasons in
+  a newly created `TDD_EVIDENCE.md`.
 
 ## 3. Minimal distribution implementation
 
@@ -22,10 +34,31 @@ All tasks below are future implementation work. This rescope completes none of t
 
 ## 4. Passing evidence and quality gates
 
-- [ ] 4.1 Re-run mapped tests and capture passing evidence after implementation.
+- [ ] 4.1 Re-run the mapped tests after implementation and record the matching
+  passing command, execution timestamp and timezone, test counts, and skip
+  reasons in `TDD_EVIDENCE.md`.
 - [ ] 4.2 Run required format, type, lint, contract, smart-test, test, and SpecFact code-review gates; resolve all findings.
 - [ ] 4.3 Run `openspec status --change ai-integration-01-agent-skill --json` and `openspec validate ai-integration-01-agent-skill --strict`.
-- [ ] 4.4 Document canonical export, conflicts, uninstall, and ownership limits using observed behavior.
+- [ ] 4.4 Review README and the published `docs/` areas, update the applicable
+  user guidance for canonical export, conflicts, uninstall, and ownership
+  limits using observed behavior, or record why no user-facing page changes;
+  update frontmatter and navigation if any page is added or moved.
+- [ ] 4.5 Run
+  `hatch run ./scripts/verify-modules-signature.py --require-signature`. If
+  signed module assets changed, apply the required module version bump, run
+  `hatch run python scripts/sign-modules.py --key-file <private-key.pem> <module-package.yaml ...>`,
+  and rerun signature verification until it passes.
+- [ ] 4.6 Apply the release-appropriate semantic version bump, synchronize all
+  canonical version sources, and add the matching changelog entry.
+- [ ] 4.7 After all substantive edits, run
+  `hatch run specfact code review run --scope full --json --out .specfact/code-review.json`,
+  resolve every finding or record an approved exception, and capture this
+  command, its execution timestamp and timezone, finding disposition, and
+  passing result in `TDD_EVIDENCE.md`. Record exact commands, timestamps and
+  timezones, result summaries, and immutable artifact links when CI-generated
+  for Tasks 4.2-4.6 in `TDD_EVIDENCE.md` or the PR description; include actual
+  test counts, skip causes, and manual-proof outcomes when those gates produce
+  them.
 
 ## 5. Delivery and post-merge cleanup
 

--- a/openspec/changes/module-scope-02-preserve-user-installs/TDD_EVIDENCE.md
+++ b/openspec/changes/module-scope-02-preserve-user-installs/TDD_EVIDENCE.md
@@ -4,6 +4,9 @@
 
 - `hatch run pytest tests/unit/registry/test_module_discovery.py::test_project_shadow_warning_is_actionable_and_emitted_once tests/unit/modules/module_registry/test_commands.py::test_doctor_reports_effective_and_shadowed_duplicate_modules -q`
   - Result: FAIL before production edits (`2 failed`).
+  - The original local execution timestamp was not retained; this historical
+    omission is recorded rather than inferred. The authoritative retained CI
+    RED run started at `2026-08-29T20:56:09Z`.
   - Discovery still recommended `specfact module uninstall backlog-core --scope
     user`, and doctor still printed `Recovery: specfact module uninstall
     nold-ai/specfact-codebase --scope user` instead of preservation/no-action
@@ -18,6 +21,9 @@
 
 - `hatch run pytest tests/unit/registry/test_module_discovery.py::test_project_shadow_warning_is_actionable_and_emitted_once tests/unit/modules/module_registry/test_commands.py::test_doctor_reports_effective_and_shadowed_duplicate_modules -q`
   - Result: PASS (`2 passed`).
+  - The original local execution timestamp was not retained; the final
+    exact-head Requirements and orchestrator controls both started at
+    `2026-08-29T22:14:08Z`.
 - `hatch run pytest tests/unit/registry/test_module_discovery.py tests/unit/modules/module_registry/test_commands.py -q`
   - Initial implementation result: PASS (`67 passed`).
   - Discovery precedence, duplicate reporting, doctor output, and explicit uninstall command coverage remain green.
@@ -35,6 +41,7 @@
   source commit `daf05baa9303ef914f5659eafe940146d311af25` executed all three
   mapped selectors using the final reviewed test bytes and produced a bound
   `observed_maturity: red` artifact with no reconciliation findings.
+  The run started at `2026-08-29T21:50:30Z`.
 - Passing focused run after the production edit: PASS (`4 passed`).
 - Related discovery/doctor files after the review fixes: PASS (`69 passed`).
 


### PR DESCRIPTION
## Summary

- records the exact #684 then #434 prerequisite order for the future agent-skill implementation
- schedules complete future inventory/update, release, signature, documentation, and evidence gates
- records retained module-scope CI timestamps without inventing missing local timestamps
- isolates these planning-only updates from the test-authored release finalization in #706

Refs #692
Relates #251 and #699

## Scope

Documentation and OpenSpec planning only. No production code, tests, workflow, dependency, registry, version, or security-policy bytes change.

## Verification

- `hatch run openspec validate --all --strict`: 176 passed, 0 failed
- `git diff --check`: passed
- mandatory staged pre-commit hooks: passed, including Requirements Evidence at planned maturity

## Rollback

Revert this PR merge. No published artifact or runtime behavior is affected.