### PR TITLE
fix(ci): isolate tests from pull-request routing state

### DIFF
--- a/.github/workflows/pr-orchestrator.yml
+++ b/.github/workflows/pr-orchestrator.yml
@@ -366,6 +366,7 @@ jobs:
           PYTEST_ADDOPTS: "-r fEw"
         run: |
           echo "🧪 Running full test suite (direct smart-test-full, Python 3.12)..."
+          unset GITHUB_BASE_REF
           python tools/smart_test_coverage.py run --level full
 
       - name: Generate coverage XML for quality gates
@@ -431,10 +432,12 @@ jobs:
       - name: Set up frozen compatibility dependencies
         uses: ./.github/actions/setup-frozen-python
       - name: Run Python 3.11 compatibility tests
+        shell: bash
         run: |
           echo "🔁 Python 3.11 compatibility checks"
           mkdir -p logs/compat-py311
           COMPAT_LOG="logs/compat-py311/compat_$(date -u +%Y%m%d_%H%M%S).log"
+          unset GITHUB_BASE_REF
           {
             python -m pytest -r fEw tests/unit tests/integration
             python -m coverage xml -o logs/compat-py311/coverage.xml || true

--- a/openspec/changes/fix-ci-test-environment-isolation/.openspec.yaml
+++ b/openspec/changes/fix-ci-test-environment-isolation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/fix-ci-test-environment-isolation/CHANGE_VALIDATION.md
+++ b/openspec/changes/fix-ci-test-environment-isolation/CHANGE_VALIDATION.md
@@ -34,3 +34,11 @@
 - Focused passing-after evidence: pending
 - Full quality/security/release gates: pending
 - Independent review: pending
+
+## Code-review disposition
+
+- `banned-generic-public-names` on the three mapped pytest selectors is a false
+  positive. The functions are tests rather than public APIs, and “test process”
+  names the exact isolation boundary in the approved mapping and specification.
+  Renaming them would invalidate the accepted mapping without improving the
+  production interface.

--- a/openspec/changes/fix-ci-test-environment-isolation/CHANGE_VALIDATION.md
+++ b/openspec/changes/fix-ci-test-environment-isolation/CHANGE_VALIDATION.md
@@ -30,8 +30,10 @@
 
 - Strict OpenSpec validation: passed (`openspec validate
   fix-ci-test-environment-isolation --strict`)
-- Focused failing-before evidence: pending
-- Focused passing-after evidence: pending
+- Focused failing-before evidence: passed (`3 failed` as expected locally and
+  in GitHub run `33910361233`)
+- Focused passing-after evidence: passed (`5 passed`, starting from inherited
+  `GITHUB_BASE_REF=main` and crossing the exact Bash removal boundary)
 - Full quality/security/release gates: pending
 - Independent review: pending
 

--- a/openspec/changes/fix-ci-test-environment-isolation/CHANGE_VALIDATION.md
+++ b/openspec/changes/fix-ci-test-environment-isolation/CHANGE_VALIDATION.md
@@ -16,6 +16,9 @@
 
 - The production version checker must retain its existing GitHub base-reference
   behavior.
+- GitHub's Variables reference confirms default `GITHUB_*` variables cannot be
+  overridden through workflow `env`; the design therefore uses shell-level
+  removal inside only the two test steps.
 - PR #706 intentionally removes the test-helper workaround and contains no test
   or workflow diff.
 - The existing R08 bounded replay design remains the long-term proof-model

--- a/openspec/changes/fix-ci-test-environment-isolation/CHANGE_VALIDATION.md
+++ b/openspec/changes/fix-ci-test-environment-isolation/CHANGE_VALIDATION.md
@@ -1,0 +1,33 @@
+# Change Validation
+
+## Repository and issue reality
+
+- Validation date: 2026-09-04 Europe/Berlin
+- Baseline: `origin/dev` at
+  `6486fd4b654f4897dbf4ecbbe1eca1e50ea19fbf`
+- Issue: nold-ai/specfact-cli#708, open and assigned to `djm81`
+- Parent: #692
+- Labels: `bug`, `openspec`, `QA`, `security`
+- Project: SpecFact CLI, status `In Progress`
+- Duplicate search: no open issue or active change covers step-scoped removal of
+  pull-request routing state from CI test processes.
+
+## Scope and dependency validation
+
+- The production version checker must retain its existing GitHub base-reference
+  behavior.
+- PR #706 intentionally removes the test-helper workaround and contains no test
+  or workflow diff.
+- The existing R08 bounded replay design remains the long-term proof-model
+  replacement and is not duplicated or modified by this change.
+- The existing `0.55.4` version and release notes already own this unreleased
+  patch transaction; another version bump would be incorrect.
+
+## Verification status
+
+- Strict OpenSpec validation: passed (`openspec validate
+  fix-ci-test-environment-isolation --strict`)
+- Focused failing-before evidence: pending
+- Focused passing-after evidence: pending
+- Full quality/security/release gates: pending
+- Independent review: pending

--- a/openspec/changes/fix-ci-test-environment-isolation/README.md
+++ b/openspec/changes/fix-ci-test-environment-isolation/README.md
@@ -1,0 +1,3 @@
+# Fix CI test environment isolation
+
+Issue-linked OpenSpec change for nold-ai/specfact-cli#708.

--- a/openspec/changes/fix-ci-test-environment-isolation/TDD_EVIDENCE.md
+++ b/openspec/changes/fix-ci-test-environment-isolation/TDD_EVIDENCE.md
@@ -18,7 +18,28 @@
 - Evidence: neither run block unsets the inherited value, the compatibility
   step does not declare Bash explicitly, and the negative control found no
   bounded removals.
+- GitHub retained RED proof:
+  - Run: `33910361233`
+  - Artifact: `9951113546` (`requirements-evidence`)
+  - Commit: `597edd1d3c07b3979c03eede1926d75785f8d16e`
+  - Tree: `d74d2d7b49556a761e6f3e1ce7ba8819613e68a8`
+  - JUnit SHA-256:
+    `bfceda1f946b3533649a78547fb37d750088449264fc2c2df6e7e168800ba566`
+  - Result: exactly three mapped failures; lifecycle maturity `red` with no
+    provenance findings.
 
 ## Passing After
 
-Pending implementation.
+- Timestamp: `2026-09-04T19:19:19Z`
+- Environment: macOS, Python 3.12.13, pytest 9.1.1; outer process started with
+  `GITHUB_BASE_REF=main`, then the same Bash `unset GITHUB_BASE_REF` boundary
+  used by CI executed before pytest.
+- Scope: the three mapped workflow selectors plus
+  `test_check_version_sources_reuses_branch_release_for_dependency_follow_up`
+  and
+  `test_check_version_sources_rejects_staged_changelog_deletion_during_follow_up`.
+- Result: `5 passed in 1.11s`.
+- Evidence: both test launchers require the shell-level removal, the negative
+  control permits it at exactly those two steps, and both original
+  version-source regressions pass without changing their helper or production
+  version logic.

--- a/openspec/changes/fix-ci-test-environment-isolation/TDD_EVIDENCE.md
+++ b/openspec/changes/fix-ci-test-environment-isolation/TDD_EVIDENCE.md
@@ -2,7 +2,22 @@
 
 ## Failing Before
 
-Pending test-authoring commit and focused failing execution.
+- Timestamp: `2026-09-04T19:15:33Z`
+- Environment: macOS, Python 3.12.13, pytest 9.1.1, inherited
+  `GITHUB_BASE_REF=main`
+- Command:
+
+  ```text
+  python -m pytest -q \
+    tests/unit/workflows/test_trustworthy_green_checks.py::test_primary_test_process_does_not_inherit_github_base_ref \
+    tests/unit/workflows/test_trustworthy_green_checks.py::test_compatibility_test_process_does_not_inherit_github_base_ref \
+    tests/unit/workflows/test_trustworthy_green_checks.py::test_only_test_processes_override_github_base_ref
+  ```
+
+- Result: expected failure, `3 failed`.
+- Evidence: neither run block unsets the inherited value, the compatibility
+  step does not declare Bash explicitly, and the negative control found no
+  bounded removals.
 
 ## Passing After
 

--- a/openspec/changes/fix-ci-test-environment-isolation/TDD_EVIDENCE.md
+++ b/openspec/changes/fix-ci-test-environment-isolation/TDD_EVIDENCE.md
@@ -1,0 +1,9 @@
+# TDD Evidence
+
+## Failing Before
+
+Pending test-authoring commit and focused failing execution.
+
+## Passing After
+
+Pending implementation.

--- a/openspec/changes/fix-ci-test-environment-isolation/design.md
+++ b/openspec/changes/fix-ci-test-environment-isolation/design.md
@@ -2,15 +2,19 @@
 
 ## Decision
 
-Override `GITHUB_BASE_REF` with an empty value only in the two workflow steps
-that execute the primary Python 3.12 suite and the Python 3.11 compatibility
-suite. `check_version_sources.py` already treats an empty value as absent, so
-synthetic repositories use their own Git history without changing production
-logic or test helpers.
+Run `unset GITHUB_BASE_REF` inside only the two Bash workflow steps that execute
+the primary Python 3.12 suite and the Python 3.11 compatibility suite, before
+either Python launcher starts. Synthetic repositories then use their own Git
+history without changing production logic or test helpers.
 
-The override is step-scoped rather than job-scoped. Setup, signature checks,
-change detection, release validation, and any later workflow routing continue
-to see GitHub's authentic base reference.
+A workflow `env` override is not sufficient: GitHub documents that assignments
+to default `GITHUB_*` variables are ignored. The shell-level removal therefore
+defines the effective process boundary. Both affected steps declare Bash
+explicitly.
+
+The removal is shell- and step-scoped rather than job-scoped. Setup, signature
+checks, change detection, release validation, and any later workflow routing
+continue to see GitHub's authentic base reference.
 
 ## Alternatives
 
@@ -29,8 +33,10 @@ to see GitHub's authentic base reference.
 
 The workflow continues to use the trusted GitHub base reference outside the
 two test steps. No secret, token, dependency, cache, checkout, or permission
-surface changes. Setting the variable to an empty string is portable across the
-existing Ubuntu runners and both supported Python lanes.
+surface changes. Bash `unset` is portable across the existing Ubuntu runners
+and both supported Python lanes.
+
+Primary reference: <https://docs.github.com/en/actions/reference/workflows-and-actions/variables>.
 
 ## Rollback
 

--- a/openspec/changes/fix-ci-test-environment-isolation/design.md
+++ b/openspec/changes/fix-ci-test-environment-isolation/design.md
@@ -1,0 +1,38 @@
+# Design: CI test environment isolation
+
+## Decision
+
+Override `GITHUB_BASE_REF` with an empty value only in the two workflow steps
+that execute the primary Python 3.12 suite and the Python 3.11 compatibility
+suite. `check_version_sources.py` already treats an empty value as absent, so
+synthetic repositories use their own Git history without changing production
+logic or test helpers.
+
+The override is step-scoped rather than job-scoped. Setup, signature checks,
+change detection, release validation, and any later workflow routing continue
+to see GitHub's authentic base reference.
+
+## Alternatives
+
+- Updating `_run_version_check` was rejected because it teaches one test helper
+  about CI routing and cannot be represented safely by the current retained-RED
+  freshness model when the helper and selected tests share a file.
+- Changing `check_version_sources.py` was rejected because the production gate
+  must continue using `GITHUB_BASE_REF` in real pull-request execution.
+- A repository-wide automatic pytest fixture was rejected because it would
+  silently change every local test and could interfere with tests that
+  deliberately exercise GitHub environment handling.
+- A generic Requirements freshness exception was rejected because it would
+  weaken provenance rather than fix the environmental boundary.
+
+## Security and compatibility
+
+The workflow continues to use the trusted GitHub base reference outside the
+two test steps. No secret, token, dependency, cache, checkout, or permission
+surface changes. Setting the variable to an empty string is portable across the
+existing Ubuntu runners and both supported Python lanes.
+
+## Rollback
+
+Revert the workflow and test commit. No data migration, published artifact
+rewrite, or dependency rollback is required.

--- a/openspec/changes/fix-ci-test-environment-isolation/proposal.md
+++ b/openspec/changes/fix-ci-test-environment-isolation/proposal.md
@@ -1,0 +1,51 @@
+# Change: Isolate CI tests from pull-request routing state
+
+## Why
+
+GitHub Actions exposes `GITHUB_BASE_REF` to pull-request jobs so workflows can
+select the correct comparison branch. The Python 3.12 and Python 3.11 test
+suites currently pass that routing variable into every test process. Tests that
+create synthetic Git repositories can therefore observe the outer pull request
+instead of their fixture history and fail for reasons unrelated to the behavior
+under test.
+
+The correction belongs at the test-process boundary. Test helpers should not
+each need to know which GitHub routing variables exist, while release,
+signature, diff-selection, and other workflow steps must retain the genuine
+pull-request base.
+
+## What Changes
+
+- Remove the effective `GITHUB_BASE_REF` value only from the primary and
+  compatibility pytest executions in the pull-request orchestrator.
+- Preserve the normal GitHub-provided value for all non-test workflow steps.
+- Add workflow regression coverage proving both boundaries.
+- Keep the version-source production check and its test helpers unchanged.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `test-suite-stabilization`
+
+## Impact
+
+- Affected workflow: `.github/workflows/pr-orchestrator.yml`.
+- Affected tests: focused workflow contract coverage only.
+- Public CLI, API, dependency graph, module payload, and package behavior are
+  unchanged.
+- No user documentation changes are needed because this is internal CI
+  isolation. Contributor-facing evidence stays in this OpenSpec change and its
+  pull request.
+- This fix joins the existing unreleased `0.55.4` transaction; it must not
+  consume another package version.
+- Rollback is a normal revert of the workflow commit.
+
+## Source Tracking
+
+- **GitHub Issue**: #708
+- **Issue URL**: <https://github.com/nold-ai/specfact-cli/issues/708>
+- **Repository**: nold-ai/specfact-cli
+- **Last Synced Status**: in progress
+- **Parent Issue**: #692
+- **Related Long-Term Design**: #675 / `requirements-08-bounded-red-green-proof`

--- a/openspec/changes/fix-ci-test-environment-isolation/proposal.md
+++ b/openspec/changes/fix-ci-test-environment-isolation/proposal.md
@@ -16,8 +16,8 @@ pull-request base.
 
 ## What Changes
 
-- Remove the effective `GITHUB_BASE_REF` value only from the primary and
-  compatibility pytest executions in the pull-request orchestrator.
+- Remove `GITHUB_BASE_REF` inside only the primary and compatibility Bash test
+  steps, immediately before their Python launchers execute.
 - Preserve the normal GitHub-provided value for all non-test workflow steps.
 - Add workflow regression coverage proving both boundaries.
 - Keep the version-source production check and its test helpers unchanged.

--- a/openspec/changes/fix-ci-test-environment-isolation/requirements-evidence.yaml
+++ b/openspec/changes/fix-ci-test-environment-isolation/requirements-evidence.yaml
@@ -16,11 +16,14 @@ requirements:
     verification_cases:
       - case_id: CI-ENV-001
         scenario_id: primary-test-suite-ignores-the-outer-pull-request-base
-        method: inspection
+        method: test
         intent: "Inspect the planned step-scoped isolation boundary for the primary test suite."
         observable: >-
           The specification requires the primary pytest process to receive no
           effective GITHUB_BASE_REF while non-test workflow behavior retains it.
+        selector:
+          runner: pytest
+          node_id: tests/unit/workflows/test_trustworthy_green_checks.py::test_primary_test_process_does_not_inherit_github_base_ref
   openspec:fix-ci-test-environment-isolation:test-suite-stabilization:compatibility-suite-ignores-the-outer-pull-request-base:
     rationale: >-
       The supported compatibility lane must exercise the same isolated test
@@ -37,11 +40,14 @@ requirements:
     verification_cases:
       - case_id: CI-ENV-002
         scenario_id: compatibility-suite-ignores-the-outer-pull-request-base
-        method: inspection
+        method: test
         intent: "Inspect the planned step-scoped isolation boundary for the compatibility suite."
         observable: >-
           The specification requires the Python 3.11 pytest process to receive
           no effective GITHUB_BASE_REF.
+        selector:
+          runner: pytest
+          node_id: tests/unit/workflows/test_trustworthy_green_checks.py::test_compatibility_test_process_does_not_inherit_github_base_ref
   openspec:fix-ci-test-environment-isolation:test-suite-stabilization:non-test-workflow-routing-remains-unchanged:
     rationale: >-
       Test isolation must not erase the pull-request base from control-plane
@@ -58,8 +64,11 @@ requirements:
     verification_cases:
       - case_id: CI-ENV-003
         scenario_id: non-test-workflow-routing-remains-unchanged
-        method: inspection
+        method: test
         intent: "Inspect the planned negative control for non-test workflow routing."
         observable: >-
           The specification preserves GitHub's authentic base reference for
           release, signature, change-selection, and other non-test steps.
+        selector:
+          runner: pytest
+          node_id: tests/unit/workflows/test_trustworthy_green_checks.py::test_only_test_processes_override_github_base_ref

--- a/openspec/changes/fix-ci-test-environment-isolation/requirements-evidence.yaml
+++ b/openspec/changes/fix-ci-test-environment-isolation/requirements-evidence.yaml
@@ -1,0 +1,65 @@
+schema_version: "2"
+requirements:
+  openspec:fix-ci-test-environment-isolation:test-suite-stabilization:primary-test-suite-ignores-the-outer-pull-request-base:
+    rationale: >-
+      Pull-request routing state must remain available to workflow control logic
+      without leaking into tests that create and inspect synthetic repositories.
+    stakeholder_refs:
+      - "nold-ai/specfact-cli#708"
+    touchpoints:
+      - id: pull-request-orchestrator
+        kind: ci_workflow
+        locator: ".github/workflows/pr-orchestrator.yml"
+      - id: workflow-contract-tests
+        kind: test_file
+        locator: "tests/unit/workflows/test_trustworthy_green_checks.py"
+    verification_cases:
+      - case_id: CI-ENV-001
+        scenario_id: primary-test-suite-ignores-the-outer-pull-request-base
+        method: inspection
+        intent: "Inspect the planned step-scoped isolation boundary for the primary test suite."
+        observable: >-
+          The specification requires the primary pytest process to receive no
+          effective GITHUB_BASE_REF while non-test workflow behavior retains it.
+  openspec:fix-ci-test-environment-isolation:test-suite-stabilization:compatibility-suite-ignores-the-outer-pull-request-base:
+    rationale: >-
+      The supported compatibility lane must exercise the same isolated test
+      boundary as the primary lane.
+    stakeholder_refs:
+      - "nold-ai/specfact-cli#708"
+    touchpoints:
+      - id: pull-request-orchestrator
+        kind: ci_workflow
+        locator: ".github/workflows/pr-orchestrator.yml"
+      - id: workflow-contract-tests
+        kind: test_file
+        locator: "tests/unit/workflows/test_trustworthy_green_checks.py"
+    verification_cases:
+      - case_id: CI-ENV-002
+        scenario_id: compatibility-suite-ignores-the-outer-pull-request-base
+        method: inspection
+        intent: "Inspect the planned step-scoped isolation boundary for the compatibility suite."
+        observable: >-
+          The specification requires the Python 3.11 pytest process to receive
+          no effective GITHUB_BASE_REF.
+  openspec:fix-ci-test-environment-isolation:test-suite-stabilization:non-test-workflow-routing-remains-unchanged:
+    rationale: >-
+      Test isolation must not erase the pull-request base from control-plane
+      logic that legitimately uses it.
+    stakeholder_refs:
+      - "nold-ai/specfact-cli#708"
+    touchpoints:
+      - id: pull-request-orchestrator
+        kind: ci_workflow
+        locator: ".github/workflows/pr-orchestrator.yml"
+      - id: workflow-contract-tests
+        kind: test_file
+        locator: "tests/unit/workflows/test_trustworthy_green_checks.py"
+    verification_cases:
+      - case_id: CI-ENV-003
+        scenario_id: non-test-workflow-routing-remains-unchanged
+        method: inspection
+        intent: "Inspect the planned negative control for non-test workflow routing."
+        observable: >-
+          The specification preserves GitHub's authentic base reference for
+          release, signature, change-selection, and other non-test steps.

--- a/openspec/changes/fix-ci-test-environment-isolation/requirements-proof/review-evidence.json
+++ b/openspec/changes/fix-ci-test-environment-isolation/requirements-proof/review-evidence.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "1",
+  "decision": "accepted",
+  "reviewer_id": "djm81",
+  "reviewer_role": "MEMBER",
+  "recorded_at": "2026-09-04T18:32:26Z",
+  "reference": "https://github.com/nold-ai/specfact-cli/issues/708#issuecomment-5544883208",
+  "mapping_digest": "sha256:b262683c8db0bca9e962cb686cc5673a1535281cc044db07c364089138961d9f"
+}

--- a/openspec/changes/fix-ci-test-environment-isolation/specs/test-suite-stabilization/spec.md
+++ b/openspec/changes/fix-ci-test-environment-isolation/specs/test-suite-stabilization/spec.md
@@ -1,0 +1,39 @@
+# test-suite-stabilization Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Primary test suite ignores the outer pull-request base
+
+The pull-request orchestrator SHALL prevent its primary test process from
+receiving an effective `GITHUB_BASE_REF` value.
+
+#### Scenario: Primary test suite ignores the outer pull-request base
+
+- **GIVEN** a pull-request job with a GitHub-provided base reference
+- **WHEN** the Python 3.12 test suite executes
+- **THEN** its test process receives no effective `GITHUB_BASE_REF` value
+- **AND** tests that create synthetic Git repositories resolve only their own
+  fixture history.
+
+### Requirement: Compatibility suite ignores the outer pull-request base
+
+The pull-request orchestrator SHALL prevent its Python 3.11 compatibility test
+process from receiving an effective `GITHUB_BASE_REF` value.
+
+#### Scenario: Compatibility suite ignores the outer pull-request base
+
+- **GIVEN** a pull-request job with a GitHub-provided base reference
+- **WHEN** the Python 3.11 compatibility suite executes
+- **THEN** its pytest process receives no effective `GITHUB_BASE_REF` value.
+
+### Requirement: Non-test workflow routing remains unchanged
+
+The pull-request orchestrator SHALL preserve GitHub's authentic base-reference
+value for non-test workflow behavior.
+
+#### Scenario: Non-test workflow routing remains unchanged
+
+- **GIVEN** release, signature, change-selection, and other non-test workflow
+  steps
+- **WHEN** they evaluate the pull-request base
+- **THEN** they retain the authentic GitHub-provided `GITHUB_BASE_REF` value.

--- a/openspec/changes/fix-ci-test-environment-isolation/tasks.md
+++ b/openspec/changes/fix-ci-test-environment-isolation/tasks.md
@@ -11,11 +11,11 @@
 
 ## 2. Tests and failing evidence
 
-- [ ] 2.1 Add exact workflow tests for the Python 3.12 and Python 3.11 pytest
+- [x] 2.1 Add exact workflow tests for the Python 3.12 and Python 3.11 pytest
   steps plus a negative control proving non-test routing remains unchanged.
-- [ ] 2.2 Map the scenarios to exact pytest selectors in
+- [x] 2.2 Map the scenarios to exact pytest selectors in
   `requirements-evidence.yaml` and obtain the required mapping acceptance.
-- [ ] 2.3 Run the focused selectors before workflow edits and record the exact
+- [x] 2.3 Run the focused selectors before workflow edits and record the exact
   failing result, timestamp, environment, and expected assertions in
   `TDD_EVIDENCE.md`.
 

--- a/openspec/changes/fix-ci-test-environment-isolation/tasks.md
+++ b/openspec/changes/fix-ci-test-environment-isolation/tasks.md
@@ -21,14 +21,14 @@
 
 ## 3. Minimal implementation
 
-- [ ] 3.1 Isolate `GITHUB_BASE_REF` only on the two test-execution steps in
+- [x] 3.1 Isolate `GITHUB_BASE_REF` only on the two test-execution steps in
   `.github/workflows/pr-orchestrator.yml`.
-- [ ] 3.2 Preserve the variable for all non-test workflow steps and avoid any
+- [x] 3.2 Preserve the variable for all non-test workflow steps and avoid any
   production-script or test-helper change.
 
 ## 4. Passing evidence and quality gates
 
-- [ ] 4.1 Re-run the focused selectors and the original two version-source
+- [x] 4.1 Re-run the focused selectors and the original two version-source
   follow-up regressions with passing evidence.
 - [ ] 4.2 Run workflow lint, YAML lint, format, lint, type-check, contract gates,
   smart tests, strict OpenSpec validation, module-signature verification,

--- a/openspec/changes/fix-ci-test-environment-isolation/tasks.md
+++ b/openspec/changes/fix-ci-test-environment-isolation/tasks.md
@@ -1,0 +1,52 @@
+# Tasks: Fix CI test environment isolation
+
+## 1. Readiness and specification
+
+- [x] 1.1 Create `bugfix/708-ci-test-env-isolation` in an isolated worktree from
+  freshly fetched `origin/dev` before implementation edits.
+- [x] 1.2 Verify issue #708 is open, assigned, labeled, in the SpecFact CLI
+  project, and linked under #692; check for duplicate issues and changes.
+- [x] 1.3 Define the step-scoped isolation behavior and rejected alternatives.
+- [x] 1.4 Validate this OpenSpec change strictly before authoring tests.
+
+## 2. Tests and failing evidence
+
+- [ ] 2.1 Add exact workflow tests for the Python 3.12 and Python 3.11 pytest
+  steps plus a negative control proving non-test routing remains unchanged.
+- [ ] 2.2 Map the scenarios to exact pytest selectors in
+  `requirements-evidence.yaml` and obtain the required mapping acceptance.
+- [ ] 2.3 Run the focused selectors before workflow edits and record the exact
+  failing result, timestamp, environment, and expected assertions in
+  `TDD_EVIDENCE.md`.
+
+## 3. Minimal implementation
+
+- [ ] 3.1 Isolate `GITHUB_BASE_REF` only on the two test-execution steps in
+  `.github/workflows/pr-orchestrator.yml`.
+- [ ] 3.2 Preserve the variable for all non-test workflow steps and avoid any
+  production-script or test-helper change.
+
+## 4. Passing evidence and quality gates
+
+- [ ] 4.1 Re-run the focused selectors and the original two version-source
+  follow-up regressions with passing evidence.
+- [ ] 4.2 Run workflow lint, YAML lint, format, lint, type-check, contract gates,
+  smart tests, strict OpenSpec validation, module-signature verification,
+  Requirements evidence, and SpecFact code review; resolve every finding or
+  document an explicitly approved exception.
+- [ ] 4.3 Confirm PR #691's Python 3.11 and Python 3.12 failures no longer
+  reproduce after the fix reaches `dev`.
+
+## 5. Documentation, release, and delivery
+
+- [ ] 5.1 Review README and published `docs/`; record that no user-facing page
+  changes because only internal CI test isolation changes.
+- [ ] 5.2 Keep the existing unreleased `0.55.4` version and changelog transaction
+  unchanged; do not create `0.55.5` for this release-blocking follow-up.
+- [ ] 5.3 Update the internal wiki source and rebuild its graph without changing
+  internal wiki PR #38 or its planning branch.
+- [ ] 5.4 Open the issue-linked PR to `dev` only after the required local gates
+  pass; resolve all review threads and merge only under normal policy.
+- [ ] 5.5 After merge, archive this change with `openspec archive
+  fix-ci-test-environment-isolation`, validate the resulting canonical spec,
+  and remove the dedicated worktree and merged branch.

--- a/tests/unit/workflows/test_trustworthy_green_checks.py
+++ b/tests/unit/workflows/test_trustworthy_green_checks.py
@@ -108,6 +108,20 @@ def _assert_condition_contains(value: object, expected: str, *, context: str) ->
     assert expected in normalized, f"{context}; got {value!r}"
 
 
+def _assert_unsets_github_base_ref_before(step: dict[str, Any], command_fragment: str) -> None:
+    run_clause = step.get("run")
+    assert isinstance(run_clause, str), "Test step must define a shell run block"
+    lines = [line.strip() for line in run_clause.splitlines()]
+    assert lines.count("unset GITHUB_BASE_REF") == 1
+    unset_index = lines.index("unset GITHUB_BASE_REF")
+    command_index = next(
+        (index for index, line in enumerate(lines) if command_fragment in line),
+        None,
+    )
+    assert command_index is not None, f"Expected test launcher containing {command_fragment!r}"
+    assert unset_index < command_index, "GITHUB_BASE_REF must be unset before the test launcher"
+
+
 def test_pr_orchestrator_pypi_version_check_gated_on_version_sources() -> None:
     """PyPI-ahead must not run on every code PR; gate matches pre-commit staged version files."""
     pypi_step = _find_named_step("tests", "Verify local version is ahead of PyPI")
@@ -145,6 +159,50 @@ def test_pr_orchestrator_version_sync_uses_base_sha_on_clean_ci_checkout() -> No
     assert "github.event.before" in run_clause, (
         "Version-source sync step must compare against the push 'before' SHA when applicable"
     )
+
+
+def test_primary_test_process_does_not_inherit_github_base_ref() -> None:
+    """The primary pytest launcher must not inherit pull-request routing state."""
+    step = _find_named_step("tests", "Run full test suite (direct smart-test-full)")
+    _assert_unsets_github_base_ref_before(step, "python tools/smart_test_coverage.py")
+
+
+def test_compatibility_test_process_does_not_inherit_github_base_ref() -> None:
+    """The Python 3.11 pytest launcher must not inherit pull-request routing state."""
+    step = _find_named_step("compat-py311", "Run Python 3.11 compatibility tests")
+    assert step.get("shell") == "bash", "Compatibility test isolation requires an explicit Bash shell"
+    _assert_unsets_github_base_ref_before(step, "python -m pytest")
+
+
+def test_only_test_processes_override_github_base_ref() -> None:
+    """Only the two test run blocks may remove GitHub's authentic base reference."""
+    workflow = _load_yaml(PR_ORCHESTRATOR)
+    workflow_environment = workflow.get("env")
+    assert not (isinstance(workflow_environment, dict) and "GITHUB_BASE_REF" in workflow_environment), (
+        "Workflow-level GITHUB_BASE_REF overrides are forbidden"
+    )
+
+    clearers: set[tuple[str, str]] = set()
+    for job_name, job in _load_jobs().items():
+        job_environment = job.get("env")
+        assert not (isinstance(job_environment, dict) and "GITHUB_BASE_REF" in job_environment), (
+            f"Job {job_name!r} must retain GitHub's authentic base reference"
+        )
+        for step in _load_job_steps(job_name):
+            step_environment = step.get("env")
+            assert not (isinstance(step_environment, dict) and "GITHUB_BASE_REF" in step_environment), (
+                "Reserved GitHub variables cannot be overridden through workflow env"
+            )
+            run_clause = step.get("run")
+            if isinstance(run_clause, str) and "unset GITHUB_BASE_REF" in {
+                line.strip() for line in run_clause.splitlines()
+            }:
+                clearers.add((job_name, str(step.get("name", ""))))
+
+    assert clearers == {
+        ("tests", "Run full test suite (direct smart-test-full)"),
+        ("compat-py311", "Run Python 3.11 compatibility tests"),
+    }
 
 
 def test_pr_orchestrator_required_checks_trigger_on_every_pr_head_commit() -> None:


### PR DESCRIPTION
## Summary

- isolate only the Python 3.12 and Python 3.11 pytest launchers from inherited pull-request routing state
- remove `GITHUB_BASE_REF` inside the two exact Bash test-process boundaries
- preserve GitHub base-reference state for every non-test workflow step and job
- keep production version checks, dependency pins, package version, and test helpers unchanged

Closes #708

## TDD and authority evidence

- approved test-authored mapping: `sha256:b262683c8db0bca9e962cb686cc5673a1535281cc044db07c364089138961d9f`
- approval: https://github.com/nold-ai/specfact-cli/issues/708#issuecomment-5544883208
- corrected design commit: `2257e277`
- signed RED commit: `597edd1d3c07b3979c03eede1926d75785f8d16e`
- RED Requirements run: https://github.com/nold-ai/specfact-cli/actions/runs/33910361233
- RED artifact: `9951113546`
- RED JUnit SHA-256: `bfceda1f946b3533649a78547fb37d750088449264fc2c2df6e7e168800ba566`
- signed GREEN commit: `da04046000d79376d0d07e34cd2e81bc823cf044`
- GREEN Requirements run: https://github.com/nold-ai/specfact-cli/actions/runs/33910681345

## Verification

- focused regression and controls with inherited `GITHUB_BASE_REF=main`, then the exact Bash unset boundary: 5 passed
- touched workflow test file: 56 passed
- touched version-source test file: 12 passed
- local full suite: 3,115 passed, 9 skipped; one environment-only sandbox failure writing `~/.specfact/metadata.json.tmp`
- authoritative GitHub PR Orchestrator run: https://github.com/nold-ai/specfact-cli/actions/runs/33910681331
- Python 3.12, Python 3.11, Quality Gates, pip-audit, Socket, static analysis, type checking, workflow lint, module signatures, reproducible delivery, and all runtime matrices: passed

## Review disposition

The generic-name warnings on the three approved selector names are false positives: these are pytest selectors rather than public APIs, and the phrase test process is the exact specification and approved mapping term. Renaming would invalidate the accepted mapping without changing behavior.

## Scope and rollback

This joins the unreleased 0.55.4 security patch transaction. It changes no dependency, package version, public CLI/API, module payload, release signature, or release-routing gate.

Rollback is the normal PR revert. No data migration or published-history rewrite is involved.
