### PR TITLE
fix(ci): handle final review artifacts without Python targets

### DIFF
--- a/openspec/changes/fix-final-requirements-review-artifact/.openspec.yaml
+++ b/openspec/changes/fix-final-requirements-review-artifact/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/fix-final-requirements-review-artifact/CHANGE_VALIDATION.md
+++ b/openspec/changes/fix-final-requirements-review-artifact/CHANGE_VALIDATION.md
@@ -27,7 +27,10 @@
 
 - Strict OpenSpec validation: passed (`openspec validate
   fix-final-requirements-review-artifact --strict`)
-- Focused failing-before evidence: pending
+- Focused failing-before evidence: passed as an expected RED (`3 failed`)
+- Test-authored mapping: accepted by unedited repository-member comment
+  `5545980847` at mapping digest
+  `sha256:e7354c1071e98cab25b4990b410a40d68865fb57911371b02046d62b50c2c0c1`
 - Focused passing-after evidence: pending
 - Full quality/security/release gates: pending
 - Independent review: pending

--- a/openspec/changes/fix-final-requirements-review-artifact/CHANGE_VALIDATION.md
+++ b/openspec/changes/fix-final-requirements-review-artifact/CHANGE_VALIDATION.md
@@ -29,8 +29,8 @@
   fix-final-requirements-review-artifact --strict`)
 - Focused failing-before evidence: passed as an expected RED (`3 failed`)
 - Test-authored mapping: accepted by unedited repository-member comment
-  `5545980847` at mapping digest
-  `sha256:e7354c1071e98cab25b4990b410a40d68865fb57911371b02046d62b50c2c0c1`
+  `5546332802` at mapping digest
+  `sha256:be79411756a4bc65c02d68513b56074b9024876720fbb0f09a9957deb93e57ab`
 - Focused passing-after evidence: pending
 - Full quality/security/release gates: pending
 - Independent review: pending

--- a/openspec/changes/fix-final-requirements-review-artifact/CHANGE_VALIDATION.md
+++ b/openspec/changes/fix-final-requirements-review-artifact/CHANGE_VALIDATION.md
@@ -1,0 +1,33 @@
+# Change Validation
+
+## Repository and issue reality
+
+- Validation date: 2026-09-04 Europe/Berlin
+- Baseline: `origin/dev` at
+  `1d9491595eb4ba0d6cc55823710d9d2e36a21b16`
+- Issue: nold-ai/specfact-cli#710, open and assigned to `djm81`
+- Parent: #692
+- Labels: `bug`, `openspec`, `QA`, `security`
+- Project: SpecFact CLI, status `In Progress`
+- Duplicate search: no open issue or pull request covers conditional final Code
+  Review artifact handling for metadata-only Requirements runs.
+
+## Scope and dependency validation
+
+- PR #706 proves the no-Python path: final review exits successfully, then the
+  unconditional strict artifact upload fails (run `33913920761`, final job
+  `101156814880`).
+- Missing reports for real Python targets must remain fatal; only the proven
+  no-target path may skip upload.
+- PR #706 stays limited to its existing three release-finalization files.
+- The existing `0.55.4` version and release notes own this unreleased patch
+  transaction; another version bump would be incorrect.
+
+## Verification status
+
+- Strict OpenSpec validation: passed (`openspec validate
+  fix-final-requirements-review-artifact --strict`)
+- Focused failing-before evidence: pending
+- Focused passing-after evidence: pending
+- Full quality/security/release gates: pending
+- Independent review: pending

--- a/openspec/changes/fix-final-requirements-review-artifact/README.md
+++ b/openspec/changes/fix-final-requirements-review-artifact/README.md
@@ -1,0 +1,3 @@
+# Fix final Requirements review artifact handling
+
+Issue-linked OpenSpec change for nold-ai/specfact-cli#710.

--- a/openspec/changes/fix-final-requirements-review-artifact/TDD_EVIDENCE.md
+++ b/openspec/changes/fix-final-requirements-review-artifact/TDD_EVIDENCE.md
@@ -22,9 +22,9 @@
 - Production workflow remained unchanged while this evidence was captured.
 - Formatting and lint controls for the test file passed.
 - Mapping acceptance: unedited repository-member issue comment
-  <https://github.com/nold-ai/specfact-cli/issues/710#issuecomment-5545980847>
+  <https://github.com/nold-ai/specfact-cli/issues/710#issuecomment-5546332802>
   binds mapping digest
-  `sha256:e7354c1071e98cab25b4990b410a40d68865fb57911371b02046d62b50c2c0c1`.
+  `sha256:be79411756a4bc65c02d68513b56074b9024876720fbb0f09a9957deb93e57ab`.
 
 ## Passing After
 

--- a/openspec/changes/fix-final-requirements-review-artifact/TDD_EVIDENCE.md
+++ b/openspec/changes/fix-final-requirements-review-artifact/TDD_EVIDENCE.md
@@ -2,7 +2,29 @@
 
 ## Failing Before
 
-Pending test-authoring commit and focused failing execution.
+- Timestamp: `2026-09-04T20:42:21Z`
+- Environment: macOS, Python 3.12.13, pytest 9.1.1
+- Workflow baseline: `origin/dev` at
+  `1d9491595eb4ba0d6cc55823710d9d2e36a21b16`
+- Command:
+
+  ```text
+  hatch run python -m pytest -q \
+    tests/unit/workflows/test_trustworthy_green_checks.py::test_requirements_final_review_marks_no_python_target_path \
+    tests/unit/workflows/test_trustworthy_green_checks.py::test_requirements_final_review_requires_artifact_for_python_targets \
+    tests/unit/workflows/test_trustworthy_green_checks.py::test_requirements_final_review_persists_failure_before_enforcement
+  ```
+
+- Result: expected failure, `3 failed`.
+- Evidence: the review step emits neither fixed output, does not distinguish an
+  empty Python diff from a deleted Python path, and uses the unconditional
+  `always()` upload rather than an exact required-review check.
+- Production workflow remained unchanged while this evidence was captured.
+- Formatting and lint controls for the test file passed.
+- Mapping acceptance: unedited repository-member issue comment
+  <https://github.com/nold-ai/specfact-cli/issues/710#issuecomment-5545980847>
+  binds mapping digest
+  `sha256:e7354c1071e98cab25b4990b410a40d68865fb57911371b02046d62b50c2c0c1`.
 
 ## Passing After
 

--- a/openspec/changes/fix-final-requirements-review-artifact/TDD_EVIDENCE.md
+++ b/openspec/changes/fix-final-requirements-review-artifact/TDD_EVIDENCE.md
@@ -1,0 +1,9 @@
+# TDD Evidence
+
+## Failing Before
+
+Pending test-authoring commit and focused failing execution.
+
+## Passing After
+
+Pending implementation.

--- a/openspec/changes/fix-final-requirements-review-artifact/design.md
+++ b/openspec/changes/fix-final-requirements-review-artifact/design.md
@@ -1,0 +1,62 @@
+# Design: Final Requirements review artifact handling
+
+## Decision
+
+The final Code Review step writes a fixed `review-required` output. It defaults
+to `false` before changed Python paths are inspected and changes to `true` as
+soon as changed-path discovery proves that at least one `*.py` or `*.pyi` path
+exists. It does not infer metadata-only status from the later existing-file
+filter: a deleted or otherwise unreviewable Python path fails closed.
+
+The artifact upload runs with `always()` only when that output is exactly
+`true`. Its existing `if-no-files-found: error` remains unchanged. The later
+verdict-enforcement step also remains unchanged.
+
+This creates four explicit outcomes:
+
+1. No changed Python paths: review succeeds, output remains `false`, and no
+   report is expected or uploaded.
+2. Existing Python targets and successful review: output is `true`, and the
+   report is required and uploaded.
+3. Deleted or otherwise unreviewable Python paths: output is already `true` and
+   the review step fails, so the missing report and verdict enforcement both
+   remain blocking.
+4. Existing Python targets and failed review: output is already `true`, so any
+   produced report is retained; a missing report and the failed review both
+   remain blocking.
+
+If changed-path discovery or another pre-target operation fails, the review step
+fails and the existing enforcement step blocks the job even though no artifact
+was declared required. This does not convert operational failure into a pass.
+
+## Alternatives
+
+- Changing `if-no-files-found` to `ignore` or `warn` was rejected because it
+  would accept missing evidence for real Python review targets.
+- Creating an empty report on metadata-only pull requests was rejected because
+  it would represent a review execution that did not occur.
+- Adding an artificial Python change to PR #706 was rejected because it would
+  enlarge release scope and merely hide the workflow defect.
+- Inferring artifact necessity again in the upload step was rejected because
+  the review step already owns the raw changed-path result and filtered target
+  set.
+- Treating an empty existing-file array as metadata-only was rejected because a
+  deletion-only Python change also produces that array and must not bypass the
+  final security review boundary.
+
+## Security and compatibility
+
+Only fixed literal values are written to `GITHUB_OUTPUT`; no repository path or
+candidate-controlled value is emitted. The existing changed-path validation,
+trusted toolchain, isolated review context, artifact action pin, strict missing
+file behavior, and final verdict enforcement remain intact.
+
+GitHub Actions step outputs are the narrow control channel between the review
+and upload steps. The condition compares the output to the exact string `true`;
+missing or different values cannot authorize an artifact upload or suppress a
+failed review verdict.
+
+## Rollback
+
+Revert the workflow and test commit. No data migration, published artifact
+rewrite, dependency rollback, or package version change is required.

--- a/openspec/changes/fix-final-requirements-review-artifact/proposal.md
+++ b/openspec/changes/fix-final-requirements-review-artifact/proposal.md
@@ -1,0 +1,52 @@
+# Change: Fix final Requirements review artifact handling
+
+## Why
+
+The final Requirements job intentionally exits its Code Review step successfully
+when a pull request changes no Python files. Its following artifact upload is
+unconditional and configured to fail when the review report is absent. A
+metadata-only pull request therefore cannot satisfy the required Requirements
+context even though no final Python review is expected.
+
+The correction must distinguish an intentional no-review path from a required
+review that failed to produce evidence. Missing artifacts for real Python
+review targets must continue to fail closed.
+
+## What Changes
+
+- Have the final Code Review step publish an explicit output that records whether
+  changed Python paths exist.
+- Upload the final Code Review artifact only when that authenticated step output
+  says review was required.
+- Preserve strict missing-artifact failure and review-verdict enforcement for
+  every Python-changing pull request.
+- Fail closed when a changed Python path is deleted or otherwise cannot be
+  submitted to the file-oriented reviewer.
+- Add workflow contract tests for both branches and the failure control.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `trustworthy-green-checks`
+
+## Impact
+
+- Affected workflow: `.github/workflows/requirements-evidence.yml`.
+- Affected tests: focused workflow contract coverage only.
+- Public CLI, API, dependency graph, package payload, and module artifacts are
+  unchanged.
+- No user documentation changes are needed because this is an internal CI
+  control-flow correction.
+- This fix joins the existing unreleased `0.55.4` transaction and must not
+  consume another package version.
+- Rollback is a normal revert of the workflow commit.
+
+## Source Tracking
+
+- **GitHub Issue**: #710
+- **Issue URL**: <https://github.com/nold-ai/specfact-cli/issues/710>
+- **Repository**: nold-ai/specfact-cli
+- **Last Synced Status**: in progress
+- **Parent Issue**: #692
+- **Blocks**: #692, #706, #691

--- a/openspec/changes/fix-final-requirements-review-artifact/requirements-evidence.yaml
+++ b/openspec/changes/fix-final-requirements-review-artifact/requirements-evidence.yaml
@@ -20,7 +20,8 @@ requirements:
         intent: "Verify the explicit no-target output suppresses only the inapplicable artifact upload."
         observable: >-
           The final review defaults its fixed output to false and exits without
-          requiring a report only when no existing Python target is present.
+          requiring a report only when no changed Python path is present; a
+          deleted or otherwise unreviewable Python path remains blocking.
         selector:
           runner: pytest
           node_id: tests/unit/workflows/test_trustworthy_green_checks.py::test_requirements_final_review_marks_no_python_target_path

--- a/openspec/changes/fix-final-requirements-review-artifact/requirements-evidence.yaml
+++ b/openspec/changes/fix-final-requirements-review-artifact/requirements-evidence.yaml
@@ -1,0 +1,72 @@
+schema_version: "2"
+requirements:
+  openspec:fix-final-requirements-review-artifact:trustworthy-green-checks:metadata-only-final-review-needs-no-artifact:
+    rationale: >-
+      An intentional no-target final review must not be misclassified as missing
+      required evidence.
+    stakeholder_refs:
+      - "nold-ai/specfact-cli#710"
+    touchpoints:
+      - id: requirements-evidence-workflow
+        kind: ci_workflow
+        locator: ".github/workflows/requirements-evidence.yml"
+      - id: workflow-contract-tests
+        kind: test_file
+        locator: "tests/unit/workflows/test_trustworthy_green_checks.py"
+    verification_cases:
+      - case_id: REQ-FINAL-REVIEW-001
+        scenario_id: metadata-only-final-review-needs-no-artifact
+        method: test
+        intent: "Verify the explicit no-target output suppresses only the inapplicable artifact upload."
+        observable: >-
+          The final review defaults its fixed output to false and exits without
+          requiring a report only when no existing Python target is present.
+        selector:
+          runner: pytest
+          node_id: tests/unit/workflows/test_trustworthy_green_checks.py::test_requirements_final_review_marks_no_python_target_path
+  openspec:fix-final-requirements-review-artifact:trustworthy-green-checks:python-final-review-requires-strict-artifact:
+    rationale: >-
+      Python-changing pull requests must retain strict missing-artifact failure.
+    stakeholder_refs:
+      - "nold-ai/specfact-cli#710"
+    touchpoints:
+      - id: requirements-evidence-workflow
+        kind: ci_workflow
+        locator: ".github/workflows/requirements-evidence.yml"
+      - id: workflow-contract-tests
+        kind: test_file
+        locator: "tests/unit/workflows/test_trustworthy_green_checks.py"
+    verification_cases:
+      - case_id: REQ-FINAL-REVIEW-002
+        scenario_id: python-final-review-requires-strict-artifact
+        method: test
+        intent: "Verify Python targets declare review before execution and keep strict artifact upload."
+        observable: >-
+          The final review emits true before invoking Code Review, and upload
+          remains pinned and fatal when the report is absent.
+        selector:
+          runner: pytest
+          node_id: tests/unit/workflows/test_trustworthy_green_checks.py::test_requirements_final_review_requires_artifact_for_python_targets
+  openspec:fix-final-requirements-review-artifact:trustworthy-green-checks:final-review-failure-blocks-requirements:
+    rationale: >-
+      Conditional artifact handling must not weaken failed-review enforcement.
+    stakeholder_refs:
+      - "nold-ai/specfact-cli#710"
+    touchpoints:
+      - id: requirements-evidence-workflow
+        kind: ci_workflow
+        locator: ".github/workflows/requirements-evidence.yml"
+      - id: workflow-contract-tests
+        kind: test_file
+        locator: "tests/unit/workflows/test_trustworthy_green_checks.py"
+    verification_cases:
+      - case_id: REQ-FINAL-REVIEW-003
+        scenario_id: final-review-failure-blocks-requirements
+        method: test
+        intent: "Verify conditional artifact handling does not weaken failed-review enforcement."
+        observable: >-
+          Failed Code Review still reaches artifact retention when required and
+          the later enforcement step exits nonzero.
+        selector:
+          runner: pytest
+          node_id: tests/unit/workflows/test_trustworthy_green_checks.py::test_requirements_final_review_persists_failure_before_enforcement

--- a/openspec/changes/fix-final-requirements-review-artifact/requirements-proof/review-evidence.json
+++ b/openspec/changes/fix-final-requirements-review-artifact/requirements-proof/review-evidence.json
@@ -3,7 +3,7 @@
   "decision": "accepted",
   "reviewer_id": "djm81",
   "reviewer_role": "MEMBER",
-  "recorded_at": "2026-09-04T20:17:50Z",
-  "reference": "https://github.com/nold-ai/specfact-cli/issues/710#issuecomment-5545980847",
-  "mapping_digest": "sha256:e7354c1071e98cab25b4990b410a40d68865fb57911371b02046d62b50c2c0c1"
+  "recorded_at": "2026-09-04T20:54:05Z",
+  "reference": "https://github.com/nold-ai/specfact-cli/issues/710#issuecomment-5546332802",
+  "mapping_digest": "sha256:be79411756a4bc65c02d68513b56074b9024876720fbb0f09a9957deb93e57ab"
 }

--- a/openspec/changes/fix-final-requirements-review-artifact/requirements-proof/review-evidence.json
+++ b/openspec/changes/fix-final-requirements-review-artifact/requirements-proof/review-evidence.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "1",
+  "decision": "accepted",
+  "reviewer_id": "djm81",
+  "reviewer_role": "MEMBER",
+  "recorded_at": "2026-09-04T20:17:50Z",
+  "reference": "https://github.com/nold-ai/specfact-cli/issues/710#issuecomment-5545980847",
+  "mapping_digest": "sha256:e7354c1071e98cab25b4990b410a40d68865fb57911371b02046d62b50c2c0c1"
+}

--- a/openspec/changes/fix-final-requirements-review-artifact/specs/trustworthy-green-checks/spec.md
+++ b/openspec/changes/fix-final-requirements-review-artifact/specs/trustworthy-green-checks/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Metadata-only final review needs no artifact
+
+The required Requirements workflow SHALL record when final changed-path
+discovery finds no changed Python path and SHALL NOT require a final Code Review
+artifact for that intentional no-review outcome. A changed Python path that is
+not an existing reviewable file, including a deleted file, SHALL remain a
+blocking review outcome rather than being treated as metadata-only.
+
+#### Scenario: Metadata-only final review needs no artifact
+
+- **GIVEN** final changed-path discovery succeeds
+- **AND** no changed `*.py` or `*.pyi` path is present
+- **WHEN** the final Code Review stage completes
+- **THEN** it SHALL record that review was not required
+- **AND** it SHALL NOT require a final Code Review artifact.
+
+#### Scenario: Deleted Python path remains review-required
+
+- **GIVEN** final changed-path discovery identifies a deleted `*.py` or `*.pyi`
+  path
+- **WHEN** the final Code Review stage cannot submit that path to its
+  file-oriented reviewer
+- **THEN** it SHALL record that review was required
+- **AND** it SHALL fail closed instead of suppressing the review artifact.
+
+### Requirement: Python final review requires strict artifact
+
+The required Requirements workflow SHALL declare final Code Review mandatory
+before it invokes the reviewer for one or more existing changed Python targets,
+and SHALL fail if the expected review artifact is absent.
+
+#### Scenario: Python final review requires strict artifact
+
+- **GIVEN** final changed-path discovery identifies at least one existing Python
+  target
+- **WHEN** the final Code Review stage starts review execution
+- **THEN** it SHALL record that review is required before invoking the reviewer
+- **AND** the final artifact upload SHALL fail if the expected report is absent.
+
+### Requirement: Final review failure blocks Requirements
+
+The required Requirements workflow SHALL retain final review output when
+available and SHALL keep the Requirements verdict non-green whenever final Code
+Review fails.
+
+#### Scenario: Final review failure blocks Requirements
+
+- **GIVEN** final Code Review is required
+- **WHEN** review execution fails
+- **THEN** the workflow SHALL attempt to retain the final report
+- **AND** the final Requirements verdict SHALL remain non-green
+- **AND** neither conditional upload nor a missing output SHALL suppress verdict
+  enforcement.

--- a/openspec/changes/fix-final-requirements-review-artifact/tasks.md
+++ b/openspec/changes/fix-final-requirements-review-artifact/tasks.md
@@ -1,0 +1,57 @@
+# Tasks: Fix final Requirements review artifact handling
+
+## 1. Readiness and specification
+
+- [x] 1.1 Create `bugfix/710-requirements-no-python-review` in an isolated
+  worktree from freshly fetched `origin/dev` before implementation edits.
+- [x] 1.2 Verify issue #710 is open, assigned, labeled, In Progress, linked under
+  #692, and a native blocker; check for duplicate issues and changes.
+- [x] 1.3 Define the no-target and required-review artifact behavior plus
+  fail-closed controls.
+- [x] 1.4 Validate this OpenSpec change strictly before authoring tests.
+
+## 2. Tests and failing evidence
+
+- [ ] 2.1 Add exact workflow tests for the no-Python-target output, required
+  Python review artifact, and unchanged verdict enforcement.
+- [ ] 2.2 Map the scenarios to exact pytest selectors in
+  `requirements-evidence.yaml` and obtain the required mapping acceptance.
+- [ ] 2.3 Run the focused selectors before workflow edits and record the exact
+  failing result, timestamp, environment, and assertions in `TDD_EVIDENCE.md`.
+
+## 3. Minimal implementation
+
+- [ ] 3.1 Emit only fixed `review-required=false|true` values from the final
+  Code Review step at the exact target-selection boundary.
+- [ ] 3.2 Make artifact upload conditional on exact `true` while retaining
+  `always()`, the pinned action, and `if-no-files-found: error`.
+- [ ] 3.3 Preserve final review failure enforcement and all trusted setup,
+  checkout, path, artifact, and toolchain controls.
+
+## 4. Passing evidence and quality gates
+
+- [ ] 4.1 Re-run the focused selectors and legitimate no-target/failure controls
+  with passing evidence.
+- [ ] 4.2 Run workflow lint, YAML lint, format, lint, type-check, contract gates,
+  smart tests, strict OpenSpec validation, module-signature verification,
+  Requirements evidence, and SpecFact Code Review; resolve every finding or
+  document an explicitly approved exception.
+- [ ] 4.3 Confirm PR #706 no longer reproduces the final artifact failure after
+  this fix reaches `dev`.
+
+## 5. Documentation, release, and delivery
+
+- [ ] 5.1 Record that README and published docs need no change because this is
+  an internal CI control-flow correction.
+- [ ] 5.2 Keep the existing unreleased `0.55.4` version and changelog transaction
+  unchanged; do not create `0.55.5` for this blocker.
+- [ ] 5.3 After merge, update the internal wiki source without altering internal
+  wiki PR #38 or its planning branch, and rebuild the graph from the internal
+  repository root.
+- [ ] 5.4 Promote the issue-linked draft PR to ready for review only after
+  required local gates pass; resolve all review threads and merge only under
+  normal policy. A draft opened at the test-only commit may retain immutable
+  GitHub RED evidence before that promotion.
+- [ ] 5.5 After merge, archive this change with `openspec archive
+  fix-final-requirements-review-artifact`, validate the resulting canonical
+  spec, and remove the dedicated worktree and merged branch.

--- a/openspec/changes/fix-final-requirements-review-artifact/tasks.md
+++ b/openspec/changes/fix-final-requirements-review-artifact/tasks.md
@@ -12,11 +12,11 @@
 
 ## 2. Tests and failing evidence
 
-- [ ] 2.1 Add exact workflow tests for the no-Python-target output, required
+- [x] 2.1 Add exact workflow tests for the no-Python-target output, required
   Python review artifact, and unchanged verdict enforcement.
-- [ ] 2.2 Map the scenarios to exact pytest selectors in
+- [x] 2.2 Map the scenarios to exact pytest selectors in
   `requirements-evidence.yaml` and obtain the required mapping acceptance.
-- [ ] 2.3 Run the focused selectors before workflow edits and record the exact
+- [x] 2.3 Run the focused selectors before workflow edits and record the exact
   failing result, timestamp, environment, and assertions in `TDD_EVIDENCE.md`.
 
 ## 3. Minimal implementation

--- a/tests/unit/workflows/test_trustworthy_green_checks.py
+++ b/tests/unit/workflows/test_trustworthy_green_checks.py
@@ -536,6 +536,36 @@ def test_requirements_final_review_prefers_full_verifier_python() -> None:
     )
 
 
+def test_requirements_final_review_marks_no_python_target_path() -> None:
+    """Only a truly empty Python diff may suppress the review artifact."""
+    review = cast(str, _find_requirements_final_step("Run Code Review with trusted final Requirements context")["run"])
+    upload = _find_requirements_final_step("Upload final Code Review evidence artifact")
+    no_review_marker = "printf 'review-required=false\\n' >> \"$GITHUB_OUTPUT\""
+    review_marker = "printf 'review-required=true\\n' >> \"$GITHUB_OUTPUT\""
+    no_changed_python = 'if [[ ! -s "$review_paths_file" ]]; then'
+    reject_unreviewable = 'if [[ ! -f "$review_path" ]]; then'
+
+    assert review.index(no_review_marker) < review.index("git diff --name-only")
+    assert review.index(no_changed_python) < review.index("exit 0") < review.index(review_marker)
+    assert review.index(review_marker) < review.index(reject_unreviewable)
+    assert review.index(reject_unreviewable) < review.index("exit 1", review.index(reject_unreviewable))
+    assert upload["if"] == "always() && steps.run-final-code-review.outputs.review-required == 'true'"
+
+
+def test_requirements_final_review_requires_artifact_for_python_targets() -> None:
+    """A Python target must declare review before execution and require its report."""
+    review = cast(str, _find_requirements_final_step("Run Code Review with trusted final Requirements context")["run"])
+    upload = _find_requirements_final_step("Upload final Code Review evidence artifact")
+    review_marker = "printf 'review-required=true\\n' >> \"$GITHUB_OUTPUT\""
+
+    assert review.index(review_marker) < review.index('"${isolated_specfact[@]}" code review run')
+    assert upload["uses"] == "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+    assert upload["if"] == "always() && steps.run-final-code-review.outputs.review-required == 'true'"
+    upload_options = cast(dict[str, str], upload["with"])
+    assert upload_options["path"] == "${{ runner.temp }}/final-code-review.json"
+    assert upload_options["if-no-files-found"] == "error"
+
+
 def test_requirements_final_review_persists_failure_before_enforcement() -> None:
     """A failing final review must retain its report without weakening the verdict."""
     workflow = _load_yaml(REQUIREMENTS_EVIDENCE)
@@ -547,11 +577,7 @@ def test_requirements_final_review_persists_failure_before_enforcement() -> None
 
     assert review["id"] == "run-final-code-review"
     assert review["continue-on-error"] is True
-    assert upload["if"] == "always()"
-    assert upload["uses"] == "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
-    upload_options = cast(dict[str, str], upload["with"])
-    assert upload_options["path"] == "${{ runner.temp }}/final-code-review.json"
-    assert upload_options["if-no-files-found"] == "error"
+    assert upload["if"] == "always() && steps.run-final-code-review.outputs.review-required == 'true'"
     assert enforce["if"] == "steps.run-final-code-review.outcome == 'failure'"
     assert enforce["run"] == "exit 1"
     assert steps.index(review) < steps.index(upload) < steps.index(enforce)


### PR DESCRIPTION
## Summary

- define the issue-linked OpenSpec contract for final Requirements review artifact necessity
- suppress the artifact only when the raw changed-Python-path set is truly empty
- fail closed for deleted or otherwise unreviewable Python paths
- preserve strict artifact and verdict enforcement for every required review
- unblock metadata-only release-finalization PR #706 without artificial code changes

## Status

The clean branch contains spec and test-only commits. All three mapped selectors fail against the unchanged dev workflow; this draft retains the immutable GitHub RED artifact before the implementation commit.

Closes #710
Parent: #692
Blocks #706 and #691.

## Security invariant

This change does not relax `if-no-files-found: error`. A deleted Python path cannot be misclassified as metadata-only and must remain blocking.