### PR TITLE
fix(ci): authenticate release promotion Requirements reuse

### DIFF
--- a/.github/workflows/requirements-evidence.yml
+++ b/.github/workflows/requirements-evidence.yml
@@ -195,6 +195,134 @@ jobs:
       - name: Prepare Requirements evidence artifact directory
         run: mkdir -p artifacts/requirements-evidence
 
+      - name: Checkout trusted promotion authority policy for producer
+        if: >-
+          github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'dev' && github.event.pull_request.base.repo.id == github.event.repository.id && github.event.pull_request.head.repo.id == github.event.repository.id && github.event.pull_request.base.repo.full_name == github.event.repository.full_name && github.event.pull_request.head.repo.full_name == github.event.repository.full_name
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          repository: nold-ai/.github
+          path: promotion-authority-policy-producer
+          ref: f7a22379f88010d77c86f9b2bbaf1ac58f15d85d
+          persist-credentials: false
+
+      - name: Authenticate protected promotion head for producer
+        if: >-
+          github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'dev' && github.event.pull_request.base.repo.id == github.event.repository.id && github.event.pull_request.head.repo.id == github.event.repository.id && github.event.pull_request.base.repo.full_name == github.event.repository.full_name && github.event.pull_request.head.repo.full_name == github.event.repository.full_name
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          trusted_policy_commit="f7a22379f88010d77c86f9b2bbaf1ac58f15d85d"
+          trusted_policy_tree="47f33b4df92060a36f3afd92948e441555fb280d"
+          trusted_policy_blob="8c7b30020033c6b6081d6e743d77aa76043724ea"
+          trusted_policy_digest="5441e26e7c3c8f18973c781e7d43c72076b3283c915d98ca5188bb174bf17c45"
+          trusted_policy_root="${GITHUB_WORKSPACE}/promotion-authority-policy-producer"
+          trusted_policy_script="$trusted_policy_root/.github/scripts/trusted_requirements_authority.py"
+          test "$(git -C "$trusted_policy_root" remote get-url origin)" = "https://github.com/nold-ai/.github"
+          test "$(git -C "$trusted_policy_root" rev-parse HEAD)" = "$trusted_policy_commit"
+          test "$(git -C "$trusted_policy_root" rev-parse 'HEAD^{tree}')" = "$trusted_policy_tree"
+          test "$(git -C "$trusted_policy_root" rev-parse 'HEAD:.github/scripts/trusted_requirements_authority.py')" = "$trusted_policy_blob"
+          test "$(sha256sum < "$trusted_policy_script" | cut -d ' ' -f 1)" = "$trusted_policy_digest"
+          GITHUB_API_URL="https://api.github.com" \
+            "${pythonLocation}/bin/python" -I -S \
+              "${GITHUB_WORKSPACE}/promotion-authority-policy-producer/.github/scripts/trusted_requirements_authority.py" \
+              --event "$GITHUB_EVENT_PATH"
+
+      - name: Fetch protected promotion evidence for producer
+        if: >-
+          github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'dev' && github.event.pull_request.base.repo.id == github.event.repository.id && github.event.pull_request.head.repo.id == github.event.repository.id && github.event.pull_request.base.repo.full_name == github.event.repository.full_name && github.event.pull_request.head.repo.full_name == github.event.repository.full_name
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          metadata_root="${RUNNER_TEMP}/promotion-producer-promotion"
+          mkdir -p "$metadata_root"
+          git fetch --no-tags origin \
+            "+refs/heads/main:refs/remotes/origin/main" \
+            "+refs/heads/dev:refs/remotes/origin/dev"
+          base_sha="$(jq -er '.pull_request.base.sha | select(type == "string" and test("^[0-9a-f]{40}$"))' "$GITHUB_EVENT_PATH")"
+          head_sha="$(jq -er '.pull_request.head.sha | select(type == "string" and test("^[0-9a-f]{40}$"))' "$GITHUB_EVENT_PATH")"
+          test "$(git rev-parse HEAD)" = "$head_sha"
+          test "$(git rev-parse 'HEAD^{tree}')" = "$(git rev-parse "${head_sha}^{tree}")"
+          test "$(git rev-parse 'refs/remotes/origin/main^{commit}')" = "$base_sha"
+          test "$(git rev-parse 'refs/remotes/origin/dev^{commit}')" = "$head_sha"
+          test "$(git cat-file -t "$base_sha")" = commit
+          test "$(git cat-file -t "$head_sha")" = commit
+          git merge-base --is-ancestor "$base_sha" "$head_sha"
+          read -r merge_sha previous_dev source_head extra_parent < <(git rev-list --parents -n 1 "$head_sha")
+          test "$merge_sha" = "$head_sha"
+          test -n "$previous_dev"
+          test -n "$source_head"
+          test -z "${extra_parent:-}"
+          test "$(git cat-file -t "$previous_dev")" = commit
+          test "$(git cat-file -t "$source_head")" = commit
+          gh api --method GET --paginate --slurp \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${GITHUB_REPOSITORY}/commits/${source_head}/pulls?per_page=100" \
+            > "$metadata_root/source-pulls-pages.json"
+          jq -e '[.[][]]' "$metadata_root/source-pulls-pages.json" > "$metadata_root/source-pulls.json"
+          gh api --method GET --paginate --slurp \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${GITHUB_REPOSITORY}/commits/${source_head}/check-runs?per_page=100" \
+            > "$metadata_root/check-runs-pages.json"
+          jq -e \
+            '{total_count: (.[0].total_count // 0), check_runs: [.[].check_runs[]]}' \
+            "$metadata_root/check-runs-pages.json" > "$metadata_root/check-runs.json"
+          requirements_run_id="$(jq -er '
+            [.check_runs[] | select(.name == "Requirements evidence")] |
+            if length == 1 then .[0].details_url |
+              capture("/actions/runs/(?<run_id>[0-9]+)/job/[0-9]+$").run_id
+            else error("expected one Requirements evidence check") end
+          ' "$metadata_root/check-runs.json")"
+          authority_run_id="$(jq -er '
+            [.check_runs[] | select(.name == "Trusted Requirements Authority")] |
+            if length == 1 then .[0].details_url |
+              capture("/actions/runs/(?<run_id>[0-9]+)/job/[0-9]+$").run_id
+            else error("expected one Trusted Requirements Authority check") end
+          ' "$metadata_root/check-runs.json")"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${requirements_run_id}" > "$metadata_root/requirements-run.json"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${authority_run_id}" > "$metadata_root/authority-run.json"
+          gh api --method GET --paginate --slurp \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${requirements_run_id}/artifacts?per_page=100" \
+            > "$metadata_root/artifacts-pages.json"
+          jq -e \
+            '{total_count: (.[0].total_count // 0), artifacts: [.[].artifacts[]]}' \
+            "$metadata_root/artifacts-pages.json" > "$metadata_root/artifacts.json"
+          producer_artifact_id="$(jq -er '
+            [.artifacts[] | select(.name == "requirements-evidence")] |
+            if length == 1 then .[0].id else error("expected one producer artifact") end
+          ' "$metadata_root/artifacts.json")"
+          execution_artifact_id="$(jq -er '
+            [.artifacts[] | select(.name == "requirements-evidence-execution")] |
+            if length == 1 then .[0].id else error("expected one execution artifact") end
+          ' "$metadata_root/artifacts.json")"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${producer_artifact_id}/zip" > "$metadata_root/producer.zip"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${execution_artifact_id}/zip" > "$metadata_root/execution.zip"
+
+      - name: Validate protected promotion evidence for producer
+        id: producer-promotion
+        if: >-
+          github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'dev' && github.event.pull_request.base.repo.id == github.event.repository.id && github.event.pull_request.head.repo.id == github.event.repository.id && github.event.pull_request.base.repo.full_name == github.event.repository.full_name && github.event.pull_request.head.repo.full_name == github.event.repository.full_name
+        shell: bash
+        run: |
+          set -euo pipefail
+          output="artifacts/requirements-evidence/requirements-promotion-reuse.json"
+          mkdir -p "$(dirname "$output")"
+          "${REQUIREMENTS_VALIDATOR_ROOT}/bin/python" -I -S scripts/requirements_promotion_reuse.py \
+            --event "$GITHUB_EVENT_PATH" \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --source-pulls "${RUNNER_TEMP}/promotion-producer-promotion/source-pulls.json" \
+            --check-runs "${RUNNER_TEMP}/promotion-producer-promotion/check-runs.json" \
+            --requirements-run "${RUNNER_TEMP}/promotion-producer-promotion/requirements-run.json" \
+            --authority-run "${RUNNER_TEMP}/promotion-producer-promotion/authority-run.json" \
+            --artifacts "${RUNNER_TEMP}/promotion-producer-promotion/artifacts.json" \
+            --producer-archive "${RUNNER_TEMP}/promotion-producer-promotion/producer.zip" \
+            --execution-archive "${RUNNER_TEMP}/promotion-producer-promotion/execution.zip" \
+            --output "artifacts/requirements-evidence/requirements-promotion-reuse.json"
+          printf 'active=true\n' >> "$GITHUB_OUTPUT"
+
       - name: Download exact late RED artifact
         if: github.event_name == 'pull_request' && github.event.pull_request.number == 704 && github.head_ref == 'bugfix/692-release-review-followup' && hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -344,6 +472,7 @@ jobs:
           EVIDENCE_FINAL_REF: ${{ github.event.pull_request.head.sha || github.sha }}
           EVIDENCE_HEAD_BRANCH: ${{ github.head_ref }}
           EVIDENCE_PULL_REQUEST: ${{ github.event.pull_request.number }}
+          EVIDENCE_PROMOTION_REUSE: ${{ steps.producer-promotion.outputs.active }}
           LATE_RED_ACTIVE: ${{ github.event.pull_request.number == 704 && github.head_ref == 'bugfix/692-release-review-followup' && hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') != '' }}
         run: |
           set -e
@@ -408,6 +537,9 @@ jobs:
           planning_maturity="$required_maturity"
           if [[ "$required_maturity" == "verified" ]]; then
             planning_maturity=test-authored
+          fi
+          if [[ "$EVIDENCE_PROMOTION_REUSE" == "true" ]]; then
+            planning_maturity=planned
           fi
           selected_change=""
           is_complete_branch_archive_move() {
@@ -577,7 +709,11 @@ jobs:
           exit_code=$?
           set -e
           failure_diagnostic="Evidence command exited with status $exit_code before writing reports."
-          if [[ "$exit_code" -eq 0 && "$required_maturity" != "planned" ]]; then
+          if [[ "$EVIDENCE_PROMOTION_REUSE" == "true" ]]; then
+            test -s artifacts/requirements-evidence/requirements-promotion-reuse.json
+            jq -e '.gate_decision == "pass" and (.plan.cases | length > 0)' \
+              artifacts/requirements-evidence/requirements-evidence.json > /dev/null
+          elif [[ "$exit_code" -eq 0 && "$required_maturity" != "planned" ]]; then
             run_stage=red
             if [[ "$required_maturity" == "verified" ]]; then
               run_stage=final
@@ -660,7 +796,7 @@ jobs:
                       --artifact-root "$bootstrap_artifact_root" \
                       --repo-root "$GITHUB_WORKSPACE" \
                       --comment-id "$bootstrap_comment_id" \
-                      --base-ref "$evidence_base_commit" \
+                      --base-ref "${evidence_base_commit}" \
                       --final-ref "$EVIDENCE_FINAL_REF" \
                       --repository "$GITHUB_REPOSITORY" \
                       --change-id "$selected_change" \
@@ -738,7 +874,7 @@ jobs:
                   --bind-red-proof artifacts/requirements-evidence/requirements-evidence.json \
                   --junit artifacts/requirements-evidence/requirements-proof.xml \
                   --repo-root "$GITHUB_WORKSPACE" \
-                  --base-ref "$evidence_base_commit" 2>&1)"; then
+                  --base-ref "${evidence_base_commit}" 2>&1)"; then
                   write_failure_reports "Red proof binding rejected: ${binding_error:-prior-red-proof-invalid}"
                   exit 1
                 fi
@@ -779,6 +915,7 @@ jobs:
             artifacts/requirements-evidence/requirements-evidence.md
             artifacts/requirements-evidence/requirements-evidence-plan.json
             artifacts/requirements-evidence/requirements-proof.xml
+            artifacts/requirements-evidence/requirements-promotion-reuse.json
             artifacts/requirements-evidence/approved-legacy-tdd-ledger.md
             artifacts/requirements-evidence/legacy-tdd-evidence.json
           if-no-files-found: warn
@@ -993,6 +1130,136 @@ jobs:
           artifact-ids: ${{ needs.requirements-evidence-producer.outputs.artifact-id }}
           path: artifacts/requirements-evidence
 
+      - name: Checkout trusted promotion authority policy for fresh execution
+        if: >-
+          github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'dev' && github.event.pull_request.base.repo.id == github.event.repository.id && github.event.pull_request.head.repo.id == github.event.repository.id && github.event.pull_request.base.repo.full_name == github.event.repository.full_name && github.event.pull_request.head.repo.full_name == github.event.repository.full_name
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          repository: nold-ai/.github
+          path: promotion-authority-policy-execution
+          ref: f7a22379f88010d77c86f9b2bbaf1ac58f15d85d
+          persist-credentials: false
+
+      - name: Authenticate protected promotion head for fresh execution
+        if: >-
+          github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'dev' && github.event.pull_request.base.repo.id == github.event.repository.id && github.event.pull_request.head.repo.id == github.event.repository.id && github.event.pull_request.base.repo.full_name == github.event.repository.full_name && github.event.pull_request.head.repo.full_name == github.event.repository.full_name
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          trusted_policy_commit="f7a22379f88010d77c86f9b2bbaf1ac58f15d85d"
+          trusted_policy_tree="47f33b4df92060a36f3afd92948e441555fb280d"
+          trusted_policy_blob="8c7b30020033c6b6081d6e743d77aa76043724ea"
+          trusted_policy_digest="5441e26e7c3c8f18973c781e7d43c72076b3283c915d98ca5188bb174bf17c45"
+          trusted_policy_root="${GITHUB_WORKSPACE}/promotion-authority-policy-execution"
+          trusted_policy_script="$trusted_policy_root/.github/scripts/trusted_requirements_authority.py"
+          test "$(git -C "$trusted_policy_root" remote get-url origin)" = "https://github.com/nold-ai/.github"
+          test "$(git -C "$trusted_policy_root" rev-parse HEAD)" = "$trusted_policy_commit"
+          test "$(git -C "$trusted_policy_root" rev-parse 'HEAD^{tree}')" = "$trusted_policy_tree"
+          test "$(git -C "$trusted_policy_root" rev-parse 'HEAD:.github/scripts/trusted_requirements_authority.py')" = "$trusted_policy_blob"
+          test "$(sha256sum < "$trusted_policy_script" | cut -d ' ' -f 1)" = "$trusted_policy_digest"
+          GITHUB_API_URL="https://api.github.com" \
+            "${pythonLocation}/bin/python" -I -S \
+              "${GITHUB_WORKSPACE}/promotion-authority-policy-execution/.github/scripts/trusted_requirements_authority.py" \
+              --event "$GITHUB_EVENT_PATH"
+
+      - name: Fetch protected promotion evidence for fresh execution
+        if: >-
+          github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'dev' && github.event.pull_request.base.repo.id == github.event.repository.id && github.event.pull_request.head.repo.id == github.event.repository.id && github.event.pull_request.base.repo.full_name == github.event.repository.full_name && github.event.pull_request.head.repo.full_name == github.event.repository.full_name
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          metadata_root="${RUNNER_TEMP}/promotion-execution-promotion"
+          mkdir -p "$metadata_root"
+          git fetch --no-tags origin \
+            "+refs/heads/main:refs/remotes/origin/main" \
+            "+refs/heads/dev:refs/remotes/origin/dev"
+          base_sha="$(jq -er '.pull_request.base.sha | select(type == "string" and test("^[0-9a-f]{40}$"))' "$GITHUB_EVENT_PATH")"
+          head_sha="$(jq -er '.pull_request.head.sha | select(type == "string" and test("^[0-9a-f]{40}$"))' "$GITHUB_EVENT_PATH")"
+          test "$(git rev-parse HEAD)" = "$head_sha"
+          test "$(git rev-parse 'HEAD^{tree}')" = "$(git rev-parse "${head_sha}^{tree}")"
+          test "$(git rev-parse 'refs/remotes/origin/main^{commit}')" = "$base_sha"
+          test "$(git rev-parse 'refs/remotes/origin/dev^{commit}')" = "$head_sha"
+          test "$(git cat-file -t "$base_sha")" = commit
+          test "$(git cat-file -t "$head_sha")" = commit
+          git merge-base --is-ancestor "$base_sha" "$head_sha"
+          read -r merge_sha previous_dev source_head extra_parent < <(git rev-list --parents -n 1 "$head_sha")
+          test "$merge_sha" = "$head_sha"
+          test -n "$previous_dev"
+          test -n "$source_head"
+          test -z "${extra_parent:-}"
+          test "$(git cat-file -t "$previous_dev")" = commit
+          test "$(git cat-file -t "$source_head")" = commit
+          gh api --method GET --paginate --slurp \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${GITHUB_REPOSITORY}/commits/${source_head}/pulls?per_page=100" \
+            > "$metadata_root/source-pulls-pages.json"
+          jq -e '[.[][]]' "$metadata_root/source-pulls-pages.json" > "$metadata_root/source-pulls.json"
+          gh api --method GET --paginate --slurp \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${GITHUB_REPOSITORY}/commits/${source_head}/check-runs?per_page=100" \
+            > "$metadata_root/check-runs-pages.json"
+          jq -e \
+            '{total_count: (.[0].total_count // 0), check_runs: [.[].check_runs[]]}' \
+            "$metadata_root/check-runs-pages.json" > "$metadata_root/check-runs.json"
+          requirements_run_id="$(jq -er '
+            [.check_runs[] | select(.name == "Requirements evidence")] |
+            if length == 1 then .[0].details_url |
+              capture("/actions/runs/(?<run_id>[0-9]+)/job/[0-9]+$").run_id
+            else error("expected one Requirements evidence check") end
+          ' "$metadata_root/check-runs.json")"
+          authority_run_id="$(jq -er '
+            [.check_runs[] | select(.name == "Trusted Requirements Authority")] |
+            if length == 1 then .[0].details_url |
+              capture("/actions/runs/(?<run_id>[0-9]+)/job/[0-9]+$").run_id
+            else error("expected one Trusted Requirements Authority check") end
+          ' "$metadata_root/check-runs.json")"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${requirements_run_id}" > "$metadata_root/requirements-run.json"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${authority_run_id}" > "$metadata_root/authority-run.json"
+          gh api --method GET --paginate --slurp \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${requirements_run_id}/artifacts?per_page=100" \
+            > "$metadata_root/artifacts-pages.json"
+          jq -e \
+            '{total_count: (.[0].total_count // 0), artifacts: [.[].artifacts[]]}' \
+            "$metadata_root/artifacts-pages.json" > "$metadata_root/artifacts.json"
+          producer_artifact_id="$(jq -er '
+            [.artifacts[] | select(.name == "requirements-evidence")] |
+            if length == 1 then .[0].id else error("expected one producer artifact") end
+          ' "$metadata_root/artifacts.json")"
+          execution_artifact_id="$(jq -er '
+            [.artifacts[] | select(.name == "requirements-evidence-execution")] |
+            if length == 1 then .[0].id else error("expected one execution artifact") end
+          ' "$metadata_root/artifacts.json")"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${producer_artifact_id}/zip" > "$metadata_root/producer.zip"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${execution_artifact_id}/zip" > "$metadata_root/execution.zip"
+
+      - name: Validate protected promotion evidence for fresh execution
+        id: execution-promotion
+        if: >-
+          github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'dev' && github.event.pull_request.base.repo.id == github.event.repository.id && github.event.pull_request.head.repo.id == github.event.repository.id && github.event.pull_request.base.repo.full_name == github.event.repository.full_name && github.event.pull_request.head.repo.full_name == github.event.repository.full_name
+        shell: bash
+        run: |
+          set -euo pipefail
+          output="artifacts/requirements-evidence/final-verification/requirements-promotion-reuse.json"
+          mkdir -p "$(dirname "$output")"
+          "${REQUIREMENTS_VALIDATOR_ROOT}/bin/python" -I -S scripts/requirements_promotion_reuse.py \
+            --event "$GITHUB_EVENT_PATH" \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --source-pulls "${RUNNER_TEMP}/promotion-execution-promotion/source-pulls.json" \
+            --check-runs "${RUNNER_TEMP}/promotion-execution-promotion/check-runs.json" \
+            --requirements-run "${RUNNER_TEMP}/promotion-execution-promotion/requirements-run.json" \
+            --authority-run "${RUNNER_TEMP}/promotion-execution-promotion/authority-run.json" \
+            --artifacts "${RUNNER_TEMP}/promotion-execution-promotion/artifacts.json" \
+            --producer-archive "${RUNNER_TEMP}/promotion-execution-promotion/producer.zip" \
+            --execution-archive "${RUNNER_TEMP}/promotion-execution-promotion/execution.zip" \
+            --expected-attestation "artifacts/requirements-evidence/requirements-promotion-reuse.json" \
+            --output "artifacts/requirements-evidence/final-verification/requirements-promotion-reuse.json"
+          cmp --silent "artifacts/requirements-evidence/final-verification/requirements-promotion-reuse.json" "artifacts/requirements-evidence/requirements-promotion-reuse.json"
+          printf 'active=true\n' >> "$GITHUB_OUTPUT"
+
       - name: Checkout trusted Requirements authority policy
         if: github.event_name == 'pull_request' && github.event.pull_request.number == 704 && github.head_ref == 'bugfix/692-release-review-followup' && hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') != ''
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -1172,17 +1439,21 @@ jobs:
       - name: Reconcile Requirements evidence on fresh runner
         timeout-minutes: 12
         env:
+          EVIDENCE_PROMOTION_REUSE: ${{ steps.execution-promotion.outputs.active }}
           LATE_RED_ACTIVE: ${{ github.event.pull_request.number == 704 && github.head_ref == 'bugfix/692-release-review-followup' && hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') != '' }}
           LATE_RED_CYCLE_BASE: ${{ steps.late-red.outputs.cycle-base-ref }}
           PRIOR_RED_ARTIFACT_DIGEST: ${{ steps.consumer-red.outputs.artifact-digest }}
           PRIOR_RED_HEAD_SHA: ${{ steps.consumer-red.outputs.head-sha }}
+          REVIEW_BASE_BRANCH: ${{ github.base_ref }}
         shell: bash
         run: |
           set -euo pipefail
           source_ref="$(git rev-parse HEAD)"
           evidence_base_commit="$(git merge-base "origin/${GITHUB_BASE_REF}" "$source_ref")"
+          review_base_commit="$(git merge-base "origin/${REVIEW_BASE_BRANCH}" HEAD)"
           [[ "$source_ref" =~ ^[0-9a-f]{40}$ ]]
           [[ "$evidence_base_commit" =~ ^[0-9a-f]{40}$ ]]
+          test "$review_base_commit" = "$evidence_base_commit"
           validator_site="${REQUIREMENTS_VALIDATOR_ROOT}/lib/python3.12/site-packages"
           isolated_python=("${REQUIREMENTS_VALIDATOR_ROOT}/bin/python" -I -S -c 'import runpy, sys; sys.path.append(sys.argv.pop(1)); script = sys.argv.pop(1); runpy.run_path(script, run_name="__main__")' "$validator_site")
           isolated_specfact=("${REQUIREMENTS_VALIDATOR_ROOT}/bin/python" -I -S -c 'import sys; site_packages, trusted_core = sys.argv[1:3]; del sys.argv[1:3]; sys.path.append(site_packages); sys.path.insert(0, trusted_core); from specfact_cli.cli import cli_main; cli_main()' "$validator_site" "$TRUSTED_REQUIREMENTS_CORE")
@@ -1213,7 +1484,11 @@ jobs:
             esac
           done < "$consumer_status_file"
           rm -f "$consumer_status_file"
-          test "$(jq -er '.required_maturity' "$producer_report")" = "$required_maturity"
+          if [[ "$EVIDENCE_PROMOTION_REUSE" == "true" ]]; then
+            test "$(jq -er '.required_maturity' "$producer_report")" = planned
+          else
+            test "$(jq -er '.required_maturity' "$producer_report")" = "$required_maturity"
+          fi
           if [[ "$required_maturity" == "test-authored" ]]; then
             printf 'A successful producer cannot stop at test-authored maturity.\n' >&2
             exit 1
@@ -1221,6 +1496,9 @@ jobs:
           planning_maturity="$required_maturity"
           if [[ "$required_maturity" == "verified" ]]; then
             planning_maturity=test-authored
+          fi
+          if [[ "$EVIDENCE_PROMOTION_REUSE" == "true" ]]; then
+            planning_maturity=planned
           fi
 
           consumer_change_paths_file="${RUNNER_TEMP}/consumer-change-paths.z"
@@ -1242,21 +1520,25 @@ jobs:
             esac
           done < "$consumer_change_paths_file"
           review_evidence_paths=()
-          if [[ "${#consumer_changed_change_ids[@]}" -eq 1 ]]; then
-            for selected_change in "${!consumer_changed_change_ids[@]}"; do
-              :
-            done
-            review_evidence_paths+=("openspec/changes/${selected_change}/requirements-proof/review-evidence.json")
-          elif [[ "${#consumer_changed_change_ids[@]}" -gt 1 ]]; then
-            printf 'Fresh reconciliation found multiple changed active OpenSpec changes.\n' >&2
-            exit 1
+          if [[ "$EVIDENCE_PROMOTION_REUSE" != "true" ]]; then
+            if [[ "${#consumer_changed_change_ids[@]}" -eq 1 ]]; then
+              for selected_change in "${!consumer_changed_change_ids[@]}"; do
+                :
+              done
+              review_evidence_paths+=("openspec/changes/${selected_change}/requirements-proof/review-evidence.json")
+            elif [[ "${#consumer_changed_change_ids[@]}" -gt 1 ]]; then
+              printf 'Fresh reconciliation found multiple changed active OpenSpec changes.\n' >&2
+              exit 1
+            fi
           fi
-          if [[ "${#review_evidence_paths[@]}" -eq 0 ]]; then
-            mapfile -t active_review_evidence < <(
-              find openspec/changes -path 'openspec/changes/archive' -prune -o -path '*/requirements-proof/review-evidence.json' -type f -print | sort
-            )
-            if [[ "${#active_review_evidence[@]}" -eq 1 ]]; then
-              review_evidence_paths+=("${active_review_evidence[0]}")
+          if [[ "$EVIDENCE_PROMOTION_REUSE" != "true" ]]; then
+            if [[ "${#review_evidence_paths[@]}" -eq 0 ]]; then
+              mapfile -t active_review_evidence < <(
+                find openspec/changes -path 'openspec/changes/archive' -prune -o -path '*/requirements-proof/review-evidence.json' -type f -print | sort
+              )
+              if [[ "${#active_review_evidence[@]}" -eq 1 ]]; then
+                review_evidence_paths+=("${active_review_evidence[0]}")
+              fi
             fi
           fi
           if [[ "${#review_evidence_paths[@]}" -gt 1 \
@@ -1288,7 +1570,12 @@ jobs:
           fi
           "${evidence_arguments[@]}"
           cmp --silent "$consumer_plan" artifacts/requirements-evidence/requirements-evidence-plan.json
-          if [[ "$required_maturity" == "planned" ]]; then
+          if [[ "$EVIDENCE_PROMOTION_REUSE" == "true" ]]; then
+            test -s artifacts/requirements-evidence/final-verification/requirements-promotion-reuse.json
+            cp "$consumer_planning_report" "$consumer_report"
+            jq -e '.gate_decision == "pass" and (.plan.cases | length > 0)' \
+              "$consumer_report" > /dev/null
+          elif [[ "$required_maturity" == "planned" ]]; then
             cp "$consumer_planning_report" "$consumer_report"
           else
             consumer_junit="${RUNNER_TEMP}/requirements-proof-consumer.xml"
@@ -1441,7 +1728,7 @@ jobs:
               "${isolated_python[@]}" "$TRUSTED_PROOF_PROVENANCE" \
                 --prior-red-proof "$prior_red_proof" \
                 --repo-root "$GITHUB_WORKSPACE" \
-                --base-ref "$evidence_base_commit" \
+                --base-ref "${evidence_base_commit}" \
                 --final-ref "$source_ref"
               reconciliation_arguments+=(--prior-red-proof "$prior_red_proof")
             elif [[ -s "$legacy_tdd_evidence" && -s "$legacy_tdd_ledger" ]]; then
@@ -1486,6 +1773,8 @@ jobs:
 
       - name: Prepare fresh Requirements execution artifact
         if: always()
+        env:
+          EVIDENCE_PROMOTION_REUSE: ${{ steps.execution-promotion.outputs.active }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1498,6 +1787,9 @@ jobs:
             cp "${RUNNER_TEMP}/requirements-proof-consumer.xml" \
               "$final_root/requirements-proof.xml"
           fi
+          if [[ "$EVIDENCE_PROMOTION_REUSE" == "true" ]]; then
+            test -s "$final_root/requirements-promotion-reuse.json"
+          fi
 
       - name: Persist fresh Requirements execution artifact
         id: upload-fresh-requirements-evidence
@@ -1505,7 +1797,10 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: requirements-evidence-execution
-          path: artifacts/requirements-evidence/final-verification
+          path: |
+            artifacts/requirements-evidence/final-verification/requirements-evidence-plan.json
+            artifacts/requirements-evidence/final-verification/requirements-proof.xml
+            artifacts/requirements-evidence/final-verification/requirements-promotion-reuse.json
           if-no-files-found: error
 
       - name: Run Code Review with finalized Requirements context
@@ -1765,6 +2060,136 @@ jobs:
           artifact-ids: ${{ needs.requirements-evidence.outputs.artifact-id }}
           path: ${{ runner.temp }}/requirements-execution
 
+      - name: Checkout trusted promotion authority policy for final verdict
+        if: >-
+          github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'dev' && github.event.pull_request.base.repo.id == github.event.repository.id && github.event.pull_request.head.repo.id == github.event.repository.id && github.event.pull_request.base.repo.full_name == github.event.repository.full_name && github.event.pull_request.head.repo.full_name == github.event.repository.full_name
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          repository: nold-ai/.github
+          path: promotion-authority-policy-final
+          ref: f7a22379f88010d77c86f9b2bbaf1ac58f15d85d
+          persist-credentials: false
+
+      - name: Authenticate protected promotion head for final verdict
+        if: >-
+          github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'dev' && github.event.pull_request.base.repo.id == github.event.repository.id && github.event.pull_request.head.repo.id == github.event.repository.id && github.event.pull_request.base.repo.full_name == github.event.repository.full_name && github.event.pull_request.head.repo.full_name == github.event.repository.full_name
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          trusted_policy_commit="f7a22379f88010d77c86f9b2bbaf1ac58f15d85d"
+          trusted_policy_tree="47f33b4df92060a36f3afd92948e441555fb280d"
+          trusted_policy_blob="8c7b30020033c6b6081d6e743d77aa76043724ea"
+          trusted_policy_digest="5441e26e7c3c8f18973c781e7d43c72076b3283c915d98ca5188bb174bf17c45"
+          trusted_policy_root="${GITHUB_WORKSPACE}/promotion-authority-policy-final"
+          trusted_policy_script="$trusted_policy_root/.github/scripts/trusted_requirements_authority.py"
+          test "$(git -C "$trusted_policy_root" remote get-url origin)" = "https://github.com/nold-ai/.github"
+          test "$(git -C "$trusted_policy_root" rev-parse HEAD)" = "$trusted_policy_commit"
+          test "$(git -C "$trusted_policy_root" rev-parse 'HEAD^{tree}')" = "$trusted_policy_tree"
+          test "$(git -C "$trusted_policy_root" rev-parse 'HEAD:.github/scripts/trusted_requirements_authority.py')" = "$trusted_policy_blob"
+          test "$(sha256sum < "$trusted_policy_script" | cut -d ' ' -f 1)" = "$trusted_policy_digest"
+          GITHUB_API_URL="https://api.github.com" \
+            "${pythonLocation}/bin/python" -I -S \
+              "${GITHUB_WORKSPACE}/promotion-authority-policy-final/.github/scripts/trusted_requirements_authority.py" \
+              --event "$GITHUB_EVENT_PATH"
+
+      - name: Fetch protected promotion evidence for final verdict
+        if: >-
+          github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'dev' && github.event.pull_request.base.repo.id == github.event.repository.id && github.event.pull_request.head.repo.id == github.event.repository.id && github.event.pull_request.base.repo.full_name == github.event.repository.full_name && github.event.pull_request.head.repo.full_name == github.event.repository.full_name
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          metadata_root="${RUNNER_TEMP}/promotion-final-promotion"
+          mkdir -p "$metadata_root"
+          git fetch --no-tags origin \
+            "+refs/heads/main:refs/remotes/origin/main" \
+            "+refs/heads/dev:refs/remotes/origin/dev"
+          base_sha="$(jq -er '.pull_request.base.sha | select(type == "string" and test("^[0-9a-f]{40}$"))' "$GITHUB_EVENT_PATH")"
+          head_sha="$(jq -er '.pull_request.head.sha | select(type == "string" and test("^[0-9a-f]{40}$"))' "$GITHUB_EVENT_PATH")"
+          test "$(git rev-parse HEAD)" = "$head_sha"
+          test "$(git rev-parse 'HEAD^{tree}')" = "$(git rev-parse "${head_sha}^{tree}")"
+          test "$(git rev-parse 'refs/remotes/origin/main^{commit}')" = "$base_sha"
+          test "$(git rev-parse 'refs/remotes/origin/dev^{commit}')" = "$head_sha"
+          test "$(git cat-file -t "$base_sha")" = commit
+          test "$(git cat-file -t "$head_sha")" = commit
+          git merge-base --is-ancestor "$base_sha" "$head_sha"
+          read -r merge_sha previous_dev source_head extra_parent < <(git rev-list --parents -n 1 "$head_sha")
+          test "$merge_sha" = "$head_sha"
+          test -n "$previous_dev"
+          test -n "$source_head"
+          test -z "${extra_parent:-}"
+          test "$(git cat-file -t "$previous_dev")" = commit
+          test "$(git cat-file -t "$source_head")" = commit
+          gh api --method GET --paginate --slurp \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${GITHUB_REPOSITORY}/commits/${source_head}/pulls?per_page=100" \
+            > "$metadata_root/source-pulls-pages.json"
+          jq -e '[.[][]]' "$metadata_root/source-pulls-pages.json" > "$metadata_root/source-pulls.json"
+          gh api --method GET --paginate --slurp \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${GITHUB_REPOSITORY}/commits/${source_head}/check-runs?per_page=100" \
+            > "$metadata_root/check-runs-pages.json"
+          jq -e \
+            '{total_count: (.[0].total_count // 0), check_runs: [.[].check_runs[]]}' \
+            "$metadata_root/check-runs-pages.json" > "$metadata_root/check-runs.json"
+          requirements_run_id="$(jq -er '
+            [.check_runs[] | select(.name == "Requirements evidence")] |
+            if length == 1 then .[0].details_url |
+              capture("/actions/runs/(?<run_id>[0-9]+)/job/[0-9]+$").run_id
+            else error("expected one Requirements evidence check") end
+          ' "$metadata_root/check-runs.json")"
+          authority_run_id="$(jq -er '
+            [.check_runs[] | select(.name == "Trusted Requirements Authority")] |
+            if length == 1 then .[0].details_url |
+              capture("/actions/runs/(?<run_id>[0-9]+)/job/[0-9]+$").run_id
+            else error("expected one Trusted Requirements Authority check") end
+          ' "$metadata_root/check-runs.json")"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${requirements_run_id}" > "$metadata_root/requirements-run.json"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${authority_run_id}" > "$metadata_root/authority-run.json"
+          gh api --method GET --paginate --slurp \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${requirements_run_id}/artifacts?per_page=100" \
+            > "$metadata_root/artifacts-pages.json"
+          jq -e \
+            '{total_count: (.[0].total_count // 0), artifacts: [.[].artifacts[]]}' \
+            "$metadata_root/artifacts-pages.json" > "$metadata_root/artifacts.json"
+          producer_artifact_id="$(jq -er '
+            [.artifacts[] | select(.name == "requirements-evidence")] |
+            if length == 1 then .[0].id else error("expected one producer artifact") end
+          ' "$metadata_root/artifacts.json")"
+          execution_artifact_id="$(jq -er '
+            [.artifacts[] | select(.name == "requirements-evidence-execution")] |
+            if length == 1 then .[0].id else error("expected one execution artifact") end
+          ' "$metadata_root/artifacts.json")"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${producer_artifact_id}/zip" > "$metadata_root/producer.zip"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${execution_artifact_id}/zip" > "$metadata_root/execution.zip"
+
+      - name: Validate protected promotion evidence for final verdict
+        id: final-promotion
+        if: >-
+          github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'dev' && github.event.pull_request.base.repo.id == github.event.repository.id && github.event.pull_request.head.repo.id == github.event.repository.id && github.event.pull_request.base.repo.full_name == github.event.repository.full_name && github.event.pull_request.head.repo.full_name == github.event.repository.full_name
+        shell: bash
+        run: |
+          set -euo pipefail
+          output="${RUNNER_TEMP}/final-promotion-reuse.json"
+          mkdir -p "$(dirname "$output")"
+          "${FINAL_VERIFIER_ROOT}/bin/python" -I -S scripts/requirements_promotion_reuse.py \
+            --event "$GITHUB_EVENT_PATH" \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --source-pulls "${RUNNER_TEMP}/promotion-final-promotion/source-pulls.json" \
+            --check-runs "${RUNNER_TEMP}/promotion-final-promotion/check-runs.json" \
+            --requirements-run "${RUNNER_TEMP}/promotion-final-promotion/requirements-run.json" \
+            --authority-run "${RUNNER_TEMP}/promotion-final-promotion/authority-run.json" \
+            --artifacts "${RUNNER_TEMP}/promotion-final-promotion/artifacts.json" \
+            --producer-archive "${RUNNER_TEMP}/promotion-final-promotion/producer.zip" \
+            --execution-archive "${RUNNER_TEMP}/promotion-final-promotion/execution.zip" \
+            --expected-attestation "${RUNNER_TEMP}/requirements-execution/requirements-promotion-reuse.json" \
+            --output "${RUNNER_TEMP}/final-promotion-reuse.json"
+          cmp --silent "${RUNNER_TEMP}/final-promotion-reuse.json" "${RUNNER_TEMP}/requirements-execution/requirements-promotion-reuse.json"
+          printf 'active=true\n' >> "$GITHUB_OUTPUT"
+
       - name: Restore producer Requirements evidence for final verdict
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
@@ -1870,6 +2295,7 @@ jobs:
 
       - name: Reconcile final Requirements verdict on fresh runner
         env:
+          EVIDENCE_PROMOTION_REUSE: ${{ steps.final-promotion.outputs.active }}
           LATE_RED_ACTIVE: ${{ github.event.pull_request.number == 704 && github.head_ref == 'bugfix/692-release-review-followup' && hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') != '' }}
           PRIOR_RED_HEAD_SHA: ${{ steps.final-retained-red.outputs.head-sha }}
         shell: bash
@@ -1920,6 +2346,9 @@ jobs:
           if [[ "$required_maturity" == "verified" ]]; then
             planning_maturity=test-authored
           fi
+          if [[ "$EVIDENCE_PROMOTION_REUSE" == "true" ]]; then
+            planning_maturity=planned
+          fi
 
           final_change_paths_file="${RUNNER_TEMP}/final-change-paths.z"
           git diff --name-only -z --diff-filter=ACMRD "$FINAL_BASE_COMMIT..$source_ref" -- openspec/changes/ \
@@ -1938,21 +2367,25 @@ jobs:
             esac
           done < "$final_change_paths_file"
           review_evidence_paths=()
-          if [[ "${#final_changed_change_ids[@]}" -eq 1 ]]; then
-            for selected_change in "${!final_changed_change_ids[@]}"; do
-              :
-            done
-            review_evidence_paths+=("openspec/changes/${selected_change}/requirements-proof/review-evidence.json")
-          elif [[ "${#final_changed_change_ids[@]}" -gt 1 ]]; then
-            printf 'Final reconciliation found multiple changed active OpenSpec changes.\n' >&2
-            exit 1
+          if [[ "$EVIDENCE_PROMOTION_REUSE" != "true" ]]; then
+            if [[ "${#final_changed_change_ids[@]}" -eq 1 ]]; then
+              for selected_change in "${!final_changed_change_ids[@]}"; do
+                :
+              done
+              review_evidence_paths+=("openspec/changes/${selected_change}/requirements-proof/review-evidence.json")
+            elif [[ "${#final_changed_change_ids[@]}" -gt 1 ]]; then
+              printf 'Final reconciliation found multiple changed active OpenSpec changes.\n' >&2
+              exit 1
+            fi
           fi
-          if [[ "${#review_evidence_paths[@]}" -eq 0 ]]; then
-            mapfile -t active_review_evidence < <(
-              find openspec/changes -path 'openspec/changes/archive' -prune -o -path '*/requirements-proof/review-evidence.json' -type f -print | sort
-            )
-            if [[ "${#active_review_evidence[@]}" -eq 1 ]]; then
-              review_evidence_paths+=("${active_review_evidence[0]}")
+          if [[ "$EVIDENCE_PROMOTION_REUSE" != "true" ]]; then
+            if [[ "${#review_evidence_paths[@]}" -eq 0 ]]; then
+              mapfile -t active_review_evidence < <(
+                find openspec/changes -path 'openspec/changes/archive' -prune -o -path '*/requirements-proof/review-evidence.json' -type f -print | sort
+              )
+              if [[ "${#active_review_evidence[@]}" -eq 1 ]]; then
+                review_evidence_paths+=("${active_review_evidence[0]}")
+              fi
             fi
           fi
           if [[ "${#review_evidence_paths[@]}" -gt 1 \
@@ -1984,7 +2417,14 @@ jobs:
           fi
           "${evidence_arguments[@]}"
           cmp --silent "$final_plan" "$execution_plan"
-          if [[ "$required_maturity" == "planned" ]]; then
+          if [[ "$EVIDENCE_PROMOTION_REUSE" == "true" ]]; then
+            test -s "$execution_root/requirements-promotion-reuse.json"
+            cp "$final_planning_report" "$final_report"
+            jq -e '.gate_decision == "pass" and (.plan.cases | length > 0)' \
+              "$final_report" > /dev/null
+            cat "$final_summary" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          elif [[ "$required_maturity" == "planned" ]]; then
             cp "$final_planning_report" "$final_report"
             jq -e '.gate_decision == "pass"' "$final_report" > /dev/null
             cat "$final_summary" >> "$GITHUB_STEP_SUMMARY"
@@ -2030,7 +2470,7 @@ jobs:
             "${isolated_python[@]}" "$FINAL_TRUSTED_PROVENANCE" \
               --prior-red-proof "$prior_red_proof" \
               --repo-root "$GITHUB_WORKSPACE" \
-              --base-ref "$FINAL_BASE_COMMIT" \
+              --base-ref "${FINAL_BASE_COMMIT}" \
               --final-ref "$source_ref"
             reconciliation_arguments+=(--prior-red-proof "$prior_red_proof")
           elif [[ -s "$legacy_tdd_evidence" && -s "$legacy_tdd_ledger" ]]; then

--- a/openspec/changes/fix-release-promotion-requirements-parity/.openspec.yaml
+++ b/openspec/changes/fix-release-promotion-requirements-parity/.openspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-09-04
+goal: Make release promotion PRs pass Requirements without weakening ordinary PR
+  validation.

--- a/openspec/changes/fix-release-promotion-requirements-parity/README.md
+++ b/openspec/changes/fix-release-promotion-requirements-parity/README.md
@@ -1,0 +1,3 @@
+# fix-release-promotion-requirements-parity
+
+Allow only authenticated same-repository dev-to-main promotions to reuse the Requirements validation already enforced at the protected dev boundary.

--- a/openspec/changes/fix-release-promotion-requirements-parity/TDD_EVIDENCE.md
+++ b/openspec/changes/fix-release-promotion-requirements-parity/TDD_EVIDENCE.md
@@ -3,7 +3,7 @@
 ## RED — 2026-09-05
 
 The specification commit `2b2b3078` preceded test authoring. Against the
-unchanged `origin/dev` implementation, the four mapped selectors failed for the
+unchanged `origin/dev` implementation, the five mapped selectors failed for the
 intended missing behavior:
 
 ```text
@@ -22,16 +22,108 @@ was not implemented. Both workflow selectors reported that the promotion
 checkout/validation steps were absent. Collection succeeded, so these are
 behavior-level RED results rather than setup or selector failures.
 
-Two independent read-only reviews then strengthened the same four selectors to
+Two independent read-only reviews then strengthened the same five selectors to
 cover real commit-to-PR API multiplicity, same-named forks, nonempty
 plan/JUnit binding, complete paginated metadata, executable central-validator
 pin checks, the public CLI boundary, exact attestation byte transport, and the
 unchanged main-relative aggregate planning scope. The rerun above is against
-that final RED contract.
+that then-current RED contract.
+
+PR review then identified two test-contract corrections without changing any
+mapped selector or requirement: GitHub artifact identifiers are opaque positive
+integers, so the invalid-identifier control uses zero instead of assuming a
+specific valid value; and the real-Git control excludes ambient configuration,
+hooks, and templates. Each correction was committed append-only before
+implementation.
+
+Post-patch review then exercised the accepted selector against the real PR #704
+evidence shape. It found that per-source mapping digests correctly differ from
+the aggregate mapping digest and that the canonical report sorts selectors
+while the plan and JUnit retain execution order. The existing acceptance
+selector was strengthened append-only with those valid conditions and a
+duplicate-selector rejection control. Before the fix, the focused accepted
+promotion selector failed in `_validate_plan_sources` with
+`promotion-reuse-invalid`. A second append-only test-only commit added malformed
+source-name/digest and duplicate-source rejection controls under the existing
+negative selector. That review-cycle RED proof is bound as follows:
+
+- commit: `27a3d6aba5d89d4aebe79b6d83c5c31b294ad56b`
+- tree: `dfaf3261083a7ae2323e128855b6c60f87df3fb1`
+- GitHub Actions run: `33993567501`
+- artifact: `9977366170` (`requirements-evidence`)
+- evidence JSON SHA-256:
+  `a7db07d98637f891d1f995f7e3999cb7f1f092c0923b9c1b48b5ceb47d98ad46`
+- JUnit SHA-256:
+  `5398b5ac3c2cf1d80683852a4de01a70e56030349b628a3754bc9f43842a2412`
+- result: five collected tests, five intended missing-behavior failures, and
+  zero provenance findings
+
+The mandatory clean-code review then required the validator's public boundary
+to group its nine authenticated inputs. The existing acceptance selector was
+strengthened to require that grouped boundary and committed test-only at
+`4f85630514ef91f2f5470b7e6441ac69a20ec601`. The final immutable RED proof is:
+
+- commit: `4f85630514ef91f2f5470b7e6441ac69a20ec601`
+- tree: `9a88aaf7c9ef0763a28b13c8ac44ff47525fdee9`
+- GitHub Actions run: `33994253343`
+- artifact: `9977565051` (`requirements-evidence`)
+- evidence JSON SHA-256:
+  `f6bdbb2abc7d4a78459b1b49dec03a9949dc85c306068bc436bae87a2a336708`
+- JUnit SHA-256:
+  `e79ca8a1dba592c119e9d9c0a9a7ff19a28cbd9b656ce69e5f5387dfc3a7daa6`
+- result: five collected tests, five intended missing-behavior failures, and
+  zero provenance findings
 
 The independently reviewed test-authored mapping digest is
-`sha256:9c34bb52969f9d9dd7c7caa41d686324f8f907ee0611e677e5615b27cdd21a1e`.
+`sha256:9c34bb52969f9d9dd7c7caa41d686324f8f907ee0611e677e5615b27cdd21a1e`,
+approved by the exact, unedited issue #692 MEMBER comment `5554670103`.
 
 ## GREEN
 
-Pending implementation and independent verification.
+The canonical validator and all three workflow validation stages now satisfy
+the five mapped selectors locally. The focused validator and workflow surface
+passes with 29 tests on Python 3.12. The mandatory code-review run
+`review-bb8895cd-2678-4578-8e71-c6c8306dc2a4` (report SHA-256
+`d13641a571900b6f35a4dcb5d9bcf6a10f0e1e2cfb2bbbf66b3c51327ae1b748`)
+reports no errors and no security findings. Its two contract warnings are
+retained intentionally: this validator
+runs in a separately provisioned, standard-library-only trust boundary, so
+importing project `icontract` dependencies would couple the verifier to the
+candidate environment it authenticates. The remaining informational
+length/complexity suggestion is retained because the expanded attestation
+assembly makes every authenticated field and output binding explicit; a
+comprehension collapse would reduce auditability without changing behavior.
+
+Verification completed on 2026-09-06 (Europe/Berlin):
+
+- focused validator/workflow suite: 29 passed
+- full Python 3.12 suite: 3,120 passed, 9 skipped, with three host-only
+  failures; the runtime-discovery and reproducible-delivery controls passed on
+  rerun with the immutable modules fixture, network access, and a task-local uv
+  cache, while the remaining test requires a write to the user's
+  `~/.specfact/metadata.json` and is deferred to the clean GitHub runner
+- real PR #704 producer/execution evidence: accepted 34 selectors with distinct
+  aggregate/source mapping digests and order-independent selector agreement
+- frozen runtime and Code Review dependency audits: passed with no unreviewed
+  vulnerabilities
+- Bandit high-severity scan and six-rule Semgrep SAST scan/gate: zero findings
+- strict OpenSpec validation, workflow lint, four module signatures, four-source
+  `0.55.4` version consistency, Ruff, and `git diff --check`: passed
+- public documentation review: no edit required because this is an internal
+  protected-branch release-control correction with no CLI or user-facing
+  contract change
+
+Independent post-patch security review found no actionable P0/P1/P2. A
+fresh-context reviewer challenged the use of the promotion-head validator in
+all three stages; independent boundary analysis rejected an
+ordinary-contributor bypass because each stage first runs the immutable central
+authority, which binds the exact repository, pull request, refs, commit/tree,
+unedited expiring approval, and a signer with live write/admin permission. A
+malicious validator therefore also requires a privileged merge and privileged
+authorization of that exact tree. The review retained three warnings without a
+demonstrated privilege path: optional `run.pull_requests` hardening, Bandit's
+bounded argv-only Git subprocess notices, and intentional repeated stage
+plumbing for independent revalidation. The documented two-parent merge
+requirement can reject squash/rebase promotions but fails closed.
+
+Final staged-tree hooks remain pending before the implementation commit.

--- a/openspec/changes/fix-release-promotion-requirements-parity/TDD_EVIDENCE.md
+++ b/openspec/changes/fix-release-promotion-requirements-parity/TDD_EVIDENCE.md
@@ -1,0 +1,37 @@
+# TDD Evidence
+
+## RED — 2026-09-05
+
+The specification commit `2b2b3078` preceded test authoring. Against the
+unchanged `origin/dev` implementation, the four mapped selectors failed for the
+intended missing behavior:
+
+```text
+pytest -q \
+  tests/unit/scripts/test_requirements_promotion_reuse.py::test_exact_protected_promotion_produces_canonical_attestation \
+  tests/unit/scripts/test_requirements_promotion_reuse.py::test_lookalike_promotion_is_rejected \
+  tests/unit/workflows/test_requirements_evidence_delivery_workflow.py::test_same_named_fork_does_not_enter_promotion_path \
+  tests/unit/scripts/test_requirements_promotion_reuse.py::test_incomplete_or_stale_promotion_provenance_is_rejected \
+  tests/unit/workflows/test_requirements_evidence_delivery_workflow.py::test_workflow_revalidates_promotion_reuse_in_all_stages
+
+5 failed in 0.45s
+```
+
+The three validator selectors reported that the protected-promotion validator
+was not implemented. Both workflow selectors reported that the promotion
+checkout/validation steps were absent. Collection succeeded, so these are
+behavior-level RED results rather than setup or selector failures.
+
+Two independent read-only reviews then strengthened the same four selectors to
+cover real commit-to-PR API multiplicity, same-named forks, nonempty
+plan/JUnit binding, complete paginated metadata, executable central-validator
+pin checks, the public CLI boundary, exact attestation byte transport, and the
+unchanged main-relative aggregate planning scope. The rerun above is against
+that final RED contract.
+
+The independently reviewed test-authored mapping digest is
+`sha256:9c34bb52969f9d9dd7c7caa41d686324f8f907ee0611e677e5615b27cdd21a1e`.
+
+## GREEN
+
+Pending implementation and independent verification.

--- a/openspec/changes/fix-release-promotion-requirements-parity/design.md
+++ b/openspec/changes/fix-release-promotion-requirements-parity/design.md
@@ -98,6 +98,12 @@ Requirements the sole promotion defense.
 
 ## Risks / Trade-offs
 
+- Promotion reuse supports only the repository's current two-parent merge
+  topology on `dev`. A squash or rebase merge can satisfy the live ruleset but
+  cannot prove the source-head/tree relationship required here, so the release
+  promotion fails closed. Mitigation: merge release-bound changes into `dev`
+  with a merge commit; otherwise rerun their Requirements evidence or extend
+  the provenance model in a separately reviewed change.
 - A privileged actor who bypasses repository-level `dev` protection could place
   unreviewed bytes on the promotion branch. Mitigation: the organization
   authority has no bypass actor; promotion reuse additionally requires the

--- a/openspec/changes/fix-release-promotion-requirements-parity/design.md
+++ b/openspec/changes/fix-release-promotion-requirements-parity/design.md
@@ -39,12 +39,20 @@ runtime, and test gates.
 
 The promotion predicate requires a pull-request event whose base and head
 repository IDs and full names equal the event repository, base ref is exactly
-`main`, and head ref is exactly `dev`. Producer, fresh execution, and final
-verification each require valid 40-hex event commits, exact checked-out and live
-remote tips, commit objects, and `main` ancestry of `dev`. A partial promotion
-match fails closed instead of falling back to ordinary pull-request behavior.
+`main`, and head ref is exactly `dev`. A fork or any other incomplete identity
+match remains on the ordinary pull-request path. After the complete identity
+matches, producer, fresh execution, and final verification each require valid
+40-hex event commits, exact checked-out and live remote tips, commit objects,
+and `main` ancestry of `dev`; any downstream mismatch fails closed.
 
 ### Authenticate the protected development result
+
+Before executing the candidate-tree promotion validator, each stage checks out
+the immutable central `nold-ai/.github` authority validator, verifies its exact
+commit, tree, script blob, and script SHA-256, and uses it to authenticate the
+current promotion pull request's repository, refs, head commit/tree, unedited
+member authority, expiry, and live permission. Candidate validator bytes are
+therefore never the first or sole authority for their own execution.
 
 The current `dev` tip must be a two-parent merge whose first parent is the
 merged pull request's recorded `dev` base and whose second parent is its exact
@@ -93,8 +101,9 @@ Requirements the sole promotion defense.
 - A privileged actor who bypasses repository-level `dev` protection could place
   unreviewed bytes on the promotion branch. Mitigation: the organization
   authority has no bypass actor; promotion reuse additionally requires the
-  exact-tree merged pull request's successful Requirements and authority runs,
-  while the promotion reruns all release gates.
+  current promotion tree's expiring member authority and the exact-tree merged
+  pull request's successful Requirements and authority runs, while the
+  promotion reruns all release gates.
 - A stale pull-request run could be mistaken for current evidence. Mitigation:
   every stage re-fetches run and artifact metadata and verifies exact live tips,
   source tree, expiry, and digests.

--- a/openspec/changes/fix-release-promotion-requirements-parity/design.md
+++ b/openspec/changes/fix-release-promotion-requirements-parity/design.md
@@ -1,0 +1,109 @@
+## Context
+
+The Requirements workflow derives one maturity for the entire pull-request diff
+and can bind one provider-neutral review-evidence record to one changed active
+OpenSpec change. That is correct for ordinary implementation pull requests. A
+release promotion is different: its diff is the accumulated, already-reviewed
+`dev` history, so multiple active planning and implementation changes are
+expected.
+
+Live rules protect both `dev` and `main` with pull requests, signed commits,
+required checks, resolved review threads, strict up-to-date checks, and the
+organization's external exact-head Requirements authority workflow. The release
+pull request also reruns the complete security, dependency, signature, build,
+runtime, and test gates.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Let the exact same-repository `dev` to `main` promotion reuse authenticated
+  Requirements validation from the merged pull request that produced the
+  current `dev` tree, without manufacturing one aggregate review acceptance.
+- Make fork, wrong-repository, wrong-base, wrong-head, stale-tip, divergent,
+  spoofed-check, expired-artifact, and digest-tampered cases fail closed.
+- Keep producer, fresh consumer, plan parity, final verifier, and prior artifact
+  authentication in agreement about the promotion classification.
+
+### Non-Goals
+
+- Support arbitrary multi-change implementation pull requests.
+- Trust a branch merely because its display name is `dev`.
+- Treat aggregate planning validation alone as production verification.
+- Skip external authority or any release security/quality gate.
+- Add a reusable exception or modify dependency/runtime behavior.
+
+## Decisions
+
+### Classify from immutable GitHub event and live Git identity
+
+The promotion predicate requires a pull-request event whose base and head
+repository IDs and full names equal the event repository, base ref is exactly
+`main`, and head ref is exactly `dev`. Producer, fresh execution, and final
+verification each require valid 40-hex event commits, exact checked-out and live
+remote tips, commit objects, and `main` ancestry of `dev`. A partial promotion
+match fails closed instead of falling back to ordinary pull-request behavior.
+
+### Authenticate the protected development result
+
+The current `dev` tip must be a two-parent merge whose first parent is the
+merged pull request's recorded `dev` base and whose second parent is its exact
+head commit. The source head tree must equal the current `dev` tree, so merge
+resolution cannot introduce unvalidated bytes. The GitHub API must return
+exactly one matching merged same-repository pull request.
+
+For that source head, the verifier requires unique successful check runs named
+`Requirements evidence` and `Trusted Requirements Authority`, both created by
+the GitHub Actions application. Their run metadata must bind the exact
+repository, pull-request event, source head and branch, completed/success state,
+and expected workflow path. The Requirements run must expose exactly one
+unexpired producer artifact and one unexpired fresh-execution artifact. Each
+artifact ID, run ID, repository/head identity, GitHub-recorded SHA-256 digest,
+downloaded archive digest, and required content is authenticated.
+
+The prior producer report must be a verified, implementation-verified pass for
+the exact source head, with mapping, plan, JUnit, and source bindings intact.
+The fresh-execution plan must be byte-identical to the producer plan.
+
+### Preserve proof transport and use a distinct reuse claim
+
+The promotion still generates a deterministic aggregate plan at planning
+maturity. The fresh runner regenerates and byte-compares that plan, and the
+final runner consumes the fresh execution artifact. Planning success alone is
+insufficient: a separate canonical `promotion-reused` attestation must pass.
+Producer, fresh execution, and final verification each independently re-fetch
+and revalidate live GitHub metadata and prior artifacts, then compare canonical
+attestation bytes. The report never claims that aggregate selectors were
+executed in the promotion run.
+
+The trusted main-relative verifier/core base, retained-RED ancestry, and both
+Code Review passes remain based on the real `main..dev` delta. Only duplicate
+aggregate Requirements selector execution is replaced by authenticated reuse.
+
+### Keep release defenses independent
+
+The organization authority check remains exact repository/pull request/branch/
+head/tree bound. The pull-request orchestrator still runs dependency trust,
+pip-audit, Socket, static analysis, module signatures, reproducible delivery,
+package/runtime matrices, and the full test suite. This change does not make
+Requirements the sole promotion defense.
+
+## Risks / Trade-offs
+
+- A privileged actor who bypasses repository-level `dev` protection could place
+  unreviewed bytes on the promotion branch. Mitigation: the organization
+  authority has no bypass actor; promotion reuse additionally requires the
+  exact-tree merged pull request's successful Requirements and authority runs,
+  while the promotion reruns all release gates.
+- A stale pull-request run could be mistaken for current evidence. Mitigation:
+  every stage re-fetches run and artifact metadata and verifies exact live tips,
+  source tree, expiry, and digests.
+- Predicate drift between stages could create inconsistent evidence.
+  Mitigation: one canonical validator and focused contract tests require the
+  same inputs and byte-identical attestation in producer, consumer, and final.
+
+## Rollback
+
+Revert the follow-up pull request. This restores the existing conservative
+failure on multi-change promotion pull requests without rewriting release
+history.

--- a/openspec/changes/fix-release-promotion-requirements-parity/proposal.md
+++ b/openspec/changes/fix-release-promotion-requirements-parity/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+PR #691 is the canonical `dev` to `main` release promotion, but the Requirements
+workflow treats the complete branch delta as one new implementation change. The
+delta contains ten independently governed active OpenSpec changes, while the
+workflow deliberately accepts review evidence for only one changed change. The
+release is therefore blocked with ten `acceptance-missing` findings even though
+the current tree already crossed the protected `dev` boundary.
+
+## What Changes
+
+- Recognize only a pull request from this repository's exact live `dev` ref to
+  this repository's exact live `main` ref as a release promotion.
+- Require immutable event commits and trees, checked-out head, live remote tips,
+  ancestry, and the merged pull request that produced the current `dev` tree.
+- Authenticate that merged pull request's successful GitHub-Actions
+  Requirements and external-authority checks plus their exact, unexpired,
+  digest-bound Requirements artifacts.
+- Keep producer, fresh execution, plan comparison, artifact, final-verdict, and
+  external authority jobs intact. Aggregate planning validation remains
+  necessary but cannot pass a promotion without a distinct authenticated reuse
+  attestation.
+- Preserve the existing single-change maturity and review-evidence behavior for
+  every other pull request, including forks and similarly named branches.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `trustworthy-green-checks`: permit an exact protected same-repository `dev` to
+  `main` promotion to reuse authenticated Requirements evidence from the pull
+  request that produced the current `dev` tree.
+
+## Impact
+
+- **Affected code:** `.github/workflows/requirements-evidence.yml`, one focused
+  promotion-attestation validator, and focused unit/workflow contract tests.
+- **Security:** the promotion verifier rejects missing, stale, spoofed, expired,
+  ambiguous, or digest-mismatched prior evidence. Every non-promotion pull
+  request retains existing fail-closed maturity, review-evidence, proof, and
+  artifact checks. The independently required exact-head authority workflow and
+  all release security/quality gates remain unchanged.
+- **Compatibility:** no CLI, API, dependency, lock, package, or runtime behavior
+  changes.
+- **Documentation:** no public docs, README, landing-page, or navigation change;
+  this internal release-governance correction is documented in its OpenSpec and
+  TDD evidence.
+- **Rollback:** revert the follow-up pull request. PR #691 will return to its
+  current fail-closed state; no package or tag is modified by this change.
+
+## Source Tracking
+
+- **GitHub Issue**: #692
+- **Issue URL**: <https://github.com/nold-ai/specfact-cli/issues/692>
+- **Repository**: nold-ai/specfact-cli
+- **Last Synced Status**: open; in progress; assigned; labels bug/openspec/QA/security

--- a/openspec/changes/fix-release-promotion-requirements-parity/proposal.md
+++ b/openspec/changes/fix-release-promotion-requirements-parity/proposal.md
@@ -13,6 +13,8 @@ the current tree already crossed the protected `dev` boundary.
   this repository's exact live `main` ref as a release promotion.
 - Require immutable event commits and trees, checked-out head, live remote tips,
   ancestry, and the merged pull request that produced the current `dev` tree.
+- Authenticate the current promotion tree first with the exact immutable
+  central authority validator and a live, expiring member authority comment.
 - Authenticate that merged pull request's successful GitHub-Actions
   Requirements and external-authority checks plus their exact, unexpired,
   digest-bound Requirements artifacts.
@@ -39,11 +41,12 @@ None.
 
 - **Affected code:** `.github/workflows/requirements-evidence.yml`, one focused
   promotion-attestation validator, and focused unit/workflow contract tests.
-- **Security:** the promotion verifier rejects missing, stale, spoofed, expired,
-  ambiguous, or digest-mismatched prior evidence. Every non-promotion pull
-  request retains existing fail-closed maturity, review-evidence, proof, and
-  artifact checks. The independently required exact-head authority workflow and
-  all release security/quality gates remain unchanged.
+- **Security:** the centrally authorized promotion verifier rejects missing,
+  stale, spoofed, expired, ambiguous, or digest-mismatched prior evidence.
+  Every non-promotion pull request retains existing fail-closed maturity,
+  review-evidence, proof, and artifact checks. The independently required
+  exact-head authority workflow and all release security/quality gates remain
+  unchanged.
 - **Compatibility:** no CLI, API, dependency, lock, package, or runtime behavior
   changes.
 - **Documentation:** no public docs, README, landing-page, or navigation change;

--- a/openspec/changes/fix-release-promotion-requirements-parity/requirements-evidence.yaml
+++ b/openspec/changes/fix-release-promotion-requirements-parity/requirements-evidence.yaml
@@ -1,0 +1,106 @@
+schema_version: "2"
+requirements:
+  openspec:fix-release-promotion-requirements-parity:trustworthy-green-checks:exact-release-promotion-reuses-protected-development-evidence:
+    rationale: >-
+      A release promotion must not invent aggregate approvals or treat planning
+      validation alone as production verification.
+    stakeholder_refs:
+      - "nold-ai/specfact-cli#692"
+    touchpoints:
+      - id: requirements-evidence-workflow
+        kind: ci_workflow
+        locator: ".github/workflows/requirements-evidence.yml"
+      - id: promotion-reuse-validator
+        kind: source_file
+        locator: "scripts/requirements_promotion_reuse.py"
+      - id: workflow-contract-tests
+        kind: test_file
+        locator: "tests/unit/workflows/test_requirements_evidence_delivery_workflow.py"
+      - id: promotion-reuse-tests
+        kind: test_file
+        locator: "tests/unit/scripts/test_requirements_promotion_reuse.py"
+    verification_cases:
+      - case_id: REQ-PROMOTION-001
+        scenario_id: exact-release-promotion-reuses-protected-development-evidence
+        method: inspection
+        intent: >-
+          Inspect the exact protected-promotion boundary before authoring its
+          validator and workflow regressions.
+        observable: >-
+          Repository identity, exact refs and live tips, ancestry, aggregate
+          planning, and a distinct reuse attestation are all required.
+  openspec:fix-release-promotion-requirements-parity:trustworthy-green-checks:lookalike-promotions-retain-ordinary-proof-requirements:
+    rationale: >-
+      A fork or similarly named branch must not gain the protected-promotion
+      trust path.
+    stakeholder_refs:
+      - "nold-ai/specfact-cli#692"
+    touchpoints:
+      - id: requirements-evidence-workflow
+        kind: ci_workflow
+        locator: ".github/workflows/requirements-evidence.yml"
+      - id: workflow-contract-tests
+        kind: test_file
+        locator: "tests/unit/workflows/test_requirements_evidence_delivery_workflow.py"
+    verification_cases:
+      - case_id: REQ-PROMOTION-002
+        scenario_id: lookalike-promotions-retain-ordinary-proof-requirements
+        method: inspection
+        intent: >-
+          Inspect the fork, wrong-repository, wrong-base, and wrong-head
+          rejection contract before authoring its workflow regression.
+        observable: >-
+          Every non-matching pull request retains ordinary maturity and proof
+          handling.
+  openspec:fix-release-promotion-requirements-parity:trustworthy-green-checks:promotion-reuse-authenticates-complete-prior-provenance:
+    rationale: >-
+      Only exact-tree, successful, GitHub-Actions-produced and digest-bound
+      prior evidence may replace duplicate aggregate selector execution.
+    stakeholder_refs:
+      - "nold-ai/specfact-cli#692"
+    touchpoints:
+      - id: requirements-evidence-workflow
+        kind: ci_workflow
+        locator: ".github/workflows/requirements-evidence.yml"
+      - id: promotion-reuse-validator
+        kind: source_file
+        locator: "scripts/requirements_promotion_reuse.py"
+      - id: promotion-reuse-tests
+        kind: test_file
+        locator: "tests/unit/scripts/test_requirements_promotion_reuse.py"
+    verification_cases:
+      - case_id: REQ-PROMOTION-003
+        scenario_id: promotion-reuse-authenticates-complete-prior-provenance
+        method: inspection
+        intent: >-
+          Inspect the fail-closed provenance contract before authoring its
+          validator and workflow regressions.
+        observable: >-
+          Missing, stale, spoofed, ambiguous, expired, or digest-mismatched
+          promotion evidence cannot produce a passing attestation.
+  openspec:fix-release-promotion-requirements-parity:trustworthy-green-checks:promotion-stages-independently-validate-reuse:
+    rationale: >-
+      No producer-controlled boolean may substitute for live validation by the
+      fresh consumer and final required check.
+    stakeholder_refs:
+      - "nold-ai/specfact-cli#692"
+    touchpoints:
+      - id: requirements-evidence-workflow
+        kind: ci_workflow
+        locator: ".github/workflows/requirements-evidence.yml"
+      - id: promotion-reuse-validator
+        kind: source_file
+        locator: "scripts/requirements_promotion_reuse.py"
+      - id: workflow-contract-tests
+        kind: test_file
+        locator: "tests/unit/workflows/test_requirements_evidence_delivery_workflow.py"
+    verification_cases:
+      - case_id: REQ-PROMOTION-004
+        scenario_id: promotion-stages-independently-validate-reuse
+        method: inspection
+        intent: >-
+          Inspect the independent stage and main-relative trust-boundary
+          contract before authoring its workflow regression.
+        observable: >-
+          Producer, execution, and final independently validate byte-identical
+          attestations while trusted inputs and Code Review stay main-relative.

--- a/openspec/changes/fix-release-promotion-requirements-parity/requirements-evidence.yaml
+++ b/openspec/changes/fix-release-promotion-requirements-parity/requirements-evidence.yaml
@@ -22,13 +22,16 @@ requirements:
     verification_cases:
       - case_id: REQ-PROMOTION-001
         scenario_id: exact-release-promotion-reuses-protected-development-evidence
-        method: inspection
+        method: test
         intent: >-
           Inspect the exact protected-promotion boundary before authoring its
           validator and workflow regressions.
         observable: >-
           Repository identity, exact refs and live tips, ancestry, aggregate
           planning, and a distinct reuse attestation are all required.
+        selector:
+          runner: pytest
+          node_id: tests/unit/scripts/test_requirements_promotion_reuse.py::test_exact_protected_promotion_produces_canonical_attestation
   openspec:fix-release-promotion-requirements-parity:trustworthy-green-checks:lookalike-promotions-retain-ordinary-proof-requirements:
     rationale: >-
       A fork or similarly named branch must not gain the protected-promotion
@@ -39,19 +42,41 @@ requirements:
       - id: requirements-evidence-workflow
         kind: ci_workflow
         locator: ".github/workflows/requirements-evidence.yml"
+      - id: promotion-reuse-validator
+        kind: source_file
+        locator: "scripts/requirements_promotion_reuse.py"
       - id: workflow-contract-tests
         kind: test_file
         locator: "tests/unit/workflows/test_requirements_evidence_delivery_workflow.py"
+      - id: promotion-reuse-tests
+        kind: test_file
+        locator: "tests/unit/scripts/test_requirements_promotion_reuse.py"
     verification_cases:
       - case_id: REQ-PROMOTION-002
         scenario_id: lookalike-promotions-retain-ordinary-proof-requirements
-        method: inspection
+        method: test
         intent: >-
           Inspect the fork, wrong-repository, wrong-base, and wrong-head
           rejection contract before authoring its workflow regression.
         observable: >-
           Every non-matching pull request retains ordinary maturity and proof
           handling.
+        selector:
+          runner: pytest
+          node_id: tests/unit/scripts/test_requirements_promotion_reuse.py::test_lookalike_promotion_is_rejected
+      - case_id: REQ-PROMOTION-002B
+        scenario_id: lookalike-promotions-retain-ordinary-proof-requirements
+        method: test
+        intent: >-
+          Verify the workflow promotion predicate includes exact base and head
+          repository identities, so a same-named fork stays on the ordinary
+          Requirements path.
+        observable: >-
+          Promotion-only steps remain unreachable for a `dev` branch from any
+          other repository identity.
+        selector:
+          runner: pytest
+          node_id: tests/unit/workflows/test_requirements_evidence_delivery_workflow.py::test_same_named_fork_does_not_enter_promotion_path
   openspec:fix-release-promotion-requirements-parity:trustworthy-green-checks:promotion-reuse-authenticates-complete-prior-provenance:
     rationale: >-
       Only exact-tree, successful, GitHub-Actions-produced and digest-bound
@@ -71,13 +96,16 @@ requirements:
     verification_cases:
       - case_id: REQ-PROMOTION-003
         scenario_id: promotion-reuse-authenticates-complete-prior-provenance
-        method: inspection
+        method: test
         intent: >-
           Inspect the fail-closed provenance contract before authoring its
           validator and workflow regressions.
         observable: >-
           Missing, stale, spoofed, ambiguous, expired, or digest-mismatched
           promotion evidence cannot produce a passing attestation.
+        selector:
+          runner: pytest
+          node_id: tests/unit/scripts/test_requirements_promotion_reuse.py::test_incomplete_or_stale_promotion_provenance_is_rejected
   openspec:fix-release-promotion-requirements-parity:trustworthy-green-checks:promotion-stages-independently-validate-reuse:
     rationale: >-
       No producer-controlled boolean may substitute for live validation by the
@@ -97,10 +125,13 @@ requirements:
     verification_cases:
       - case_id: REQ-PROMOTION-004
         scenario_id: promotion-stages-independently-validate-reuse
-        method: inspection
+        method: test
         intent: >-
           Inspect the independent stage and main-relative trust-boundary
           contract before authoring its workflow regression.
         observable: >-
           Producer, execution, and final independently validate byte-identical
           attestations while trusted inputs and Code Review stay main-relative.
+        selector:
+          runner: pytest
+          node_id: tests/unit/workflows/test_requirements_evidence_delivery_workflow.py::test_workflow_revalidates_promotion_reuse_in_all_stages

--- a/openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/review-evidence.json
+++ b/openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/review-evidence.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "1",
+  "decision": "accepted",
+  "reviewer_id": "djm81",
+  "reviewer_role": "MEMBER",
+  "recorded_at": "2026-09-05T20:45:50Z",
+  "reference": "https://github.com/nold-ai/specfact-cli/issues/692#issuecomment-5554670103",
+  "mapping_digest": "sha256:9c34bb52969f9d9dd7c7caa41d686324f8f907ee0611e677e5615b27cdd21a1e"
+}

--- a/openspec/changes/fix-release-promotion-requirements-parity/specs/trustworthy-green-checks/spec.md
+++ b/openspec/changes/fix-release-promotion-requirements-parity/specs/trustworthy-green-checks/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Exact release promotion reuses protected development evidence
+
+The Requirements workflow SHALL recognize a release promotion only when a
+GitHub pull-request event identifies the same repository as both base and head,
+the base ref is exactly `main`, the head ref is exactly `dev`, every Requirements
+stage is checked out at the event's exact head commit, live `main` and `dev` tips
+equal the event commits, and `main` is an ancestor of `dev`. The workflow SHALL
+require both deterministic aggregate planning validation and a distinct
+authenticated `promotion-reused` attestation instead of one synthetic review
+acceptance for the accumulated active OpenSpec changes.
+
+#### Scenario: Exact protected development promotion is accepted
+
+- **GIVEN** a pull request whose base and head repository identities equal the
+  event repository
+- **AND** the exact refs are `main` and `dev`
+- **AND** the event commits equal the checked-out and live remote tips and
+  `main` is an ancestor of `dev`
+- **WHEN** the accumulated branch delta contains multiple active OpenSpec
+  changes
+- **THEN** each stage SHALL validate the deterministic aggregate plan and the
+  canonical `promotion-reused` attestation
+- **AND** SHALL NOT require a fabricated aggregate review-evidence record.
+
+### Requirement: Lookalike promotions retain ordinary proof requirements
+
+Every pull request that does not satisfy the complete protected-promotion
+identity SHALL retain the existing single-change maturity and proof requirements.
+
+#### Scenario: Lookalike promotion remains fail closed
+
+- **GIVEN** a pull request from a fork, another repository identity, another
+  base, or a branch merely named similarly to `dev`
+- **WHEN** the Requirements workflow classifies the pull request
+- **THEN** it SHALL NOT use the release-promotion path
+- **AND** the existing changed-path maturity, single-change acceptance, proof,
+  and artifact rules SHALL remain enforced.
+
+### Requirement: Promotion reuse authenticates complete prior provenance
+
+The workflow SHALL authenticate the unique merged pull request that produced
+the exact current `dev` tree, that pull request's successful GitHub-Actions
+Requirements and external-authority runs, and the Requirements run's exact
+unexpired, digest-bound producer and fresh-execution artifacts.
+
+#### Scenario: Promotion provenance is incomplete or stale
+
+- **GIVEN** an otherwise exact same-repository `dev` to `main` event
+- **WHEN** any commit, tree, live tip, ancestry, source pull request, check run,
+  workflow, application, artifact identity, expiry, digest, report, plan, or
+  JUnit binding is absent, ambiguous, stale, unsuccessful, or mismatched
+- **THEN** that stage SHALL fail closed before accepting promotion reuse.
+
+### Requirement: Promotion stages independently validate reuse
+
+Producer, fresh execution, and final verification SHALL each fetch and validate
+the live source evidence and SHALL agree on one canonical promotion attestation.
+Trusted core, retained-RED ancestry, Code Review, and release gates SHALL remain
+`main`-relative.
+
+#### Scenario: Promotion stages independently agree
+
+- **GIVEN** the producer emitted a canonical `promotion-reused` attestation
+- **WHEN** the fresh consumer and final verifier evaluate the promotion
+- **THEN** each SHALL independently fetch and validate the live source evidence
+- **AND** SHALL require its canonical attestation bytes to equal the prior-stage
+  attestation
+- **AND** trusted core, retained-RED ancestry, Code Review, and release gates
+  SHALL remain `main`-relative.

--- a/openspec/changes/fix-release-promotion-requirements-parity/specs/trustworthy-green-checks/spec.md
+++ b/openspec/changes/fix-release-promotion-requirements-parity/specs/trustworthy-green-checks/spec.md
@@ -7,9 +7,10 @@ GitHub pull-request event identifies the same repository as both base and head,
 the base ref is exactly `main`, the head ref is exactly `dev`, every Requirements
 stage is checked out at the event's exact head commit, live `main` and `dev` tips
 equal the event commits, and `main` is an ancestor of `dev`. The workflow SHALL
-require both deterministic aggregate planning validation and a distinct
-authenticated `promotion-reused` attestation instead of one synthetic review
-acceptance for the accumulated active OpenSpec changes.
+first authenticate the candidate tree with an immutable centrally pinned
+authority validator, then require both deterministic aggregate planning
+validation and a distinct authenticated `promotion-reused` attestation instead
+of one synthetic review acceptance for the accumulated active OpenSpec changes.
 
 #### Scenario: Exact protected development promotion is accepted
 
@@ -18,6 +19,8 @@ acceptance for the accumulated active OpenSpec changes.
 - **AND** the exact refs are `main` and `dev`
 - **AND** the event commits equal the checked-out and live remote tips and
   `main` is an ancestor of `dev`
+- **AND** the current head has a live, expiring, unedited member authority
+  accepted by the exact pinned central validator bytes
 - **WHEN** the accumulated branch delta contains multiple active OpenSpec
   changes
 - **THEN** each stage SHALL validate the deterministic aggregate plan and the
@@ -40,17 +43,19 @@ identity SHALL retain the existing single-change maturity and proof requirements
 
 ### Requirement: Promotion reuse authenticates complete prior provenance
 
-The workflow SHALL authenticate the unique merged pull request that produced
-the exact current `dev` tree, that pull request's successful GitHub-Actions
-Requirements and external-authority runs, and the Requirements run's exact
-unexpired, digest-bound producer and fresh-execution artifacts.
+The workflow SHALL authenticate its current candidate tree with exact pinned
+central authority bytes, then authenticate the unique merged pull request that
+produced the exact current `dev` tree, that pull request's successful
+GitHub-Actions Requirements and external-authority runs, and the Requirements
+run's exact unexpired, digest-bound producer and fresh-execution artifacts.
 
 #### Scenario: Promotion provenance is incomplete or stale
 
 - **GIVEN** an otherwise exact same-repository `dev` to `main` event
 - **WHEN** any commit, tree, live tip, ancestry, source pull request, check run,
   workflow, application, artifact identity, expiry, digest, report, plan, or
-  JUnit binding is absent, ambiguous, stale, unsuccessful, or mismatched
+  JUnit binding is absent, ambiguous, stale, unsuccessful, or mismatched, or
+  the central validator commit/tree/blob/digest or member authority is invalid
 - **THEN** that stage SHALL fail closed before accepting promotion reuse.
 
 ### Requirement: Promotion stages independently validate reuse

--- a/openspec/changes/fix-release-promotion-requirements-parity/tasks.md
+++ b/openspec/changes/fix-release-promotion-requirements-parity/tasks.md
@@ -1,0 +1,49 @@
+# Tasks: fix-release-promotion-requirements-parity
+
+## 1. Governance and specification
+
+- [x] 1.1 Refresh `origin/dev`, issue #692 metadata, and the GitHub hierarchy cache.
+- [x] 1.2 Define the exact repository/ref/commit/tree/ancestry and prior-evidence
+  release-promotion boundary.
+- [x] 1.3 Validate the OpenSpec change strictly before implementation.
+
+## 2. Tests first
+
+- [ ] 2.1 Add mapped validator and workflow regressions for exact promotion
+  acceptance; lookalike, stale, spoofed, ambiguous, expired, and digest-tampered
+  rejection; and producer/consumer/final independent validation.
+- [ ] 2.2 Run the focused selectors against unmodified production code and retain
+  failing-before evidence.
+- [ ] 2.3 Obtain acceptance for the stable test-authored mapping before the
+  implementation commit.
+
+## 3. Minimal implementation
+
+- [ ] 3.1 Add one canonical promotion-reuse validator for event, commit/tree,
+  source-pull, check/run, artifact, report, plan, and JUnit bindings.
+- [ ] 3.2 Require producer, consumer, and final to fetch and independently
+  validate exact live evidence and byte-identical promotion attestations.
+- [ ] 3.3 Permit aggregate planning validation only when the separate promotion
+  attestation passes; do not claim current aggregate selector execution.
+- [ ] 3.4 Leave trusted main-relative inputs, every ordinary pull request, and
+  every independent authority/release gate unchanged.
+
+## 4. Verification and delivery
+
+- [ ] 4.1 Run focused legitimate and bypass controls, full workflow tests, strict
+  OpenSpec validation, workflow lint, and `git diff --check`.
+- [ ] 4.2 Run independent security-boundary and bypass/regression review; resolve
+  all P0/P1/P2 findings and disposition warnings.
+- [ ] 4.3 Review README, `docs/`, the docs landing page, and navigation; record why
+  this internal release-control correction requires no public documentation edit.
+- [ ] 4.4 Run strict module-signature verification; do not re-sign or bump a module
+  because no signed module asset or manifest changes.
+- [ ] 4.5 Validate the existing unreleased `0.55.4` four-source version and
+  changelog bundle against `origin/dev`; do not consume `0.55.5` for a follow-up
+  required to make the same release promotable.
+- [ ] 4.6 Generate a fresh `.specfact/code-review.json`, resolve every finding or
+  document an approved narrow exception, and record the exact review evidence.
+- [ ] 4.7 Push an issue-linked pull request to `dev`, obtain all required checks,
+  and merge only under repository policy.
+- [ ] 4.8 Re-run PR #691 at the new exact `dev` head and verify Requirements,
+  security, release, review, and authority gates before promotion.

--- a/openspec/changes/fix-release-promotion-requirements-parity/tasks.md
+++ b/openspec/changes/fix-release-promotion-requirements-parity/tasks.md
@@ -14,34 +14,34 @@
   rejection; and producer/consumer/final independent validation.
 - [x] 2.2 Run the focused selectors against unmodified production code and retain
   failing-before evidence.
-- [ ] 2.3 Obtain acceptance for the stable test-authored mapping before the
+- [x] 2.3 Obtain acceptance for the stable test-authored mapping before the
   implementation commit.
 
 ## 3. Minimal implementation
 
-- [ ] 3.1 Add one canonical promotion-reuse validator for event, commit/tree,
+- [x] 3.1 Add one canonical promotion-reuse validator for event, commit/tree,
   source-pull, check/run, artifact, report, plan, and JUnit bindings.
-- [ ] 3.2 Require producer, consumer, and final to fetch and independently
+- [x] 3.2 Require producer, consumer, and final to fetch and independently
   validate exact live evidence and byte-identical promotion attestations.
-- [ ] 3.3 Permit aggregate planning validation only when the separate promotion
+- [x] 3.3 Permit aggregate planning validation only when the separate promotion
   attestation passes; do not claim current aggregate selector execution.
-- [ ] 3.4 Leave trusted main-relative inputs, every ordinary pull request, and
+- [x] 3.4 Leave trusted main-relative inputs, every ordinary pull request, and
   every independent authority/release gate unchanged.
 
 ## 4. Verification and delivery
 
-- [ ] 4.1 Run focused legitimate and bypass controls, full workflow tests, strict
+- [x] 4.1 Run focused legitimate and bypass controls, full workflow tests, strict
   OpenSpec validation, workflow lint, and `git diff --check`.
-- [ ] 4.2 Run independent security-boundary and bypass/regression review; resolve
+- [x] 4.2 Run independent security-boundary and bypass/regression review; resolve
   all P0/P1/P2 findings and disposition warnings.
-- [ ] 4.3 Review README, `docs/`, the docs landing page, and navigation; record why
+- [x] 4.3 Review README, `docs/`, the docs landing page, and navigation; record why
   this internal release-control correction requires no public documentation edit.
-- [ ] 4.4 Run strict module-signature verification; do not re-sign or bump a module
+- [x] 4.4 Run strict module-signature verification; do not re-sign or bump a module
   because no signed module asset or manifest changes.
-- [ ] 4.5 Validate the existing unreleased `0.55.4` four-source version and
+- [x] 4.5 Validate the existing unreleased `0.55.4` four-source version and
   changelog bundle against `origin/dev`; do not consume `0.55.5` for a follow-up
   required to make the same release promotable.
-- [ ] 4.6 Generate a fresh `.specfact/code-review.json`, resolve every finding or
+- [x] 4.6 Generate a fresh `.specfact/code-review.json`, resolve every finding or
   document an approved narrow exception, and record the exact review evidence.
 - [ ] 4.7 Push an issue-linked pull request to `dev`, obtain all required checks,
   and merge only under repository policy.

--- a/openspec/changes/fix-release-promotion-requirements-parity/tasks.md
+++ b/openspec/changes/fix-release-promotion-requirements-parity/tasks.md
@@ -9,10 +9,10 @@
 
 ## 2. Tests first
 
-- [ ] 2.1 Add mapped validator and workflow regressions for exact promotion
+- [x] 2.1 Add mapped validator and workflow regressions for exact promotion
   acceptance; lookalike, stale, spoofed, ambiguous, expired, and digest-tampered
   rejection; and producer/consumer/final independent validation.
-- [ ] 2.2 Run the focused selectors against unmodified production code and retain
+- [x] 2.2 Run the focused selectors against unmodified production code and retain
   failing-before evidence.
 - [ ] 2.3 Obtain acceptance for the stable test-authored mapping before the
   implementation commit.

--- a/scripts/requirements_promotion_reuse.py
+++ b/scripts/requirements_promotion_reuse.py
@@ -1,0 +1,750 @@
+#!/usr/bin/env python3
+"""Authenticate Requirements evidence reused by an exact dev-to-main promotion."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+import sys
+import tempfile
+import zipfile
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import NamedTuple, NoReturn, cast
+from xml.parsers import expat
+
+
+REPOSITORY = "nold-ai/specfact-cli"
+REPOSITORY_ID = 1085706003
+BASE_REF = "main"
+HEAD_REF = "dev"
+GITHUB_ACTIONS_APP_ID = 15368
+REQUIREMENTS_WORKFLOW_ID = 323253915
+AUTHORITY_WORKFLOW_ID = 348163848
+REQUIREMENTS_WORKFLOW_PATH = ".github/workflows/requirements-evidence.yml"
+AUTHORITY_WORKFLOW_PATH = ".github/workflows/trusted-requirements-authority.yml"
+MAX_INPUT_BYTES = 100 * 1024 * 1024
+MAX_ARCHIVE_MEMBER_BYTES = 25 * 1024 * 1024
+MAX_ARCHIVE_CONTENT_BYTES = 50 * 1024 * 1024
+OBJECT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+GitRunner = Callable[[Path, list[str]], str]
+
+
+PromotionReuseError = ValueError
+
+
+class PromotionInputs(NamedTuple):
+    """Authenticated inputs required to validate one protected promotion."""
+
+    event: dict[str, object]
+    repo_root: Path
+    source_pulls: object
+    check_runs: object
+    requirements_run: dict[str, object]
+    authority_run: dict[str, object]
+    artifacts: object
+    producer_archive: Path
+    execution_archive: Path
+
+
+class _RunExpectation(NamedTuple):
+    source_branch: str
+    source_sha: str
+    name: str
+    path: str
+    workflow_id: int
+    required_workflow: bool
+
+
+class _SourceRun(NamedTuple):
+    run_id: int
+    branch: str
+    sha: str
+
+
+class _ArtifactFiles(NamedTuple):
+    producer: Path
+    execution: Path
+
+
+def _reject() -> NoReturn:
+    raise PromotionReuseError("promotion-reuse-invalid")
+
+
+def _object(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        _reject()
+    return cast(dict[str, object], value)
+
+
+def _integer(value: object) -> int:
+    if type(value) is not int or cast(int, value) <= 0:
+        _reject()
+    return cast(int, value)
+
+
+def _string(value: object, pattern: re.Pattern[str] | None = None) -> str:
+    if not isinstance(value, str) or not value or (pattern is not None and pattern.fullmatch(value) is None):
+        _reject()
+    return value
+
+
+def _strings(value: object) -> list[str]:
+    if not isinstance(value, list) or not value or not all(isinstance(item, str) and item for item in value):
+        _reject()
+    result = cast(list[str], value)
+    if len(result) != len(set(result)):
+        _reject()
+    return result
+
+
+def _pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            _reject()
+        result[key] = value
+    return result
+
+
+def _regular_payload(path: Path, *, maximum: int = MAX_INPUT_BYTES) -> bytes:
+    details = path.lstat()
+    if not stat.S_ISREG(details.st_mode) or details.st_size > maximum:
+        _reject()
+    payload = path.read_bytes()
+    if len(payload) != details.st_size:
+        _reject()
+    return payload
+
+
+def _json_value(payload: bytes) -> object:
+    try:
+        return json.loads(payload, object_pairs_hook=_pairs)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise PromotionReuseError("promotion-reuse-invalid") from error
+
+
+def _read_json(path: Path) -> object:
+    return _json_value(_regular_payload(path))
+
+
+def _digest(payload: bytes) -> str:
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+def _repository(value: object) -> None:
+    repository = _object(value)
+    if repository.get("id") != REPOSITORY_ID or repository.get("full_name") != REPOSITORY:
+        _reject()
+
+
+def _run_git(repo_root: Path, arguments: list[str]) -> str:
+    """Run one bounded Git query and return its stripped stdout."""
+    completed = subprocess.run(
+        ["git", *arguments],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return completed.stdout.strip()
+
+
+def _git(git_runner: GitRunner, repo_root: Path, arguments: list[str]) -> str:
+    try:
+        return git_runner(repo_root, arguments).strip()
+    except (OSError, subprocess.SubprocessError) as error:
+        raise PromotionReuseError("promotion-reuse-invalid") from error
+
+
+def _git_object(git_runner: GitRunner, repo_root: Path, commit: str) -> None:
+    if _git(git_runner, repo_root, ["cat-file", "-t", commit]) != "commit":
+        _reject()
+
+
+def _validate_event(event: dict[str, object]) -> tuple[int, str, str]:
+    _repository(event.get("repository"))
+    pull_request = _object(event.get("pull_request"))
+    base = _object(pull_request.get("base"))
+    head = _object(pull_request.get("head"))
+    _repository(base.get("repo"))
+    _repository(head.get("repo"))
+    if base.get("ref") != BASE_REF or head.get("ref") != HEAD_REF:
+        _reject()
+    return (
+        _integer(pull_request.get("number")),
+        _string(base.get("sha"), OBJECT_PATTERN),
+        _string(head.get("sha"), OBJECT_PATTERN),
+    )
+
+
+def _validate_git(repo_root: Path, base_sha: str, head_sha: str, git_runner: GitRunner) -> tuple[str, str, str]:
+    if _git(git_runner, repo_root, ["rev-parse", "HEAD"]) != head_sha:
+        _reject()
+    head_tree = _string(_git(git_runner, repo_root, ["rev-parse", "HEAD^{tree}"]), OBJECT_PATTERN)
+    if _git(git_runner, repo_root, ["rev-parse", "refs/remotes/origin/main^{commit}"]) != base_sha:
+        _reject()
+    if _git(git_runner, repo_root, ["rev-parse", "refs/remotes/origin/dev^{commit}"]) != head_sha:
+        _reject()
+    _git_object(git_runner, repo_root, base_sha)
+    _git_object(git_runner, repo_root, head_sha)
+    _git(git_runner, repo_root, ["merge-base", "--is-ancestor", base_sha, head_sha])
+    parents = _git(git_runner, repo_root, ["rev-list", "--parents", "-n", "1", head_sha]).split()
+    if len(parents) != 3 or parents[0] != head_sha:
+        _reject()
+    previous_dev_sha = _string(parents[1], OBJECT_PATTERN)
+    source_sha = _string(parents[2], OBJECT_PATTERN)
+    if len({head_sha, previous_dev_sha, source_sha}) != 3:
+        _reject()
+    _git_object(git_runner, repo_root, previous_dev_sha)
+    _git_object(git_runner, repo_root, source_sha)
+    if _git(git_runner, repo_root, ["rev-parse", f"{source_sha}^{{tree}}"]) != head_tree:
+        _reject()
+    return head_tree, previous_dev_sha, source_sha
+
+
+def _flatten_source_pulls(value: object) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        _reject()
+    entries = cast(list[object], value)
+    if entries and all(isinstance(entry, list) for entry in entries):
+        entries = [item for page in cast(list[list[object]], entries) for item in page]
+    if not all(isinstance(entry, dict) for entry in entries):
+        _reject()
+    return cast(list[dict[str, object]], entries)
+
+
+def _validate_source_pull(
+    source_pulls: object, previous_dev_sha: str, source_sha: str, head_sha: str
+) -> dict[str, object]:
+    candidates = [pull for pull in _flatten_source_pulls(source_pulls) if pull.get("merge_commit_sha") == head_sha]
+    if len(candidates) != 1:
+        _reject()
+    source_pull = candidates[0]
+    base = _object(source_pull.get("base"))
+    head = _object(source_pull.get("head"))
+    _repository(base.get("repo"))
+    _repository(head.get("repo"))
+    if (
+        source_pull.get("state") != "closed"
+        or not isinstance(source_pull.get("merged_at"), str)
+        or not source_pull["merged_at"]
+        or base.get("ref") != HEAD_REF
+        or base.get("sha") != previous_dev_sha
+        or head.get("sha") != source_sha
+    ):
+        _reject()
+    _string(head.get("ref"))
+    _integer(source_pull.get("number"))
+    return source_pull
+
+
+def _complete_collection(payload: object, field: str) -> list[dict[str, object]]:
+    pages = cast(list[object], payload) if isinstance(payload, list) else [payload]
+    parsed_pages = [_collection_page(page, field) for page in pages]
+    totals = {total for total, _entries in parsed_pages}
+    if len(totals) != 1:
+        _reject()
+    expected_total = totals.pop()
+    entries = [entry for _total, page_entries in parsed_pages for entry in page_entries]
+    if len(entries) != expected_total:
+        _reject()
+    return entries
+
+
+def _collection_page(page_value: object, field: str) -> tuple[int, list[dict[str, object]]]:
+    page = _object(page_value)
+    total = page.get("total_count")
+    page_entries = page.get(field)
+    if type(total) is not int or cast(int, total) < 0:
+        _reject()
+    if not isinstance(page_entries, list) or not all(isinstance(entry, dict) for entry in page_entries):
+        _reject()
+    return cast(int, total), cast(list[dict[str, object]], page_entries)
+
+
+def _required_check(checks: list[dict[str, object]], name: str) -> dict[str, object]:
+    matching = [check for check in checks if check.get("name") == name]
+    if len(matching) != 1:
+        _reject()
+    return matching[0]
+
+
+def _validate_check(check: dict[str, object], *, run_id: int, source_sha: str) -> None:
+    check_id = _integer(check.get("id"))
+    app = _object(check.get("app"))
+    owner = _object(app.get("owner"))
+    expected_url = f"https://github.com/{REPOSITORY}/actions/runs/{run_id}/job/{check_id}"
+    if (
+        check.get("status") != "completed"
+        or check.get("conclusion") != "success"
+        or check.get("head_sha") != source_sha
+        or check.get("details_url") != expected_url
+        or app.get("id") != GITHUB_ACTIONS_APP_ID
+        or app.get("slug") != "github-actions"
+        or owner.get("login") != "github"
+    ):
+        _reject()
+
+
+def _validate_run(
+    run: dict[str, object],
+    *,
+    check: dict[str, object],
+    expected: _RunExpectation,
+) -> int:
+    run_id = _integer(run.get("id"))
+    _repository(run.get("repository"))
+    workflow_kind = "required_workflows" if expected.required_workflow else "workflows"
+    expected_url = f"https://api.github.com/repos/{REPOSITORY}/actions/{workflow_kind}/{expected.workflow_id}"
+    fields = {
+        "event": "pull_request",
+        "name": expected.name,
+        "path": expected.path,
+        "workflow_id": expected.workflow_id,
+        "workflow_url": expected_url,
+        "status": "completed",
+        "conclusion": "success",
+        "head_sha": expected.source_sha,
+        "head_branch": expected.source_branch,
+    }
+    if any(run.get(field) != value for field, value in fields.items()):
+        _reject()
+    _validate_check(check, run_id=run_id, source_sha=expected.source_sha)
+    return run_id
+
+
+def _validate_checks_and_runs(
+    check_runs: object,
+    requirements_run: dict[str, object],
+    authority_run: dict[str, object],
+    source_branch: str,
+    source_sha: str,
+) -> tuple[int, int]:
+    checks = _complete_collection(check_runs, "check_runs")
+    requirements_check = _required_check(checks, "Requirements evidence")
+    authority_check = _required_check(checks, "Trusted Requirements Authority")
+    requirements_run_id = _validate_run(
+        requirements_run,
+        check=requirements_check,
+        expected=_RunExpectation(
+            source_branch,
+            source_sha,
+            "Requirements Evidence",
+            REQUIREMENTS_WORKFLOW_PATH,
+            REQUIREMENTS_WORKFLOW_ID,
+            False,
+        ),
+    )
+    authority_run_id = _validate_run(
+        authority_run,
+        check=authority_check,
+        expected=_RunExpectation(
+            source_branch,
+            source_sha,
+            "Trusted Requirements Authority",
+            AUTHORITY_WORKFLOW_PATH,
+            AUTHORITY_WORKFLOW_ID,
+            True,
+        ),
+    )
+    if requirements_run_id == authority_run_id:
+        _reject()
+    return requirements_run_id, authority_run_id
+
+
+def _artifact(
+    artifacts: list[dict[str, object]],
+    *,
+    name: str,
+    source_run: _SourceRun,
+    archive: Path,
+) -> dict[str, object]:
+    matching = [artifact for artifact in artifacts if artifact.get("name") == name]
+    if len(matching) != 1:
+        _reject()
+    artifact = matching[0]
+    _integer(artifact.get("id"))
+    digest = _string(artifact.get("digest"), DIGEST_PATTERN)
+    workflow_run = _object(artifact.get("workflow_run"))
+    expected_run = {
+        "id": source_run.run_id,
+        "head_sha": source_run.sha,
+        "head_branch": source_run.branch,
+        "head_repository_id": REPOSITORY_ID,
+        "repository_id": REPOSITORY_ID,
+    }
+    invalid_run = any(workflow_run.get(field) != value for field, value in expected_run.items())
+    if artifact.get("expired") is not False or invalid_run or _digest(_regular_payload(archive)) != digest:
+        _reject()
+    return artifact
+
+
+def _validate_artifacts(
+    payload: object,
+    *,
+    source_run: _SourceRun,
+    files: _ArtifactFiles,
+) -> tuple[dict[str, object], dict[str, object]]:
+    artifacts = _complete_collection(payload, "artifacts")
+    artifact_ids = [_integer(artifact.get("id")) for artifact in artifacts]
+    if len(artifact_ids) != len(set(artifact_ids)):
+        _reject()
+    producer = _artifact(
+        artifacts,
+        name="requirements-evidence",
+        source_run=source_run,
+        archive=files.producer,
+    )
+    execution = _artifact(
+        artifacts,
+        name="requirements-evidence-execution",
+        source_run=source_run,
+        archive=files.execution,
+    )
+    return producer, execution
+
+
+def _archive_files(path: Path) -> dict[str, bytes]:
+    _regular_payload(path)
+    try:
+        with zipfile.ZipFile(path) as archive:
+            infos = archive.infolist()
+            _validate_archive_index(infos)
+            return {info.filename: _archive_member(archive, info) for info in infos}
+    except (OSError, RuntimeError, zipfile.BadZipFile) as error:
+        raise PromotionReuseError("promotion-reuse-invalid") from error
+
+
+def _validate_archive_index(infos: list[zipfile.ZipInfo]) -> None:
+    if len(infos) != len({info.filename for info in infos}):
+        _reject()
+    if sum(info.file_size for info in infos) > MAX_ARCHIVE_CONTENT_BYTES:
+        _reject()
+
+
+def _archive_member(archive: zipfile.ZipFile, info: zipfile.ZipInfo) -> bytes:
+    mode = info.external_attr >> 16
+    file_type = stat.S_IFMT(mode)
+    if info.flag_bits & 0x1 or info.is_dir() or file_type not in {0, stat.S_IFREG}:
+        _reject()
+    if info.file_size > MAX_ARCHIVE_MEMBER_BYTES:
+        _reject()
+    payload = archive.read(info)
+    if len(payload) != info.file_size:
+        _reject()
+    return payload
+
+
+class _JunitCollector:
+    def __init__(self) -> None:
+        self.cases: list[tuple[str, str, bool]] = []
+        self.properties: dict[str, list[str]] | None = None
+        self.failed = False
+
+    def _start(self, name: str, attributes: dict[str, str]) -> None:
+        if name == "testcase":
+            if self.properties is not None:
+                _reject()
+            self.properties = {}
+            self.failed = False
+            return
+        if self.properties is None:
+            return
+        if name in {"failure", "error", "skipped"}:
+            self.failed = True
+        elif name == "property":
+            key, value = attributes.get("name"), attributes.get("value")
+            if key is not None and value is not None:
+                self.properties.setdefault(key, []).append(value)
+
+    def _end(self, name: str) -> None:
+        if name != "testcase" or self.properties is None:
+            return
+        selectors = self.properties.get("specfact.selector", [])
+        runners = self.properties.get("specfact.runner", [])
+        if len(selectors) != 1 or len(runners) != 1 or not selectors[0] or not runners[0]:
+            _reject()
+        self.cases.append((selectors[0], runners[0], self.failed))
+        self.properties = None
+
+    def _reject(self, *_arguments: object) -> int:
+        _reject()
+
+
+def _junit_selectors(payload: bytes) -> list[str]:
+    collector = _JunitCollector()
+    parser = expat.ParserCreate()
+    parser.StartElementHandler = collector._start
+    parser.EndElementHandler = collector._end
+    parser.StartDoctypeDeclHandler = collector._reject
+    parser.EntityDeclHandler = collector._reject
+    parser.ExternalEntityRefHandler = collector._reject
+    parser.SetParamEntityParsing(expat.XML_PARAM_ENTITY_PARSING_NEVER)
+    try:
+        parser.Parse(payload, True)
+    except expat.ExpatError as error:
+        raise PromotionReuseError("promotion-reuse-invalid") from error
+    if collector.properties is not None or not collector.cases:
+        _reject()
+    selectors = [selector for selector, runner, failed in collector.cases if runner == "pytest" and not failed]
+    if len(selectors) != len(collector.cases) or len(selectors) != len(set(selectors)):
+        _reject()
+    return selectors
+
+
+def _planned_selectors(plan: dict[str, object]) -> list[str]:
+    cases = plan.get("cases")
+    if not isinstance(cases, list) or not cases:
+        _reject()
+    selectors: list[str] = []
+    for case_value in cast(list[object], cases):
+        case = _object(case_value)
+        selector = _object(case.get("selector"))
+        node_id = _string(case.get("node_id"))
+        if case.get("method") != "test" or selector.get("runner") != "pytest" or selector.get("node_id") != node_id:
+            _reject()
+        selectors.append(node_id)
+    if len(selectors) != len(set(selectors)):
+        _reject()
+    return selectors
+
+
+def _expected_fields(payload: dict[str, object], expected: Mapping[str, object]) -> None:
+    if any(payload.get(key) != value for key, value in expected.items()):
+        _reject()
+
+
+def _evidence_payloads(producer_archive: Path, execution_archive: Path) -> tuple[bytes, bytes, bytes]:
+    producer_files = _archive_files(producer_archive)
+    execution_files = _archive_files(execution_archive)
+    required_producer = {
+        "requirements-evidence.json",
+        "requirements-evidence-plan.json",
+        "requirements-evidence.md",
+        "requirements-proof.xml",
+    }
+    if not required_producer.issubset(producer_files) or "requirements-evidence-plan.json" not in execution_files:
+        _reject()
+    producer_plan = producer_files["requirements-evidence-plan.json"]
+    if execution_files["requirements-evidence-plan.json"] != producer_plan:
+        _reject()
+    return producer_files["requirements-evidence.json"], producer_plan, producer_files["requirements-proof.xml"]
+
+
+def _report_evidence(report: dict[str, object], source_sha: str, junit_digest: str) -> tuple[str, str, list[str]]:
+    expected_report = {
+        "schema_version": "2",
+        "verdict": "passed",
+        "gate_decision": "pass",
+        "required_maturity": "verified",
+        "observed_maturity": "verified",
+        "delivery_status": "implementation-verified",
+        "implementation_evidence": "passing-after-red-proven",
+    }
+    _expected_fields(report, expected_report)
+    execution_proof = _object(report.get("execution_proof"))
+    expected_execution = {
+        "source_ref": source_sha,
+        "run_stage": "final",
+        "proof_basis": "red-junit",
+        "junit_digest": junit_digest,
+    }
+    _expected_fields(execution_proof, expected_execution)
+    mapping_digest = _string(report.get("mapping_digest"), DIGEST_PATTERN)
+    plan_digest = _string(report.get("plan_digest"), DIGEST_PATTERN)
+    return mapping_digest, plan_digest, _strings(execution_proof.get("selectors"))
+
+
+def _validate_plan_sources(plan_report: dict[str, object]) -> None:
+    sources = plan_report.get("sources")
+    if not isinstance(sources, list) or not sources:
+        _reject()
+    source_names: list[str] = []
+    for source_value in cast(list[object], sources):
+        source = _object(source_value)
+        source_names.append(_string(source.get("source")))
+        _string(source.get("mapping_digest"), DIGEST_PATTERN)
+    if len(source_names) != len(set(source_names)):
+        _reject()
+
+
+def _plan_evidence(plan_report: dict[str, object], mapping_digest: str, plan_digest: str) -> list[str]:
+    expected_plan_report = {
+        "schema_version": "2",
+        "verdict": "passed",
+        "gate_decision": "pass",
+        "required_maturity": "test-authored",
+        "observed_maturity": "test-authored",
+        "mapping_digest": mapping_digest,
+    }
+    _expected_fields(plan_report, expected_plan_report)
+    _string(plan_report.get("plan_identity_digest"), DIGEST_PATTERN)
+    plan = _object(plan_report.get("plan"))
+    _expected_fields(plan, {"mapping_digest": mapping_digest, "plan_digest": plan_digest})
+    _validate_plan_sources(plan_report)
+    return _planned_selectors(plan)
+
+
+def _validate_selectors(reported: list[str], planned: list[str], junit_payload: bytes) -> None:
+    junit_selectors = _junit_selectors(junit_payload)
+    if set(reported) != set(planned) or set(junit_selectors) != set(planned):
+        _reject()
+
+
+def _validate_evidence(
+    producer_archive: Path, execution_archive: Path, source_sha: str
+) -> tuple[str, str, str, list[str]]:
+    report_payload, producer_plan_payload, junit_payload = _evidence_payloads(producer_archive, execution_archive)
+    report = _object(_json_value(report_payload))
+    plan_report = _object(_json_value(producer_plan_payload))
+    junit_digest = _digest(junit_payload)
+    mapping_digest, plan_digest, selectors = _report_evidence(report, source_sha, junit_digest)
+    planned_selectors = _plan_evidence(plan_report, mapping_digest, plan_digest)
+    _validate_selectors(selectors, planned_selectors, junit_payload)
+    return mapping_digest, plan_digest, junit_digest, selectors
+
+
+def build_attestation(inputs: PromotionInputs, *, git_runner: GitRunner = _run_git) -> dict[str, object]:
+    """Return one canonical attestation or fail closed on any incomplete binding."""
+    try:
+        pull_request, base_sha, head_sha = _validate_event(inputs.event)
+        head_tree, previous_dev_sha, source_sha = _validate_git(inputs.repo_root, base_sha, head_sha, git_runner)
+        source_pull = _validate_source_pull(inputs.source_pulls, previous_dev_sha, source_sha, head_sha)
+        source_head = _object(source_pull.get("head"))
+        source_branch = _string(source_head.get("ref"))
+        requirements_run_id, authority_run_id = _validate_checks_and_runs(
+            inputs.check_runs,
+            inputs.requirements_run,
+            inputs.authority_run,
+            source_branch,
+            source_sha,
+        )
+        producer, execution = _validate_artifacts(
+            inputs.artifacts,
+            source_run=_SourceRun(requirements_run_id, source_branch, source_sha),
+            files=_ArtifactFiles(inputs.producer_archive, inputs.execution_archive),
+        )
+        mapping_digest, plan_digest, junit_digest, selectors = _validate_evidence(
+            inputs.producer_archive, inputs.execution_archive, source_sha
+        )
+        return {
+            "schema_version": "1",
+            "claim": "promotion-reused",
+            "repository": {"id": REPOSITORY_ID, "full_name": REPOSITORY},
+            "promotion": {
+                "base_ref": BASE_REF,
+                "base_sha": base_sha,
+                "head_ref": HEAD_REF,
+                "head_sha": head_sha,
+                "head_tree": head_tree,
+                "pull_request": pull_request,
+            },
+            "source_pull_request": {
+                "number": _integer(source_pull.get("number")),
+                "base_sha": previous_dev_sha,
+                "head_ref": source_branch,
+                "head_sha": source_sha,
+                "merge_commit_sha": head_sha,
+            },
+            "checks": {
+                "requirements_run_id": requirements_run_id,
+                "authority_run_id": authority_run_id,
+            },
+            "artifacts": {
+                "producer_id": _integer(producer.get("id")),
+                "producer_digest": _string(producer.get("digest"), DIGEST_PATTERN),
+                "execution_id": _integer(execution.get("id")),
+                "execution_digest": _string(execution.get("digest"), DIGEST_PATTERN),
+            },
+            "evidence": {
+                "mapping_digest": mapping_digest,
+                "plan_digest": plan_digest,
+                "junit_digest": junit_digest,
+                "selectors": selectors,
+            },
+        }
+    except Exception as error:
+        if isinstance(error, PromotionReuseError):
+            raise
+        raise PromotionReuseError("promotion-reuse-invalid") from error
+
+
+def _argument_error(message: str) -> NoReturn:
+    del message
+    raise PromotionReuseError("promotion-reuse-invalid")
+
+
+def _arguments(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.error = _argument_error
+    for name in (
+        "event",
+        "repo-root",
+        "source-pulls",
+        "check-runs",
+        "requirements-run",
+        "authority-run",
+        "artifacts",
+        "producer-archive",
+        "execution-archive",
+        "output",
+    ):
+        parser.add_argument(f"--{name}", type=Path, required=True)
+    parser.add_argument("--expected-attestation", type=Path)
+    return parser.parse_args(argv)
+
+
+def _canonical_json(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode() + b"\n"
+
+
+def _write_output(path: Path, payload: bytes) -> None:
+    parent = path.parent.resolve(strict=True)
+    with tempfile.NamedTemporaryFile(prefix=f".{path.name}.", dir=parent, delete=False) as candidate:
+        candidate_path = Path(candidate.name)
+        candidate.write(payload)
+        candidate.flush()
+        os.fsync(candidate.fileno())
+    try:
+        os.replace(candidate_path, path)
+    except Exception:
+        candidate_path.unlink(missing_ok=True)
+        raise
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Validate promotion reuse, write canonical JSON, and return a shell status."""
+    try:
+        arguments = _arguments(argv)
+        inputs = PromotionInputs(
+            event=_object(_read_json(arguments.event)),
+            repo_root=arguments.repo_root.resolve(strict=True),
+            source_pulls=_read_json(arguments.source_pulls),
+            check_runs=_read_json(arguments.check_runs),
+            requirements_run=_object(_read_json(arguments.requirements_run)),
+            authority_run=_object(_read_json(arguments.authority_run)),
+            artifacts=_read_json(arguments.artifacts),
+            producer_archive=arguments.producer_archive,
+            execution_archive=arguments.execution_archive,
+        )
+        attestation = build_attestation(inputs)
+        payload = _canonical_json(attestation)
+        if arguments.expected_attestation is not None and _regular_payload(arguments.expected_attestation) != payload:
+            _reject()
+        _write_output(arguments.output, payload)
+    except Exception:
+        sys.stderr.write("promotion-reuse-invalid\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_requirements_promotion_reuse.py
+++ b/tests/unit/scripts/test_requirements_promotion_reuse.py
@@ -385,7 +385,7 @@ def _promotion_fixture(tmp_path: Path) -> _PromotionFixture:
 
 def _validate(fixture: _PromotionFixture) -> dict[str, object]:
     validator = _load_validator()
-    return validator.build_attestation(
+    inputs = validator.PromotionInputs(
         event=fixture.event,
         repo_root=REPO_ROOT,
         source_pulls=fixture.source_pulls,
@@ -395,8 +395,8 @@ def _validate(fixture: _PromotionFixture) -> dict[str, object]:
         artifacts=fixture.artifacts,
         producer_archive=fixture.producer_archive,
         execution_archive=fixture.execution_archive,
-        git_runner=fixture.run_git,
     )
+    return validator.build_attestation(inputs, git_runner=fixture.run_git)
 
 
 def _write_cli_inputs(tmp_path: Path, fixture: _PromotionFixture) -> _CliInputs:
@@ -461,8 +461,8 @@ def _assert_cli_contract(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
     attestation: dict[str, object] = {"claim": "promotion-reused", "source_head": SOURCE_SHA}
     captured: dict[str, object] = {}
 
-    def accepted_build(**keywords: object) -> dict[str, object]:
-        captured.update(keywords)
+    def accepted_build(inputs: object) -> dict[str, object]:
+        captured["inputs"] = inputs
         return attestation
 
     monkeypatch.setattr(validator, "build_attestation", accepted_build)
@@ -471,8 +471,9 @@ def _assert_cli_contract(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
     assert validator.main(_cli_arguments(fixture, inputs, first_output)) == 0
     assert validator.main(_cli_arguments(fixture, inputs, second_output)) == 0
     assert first_output.read_bytes() == second_output.read_bytes() == _json_bytes(attestation)
-    assert "git_runner" not in captured
-    assert captured["repo_root"] == REPO_ROOT
+    captured_inputs = captured["inputs"]
+    assert isinstance(captured_inputs, validator.PromotionInputs)
+    assert captured_inputs.repo_root == REPO_ROOT
 
     expected = tmp_path / "expected.json"
     expected.write_bytes(b"{}\n")
@@ -480,7 +481,7 @@ def _assert_cli_contract(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
     assert validator.main(_cli_arguments(fixture, inputs, rejected_output, expected)) == 1
     assert not rejected_output.exists()
 
-    def rejected_build(**_keywords: object) -> dict[str, object]:
+    def rejected_build(_inputs: object) -> dict[str, object]:
         raise validator.PromotionReuseError
 
     monkeypatch.setattr(validator, "build_attestation", rejected_build)
@@ -547,6 +548,7 @@ def test_exact_protected_promotion_produces_canonical_attestation(
     attestation = _validate(fixture)
 
     assert "git_facts" not in inspect.signature(_load_validator().build_attestation).parameters
+    assert len(inspect.signature(_load_validator().build_attestation).parameters) == 2
     assert attestation["claim"] == "promotion-reused"
     assert attestation["promotion"] == {
         "base_ref": "main",

--- a/tests/unit/scripts/test_requirements_promotion_reuse.py
+++ b/tests/unit/scripts/test_requirements_promotion_reuse.py
@@ -1,0 +1,769 @@
+"""Security-boundary tests for protected release-promotion proof reuse."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import inspect
+import json
+import subprocess
+import sys
+import types
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+VALIDATOR_PATH = REPO_ROOT / "scripts" / "requirements_promotion_reuse.py"
+REPOSITORY = "nold-ai/specfact-cli"
+REPOSITORY_ID = 1085706003
+BASE_SHA = "1" * 40
+PREVIOUS_DEV_SHA = "2" * 40
+SOURCE_SHA = "3" * 40
+HEAD_SHA = "4" * 40
+HEAD_TREE = "5" * 40
+MAPPING_DIGEST = f"sha256:{'6' * 64}"
+PLAN_DIGEST = f"sha256:{'7' * 64}"
+REQUIREMENTS_WORKFLOW_ID = 323253915
+AUTHORITY_WORKFLOW_ID = 348163848
+GitArguments = tuple[str, ...]
+
+
+@dataclass
+class _PromotionFixture:
+    event: dict[str, object]
+    source_pulls: list[object]
+    check_runs: dict[str, object]
+    requirements_run: dict[str, object]
+    authority_run: dict[str, object]
+    artifacts: dict[str, object]
+    producer_archive: Path
+    execution_archive: Path
+    git_outputs: dict[GitArguments, str]
+    git_failures: set[GitArguments] = field(default_factory=set)
+    git_calls: list[GitArguments] = field(default_factory=list)
+
+    def run_git(self, _repo_root: Path, arguments: list[str]) -> str:
+        command = tuple(arguments)
+        self.git_calls.append(command)
+        if command in self.git_failures or command not in self.git_outputs:
+            raise subprocess.CalledProcessError(1, ["git", *arguments])
+        return self.git_outputs[command]
+
+
+@dataclass(frozen=True)
+class _CliInputs:
+    event: Path
+    source_pulls: Path
+    check_runs: Path
+    requirements_run: Path
+    authority_run: Path
+    artifacts: Path
+
+
+def _load_validator() -> types.ModuleType:
+    if not VALIDATOR_PATH.is_file():
+        pytest.fail("protected-promotion validator is not implemented")
+    name = "requirements_promotion_reuse"
+    spec = importlib.util.spec_from_file_location(name, VALIDATOR_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(name, None)
+    return module
+
+
+def _json_bytes(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode() + b"\n"
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.write_bytes(_json_bytes(value))
+
+
+def _archive_files(path: Path) -> dict[str, bytes]:
+    with zipfile.ZipFile(path) as archive:
+        return {name: archive.read(name) for name in archive.namelist()}
+
+
+def _write_archive(path: Path, files: dict[str, bytes]) -> None:
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for name, content in sorted(files.items()):
+            info = zipfile.ZipInfo(name, date_time=(2026, 1, 1, 0, 0, 0))
+            info.external_attr = 0o100644 << 16
+            archive.writestr(info, content)
+
+
+def _artifact_digest(path: Path) -> str:
+    return f"sha256:{hashlib.sha256(path.read_bytes()).hexdigest()}"
+
+
+def _set_nested(payload: dict[str, object], path: tuple[str, ...], value: object) -> None:
+    target = payload
+    for key in path[:-1]:
+        target = cast(dict[str, object], target[key])
+    target[path[-1]] = value
+
+
+def _object_list(payload: dict[str, object], key: str) -> list[dict[str, object]]:
+    return cast(list[dict[str, object]], payload[key])
+
+
+def _rewrite_json_member(path: Path, name: str, field_path: tuple[str, ...], value: object) -> None:
+    files = _archive_files(path)
+    payload = json.loads(files[name])
+    assert isinstance(payload, dict)
+    _set_nested(payload, field_path, value)
+    files[name] = _json_bytes(payload)
+    _write_archive(path, files)
+
+
+def _refresh_artifact_digest(fixture: _PromotionFixture, artifact_index: int, archive: Path) -> None:
+    _object_list(fixture.artifacts, "artifacts")[artifact_index]["digest"] = _artifact_digest(archive)
+
+
+def _proof_archives(tmp_path: Path) -> tuple[Path, Path]:
+    selector = "tests/test_fix.py::test_fix"
+    plan = {
+        "schema_version": "2",
+        "verdict": "passed",
+        "gate_decision": "pass",
+        "required_maturity": "test-authored",
+        "observed_maturity": "test-authored",
+        "mapping_digest": MAPPING_DIGEST,
+        "plan_identity_digest": f"sha256:{'8' * 64}",
+        "sources": [{"source": "openspec/changes/fix", "mapping_digest": MAPPING_DIGEST}],
+        "plan": {
+            "mapping_digest": MAPPING_DIGEST,
+            "plan_digest": PLAN_DIGEST,
+            "cases": [
+                {
+                    "method": "test",
+                    "node_id": selector,
+                    "selector": {"runner": "pytest", "node_id": selector},
+                }
+            ],
+        },
+    }
+    junit = (
+        b'<testsuite tests="1" failures="0"><testcase><properties>'
+        b'<property name="specfact.selector" value="tests/test_fix.py::test_fix"/>'
+        b'<property name="specfact.runner" value="pytest"/>'
+        b"</properties></testcase></testsuite>\n"
+    )
+    report = {
+        "schema_version": "2",
+        "verdict": "passed",
+        "gate_decision": "pass",
+        "required_maturity": "verified",
+        "observed_maturity": "verified",
+        "delivery_status": "implementation-verified",
+        "implementation_evidence": "passing-after-red-proven",
+        "mapping_digest": MAPPING_DIGEST,
+        "plan_digest": PLAN_DIGEST,
+        "execution_proof": {
+            "source_ref": SOURCE_SHA,
+            "run_stage": "final",
+            "proof_basis": "red-junit",
+            "selectors": [selector],
+            "junit_digest": f"sha256:{hashlib.sha256(junit).hexdigest()}",
+        },
+    }
+    producer_archive = tmp_path / "producer.zip"
+    execution_archive = tmp_path / "execution.zip"
+    _write_archive(
+        producer_archive,
+        {
+            "requirements-evidence.json": _json_bytes(report),
+            "requirements-evidence-plan.json": _json_bytes(plan),
+            "requirements-evidence.md": b"# passed\n",
+            "requirements-proof.xml": junit,
+        },
+    )
+    _write_archive(execution_archive, {"requirements-evidence-plan.json": _json_bytes(plan)})
+    return producer_archive, execution_archive
+
+
+def _repository_identity() -> dict[str, object]:
+    return {"id": REPOSITORY_ID, "full_name": REPOSITORY}
+
+
+def _promotion_event() -> dict[str, object]:
+    return {
+        "repository": {"id": REPOSITORY_ID, "full_name": REPOSITORY},
+        "pull_request": {
+            "number": 691,
+            "base": {
+                "ref": "main",
+                "sha": BASE_SHA,
+                "repo": _repository_identity(),
+            },
+            "head": {
+                "ref": "dev",
+                "sha": HEAD_SHA,
+                "repo": _repository_identity(),
+            },
+        },
+    }
+
+
+def _source_pull() -> dict[str, object]:
+    return {
+        "number": 714,
+        "state": "closed",
+        "merged_at": "2026-09-05T00:00:00Z",
+        "merge_commit_sha": HEAD_SHA,
+        "base": {
+            "ref": "dev",
+            "sha": PREVIOUS_DEV_SHA,
+            "repo": _repository_identity(),
+        },
+        "head": {
+            "ref": "bugfix/692-release-promotion-requirements-parity",
+            "sha": SOURCE_SHA,
+            "repo": _repository_identity(),
+        },
+    }
+
+
+def _release_association() -> dict[str, object]:
+    return {
+        "number": 691,
+        "state": "open",
+        "merged_at": None,
+        "merge_commit_sha": None,
+        "base": {
+            "ref": "main",
+            "sha": BASE_SHA,
+            "repo": _repository_identity(),
+        },
+        "head": {
+            "ref": "dev",
+            "sha": HEAD_SHA,
+            "repo": _repository_identity(),
+        },
+    }
+
+
+def _check_run(run_id: int, check_id: int, name: str, conclusion: str = "success") -> dict[str, object]:
+    return {
+        "id": check_id,
+        "name": name,
+        "status": "completed",
+        "conclusion": conclusion,
+        "head_sha": SOURCE_SHA,
+        "details_url": f"https://github.com/{REPOSITORY}/actions/runs/{run_id}/job/{check_id}",
+        "app": {"id": 15368, "slug": "github-actions", "owner": {"login": "github"}},
+    }
+
+
+def _check_runs() -> dict[str, object]:
+    return {
+        "total_count": 4,
+        "check_runs": [
+            _check_run(201, 101, "Requirements evidence"),
+            _check_run(202, 102, "Trusted Requirements Authority"),
+            _check_run(203, 103, "Tests (Python 3.12)"),
+            _check_run(204, 104, "Unrelated failed check", "failure"),
+        ],
+    }
+
+
+def _workflow_runs(source_branch: object) -> tuple[dict[str, object], dict[str, object]]:
+    common_run: dict[str, object] = {
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "head_sha": SOURCE_SHA,
+        "head_branch": source_branch,
+        "pull_requests": [],
+        "repository": _repository_identity(),
+    }
+    requirements_run = {
+        **common_run,
+        "id": 201,
+        "name": "Requirements Evidence",
+        "path": ".github/workflows/requirements-evidence.yml",
+        "workflow_id": REQUIREMENTS_WORKFLOW_ID,
+        "workflow_url": f"https://api.github.com/repos/{REPOSITORY}/actions/workflows/{REQUIREMENTS_WORKFLOW_ID}",
+    }
+    authority_run = {
+        **common_run,
+        "id": 202,
+        "name": "Trusted Requirements Authority",
+        "path": ".github/workflows/trusted-requirements-authority.yml",
+        "workflow_id": AUTHORITY_WORKFLOW_ID,
+        "workflow_url": f"https://api.github.com/repos/{REPOSITORY}/actions/required_workflows/{AUTHORITY_WORKFLOW_ID}",
+    }
+    return requirements_run, authority_run
+
+
+def _artifact_record(artifact_id: int, name: str, archive: Path, source_branch: object) -> dict[str, object]:
+    return {
+        "id": artifact_id,
+        "name": name,
+        "expired": False,
+        "digest": _artifact_digest(archive),
+        "workflow_run": {
+            "id": 201,
+            "head_sha": SOURCE_SHA,
+            "head_branch": source_branch,
+            "head_repository_id": REPOSITORY_ID,
+            "repository_id": REPOSITORY_ID,
+        },
+    }
+
+
+def _artifacts(producer_archive: Path, execution_archive: Path, source_branch: object) -> dict[str, object]:
+    return {
+        "total_count": 2,
+        "artifacts": [
+            _artifact_record(301, "requirements-evidence", producer_archive, source_branch),
+            _artifact_record(302, "requirements-evidence-execution", execution_archive, source_branch),
+        ],
+    }
+
+
+def _git_outputs() -> dict[GitArguments, str]:
+    return {
+        ("rev-parse", "HEAD"): HEAD_SHA,
+        ("rev-parse", "HEAD^{tree}"): HEAD_TREE,
+        ("rev-parse", "refs/remotes/origin/main^{commit}"): BASE_SHA,
+        ("rev-parse", "refs/remotes/origin/dev^{commit}"): HEAD_SHA,
+        ("cat-file", "-t", BASE_SHA): "commit",
+        ("cat-file", "-t", HEAD_SHA): "commit",
+        ("merge-base", "--is-ancestor", BASE_SHA, HEAD_SHA): "",
+        ("rev-list", "--parents", "-n", "1", HEAD_SHA): f"{HEAD_SHA} {PREVIOUS_DEV_SHA} {SOURCE_SHA}",
+        ("cat-file", "-t", PREVIOUS_DEV_SHA): "commit",
+        ("cat-file", "-t", SOURCE_SHA): "commit",
+        ("rev-parse", f"{SOURCE_SHA}^{{tree}}"): HEAD_TREE,
+    }
+
+
+def _promotion_fixture(tmp_path: Path) -> _PromotionFixture:
+    producer_archive, execution_archive = _proof_archives(tmp_path)
+    source_pull = _source_pull()
+    source_branch = cast(dict[str, object], source_pull["head"])["ref"]
+    requirements_run, authority_run = _workflow_runs(source_branch)
+    return _PromotionFixture(
+        event=_promotion_event(),
+        source_pulls=[_release_association(), source_pull],
+        check_runs=_check_runs(),
+        requirements_run=requirements_run,
+        authority_run=authority_run,
+        artifacts=_artifacts(producer_archive, execution_archive, source_branch),
+        producer_archive=producer_archive,
+        execution_archive=execution_archive,
+        git_outputs=_git_outputs(),
+    )
+
+
+def _validate(fixture: _PromotionFixture) -> dict[str, object]:
+    validator = _load_validator()
+    return validator.build_attestation(
+        event=fixture.event,
+        repo_root=REPO_ROOT,
+        source_pulls=fixture.source_pulls,
+        check_runs=fixture.check_runs,
+        requirements_run=fixture.requirements_run,
+        authority_run=fixture.authority_run,
+        artifacts=fixture.artifacts,
+        producer_archive=fixture.producer_archive,
+        execution_archive=fixture.execution_archive,
+        git_runner=fixture.run_git,
+    )
+
+
+def _write_cli_inputs(tmp_path: Path, fixture: _PromotionFixture) -> _CliInputs:
+    inputs = _CliInputs(
+        event=tmp_path / "event.json",
+        source_pulls=tmp_path / "source-pulls.json",
+        check_runs=tmp_path / "check-runs.json",
+        requirements_run=tmp_path / "requirements-run.json",
+        authority_run=tmp_path / "authority-run.json",
+        artifacts=tmp_path / "artifacts.json",
+    )
+    for path, value in (
+        (inputs.event, fixture.event),
+        (inputs.source_pulls, fixture.source_pulls),
+        (inputs.check_runs, fixture.check_runs),
+        (inputs.requirements_run, fixture.requirements_run),
+        (inputs.authority_run, fixture.authority_run),
+        (inputs.artifacts, fixture.artifacts),
+    ):
+        _write_json(path, value)
+    return inputs
+
+
+def _cli_arguments(
+    fixture: _PromotionFixture,
+    inputs: _CliInputs,
+    output: Path,
+    expected_attestation: Path | None = None,
+) -> list[str]:
+    arguments = [
+        "--event",
+        str(inputs.event),
+        "--repo-root",
+        str(REPO_ROOT),
+        "--source-pulls",
+        str(inputs.source_pulls),
+        "--check-runs",
+        str(inputs.check_runs),
+        "--requirements-run",
+        str(inputs.requirements_run),
+        "--authority-run",
+        str(inputs.authority_run),
+        "--artifacts",
+        str(inputs.artifacts),
+        "--producer-archive",
+        str(fixture.producer_archive),
+        "--execution-archive",
+        str(fixture.execution_archive),
+        "--output",
+        str(output),
+    ]
+    if expected_attestation is not None:
+        arguments.extend(("--expected-attestation", str(expected_attestation)))
+    return arguments
+
+
+def _assert_cli_contract(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    tmp_path.mkdir(parents=True)
+    validator = _load_validator()
+    fixture = _promotion_fixture(tmp_path)
+    inputs = _write_cli_inputs(tmp_path, fixture)
+    attestation: dict[str, object] = {"claim": "promotion-reused", "source_head": SOURCE_SHA}
+    captured: dict[str, object] = {}
+
+    def accepted_build(**keywords: object) -> dict[str, object]:
+        captured.update(keywords)
+        return attestation
+
+    monkeypatch.setattr(validator, "build_attestation", accepted_build)
+    first_output = tmp_path / "first.json"
+    second_output = tmp_path / "second.json"
+    assert validator.main(_cli_arguments(fixture, inputs, first_output)) == 0
+    assert validator.main(_cli_arguments(fixture, inputs, second_output)) == 0
+    assert first_output.read_bytes() == second_output.read_bytes() == _json_bytes(attestation)
+    assert "git_runner" not in captured
+    assert captured["repo_root"] == REPO_ROOT
+
+    expected = tmp_path / "expected.json"
+    expected.write_bytes(b"{}\n")
+    rejected_output = tmp_path / "rejected.json"
+    assert validator.main(_cli_arguments(fixture, inputs, rejected_output, expected)) == 1
+    assert not rejected_output.exists()
+
+    def rejected_build(**_keywords: object) -> dict[str, object]:
+        raise validator.PromotionReuseError
+
+    monkeypatch.setattr(validator, "build_attestation", rejected_build)
+    invalid_output = tmp_path / "invalid.json"
+    assert validator.main(_cli_arguments(fixture, inputs, invalid_output)) == 1
+    assert not invalid_output.exists()
+
+
+def _assert_default_git_runner(tmp_path: Path) -> None:
+    validator = _load_validator()
+    repo_root = tmp_path / "git-repository"
+    repo_root.mkdir()
+    subprocess.run(["git", "init", "--quiet"], cwd=repo_root, check=True)
+    subprocess.run(["git", "config", "user.email", "proof@example.test"], cwd=repo_root, check=True)
+    subprocess.run(["git", "config", "user.name", "Proof"], cwd=repo_root, check=True)
+    (repo_root / "proof.txt").write_text("proof\n", encoding="utf-8")
+    subprocess.run(["git", "add", "proof.txt"], cwd=repo_root, check=True)
+    subprocess.run(["git", "commit", "--quiet", "--no-gpg-sign", "-m", "proof"], cwd=repo_root, check=True)
+    expected = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert validator._run_git(repo_root, ["rev-parse", "HEAD"]) == expected
+
+
+def _assert_rejected(validator: types.ModuleType, fixture: _PromotionFixture) -> None:
+    with pytest.raises(validator.PromotionReuseError):
+        _validate(fixture)
+
+
+def test_exact_protected_promotion_produces_canonical_attestation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fixture = _promotion_fixture(tmp_path)
+
+    attestation = _validate(fixture)
+
+    assert "git_facts" not in inspect.signature(_load_validator().build_attestation).parameters
+    assert attestation["claim"] == "promotion-reused"
+    assert attestation["promotion"] == {
+        "base_ref": "main",
+        "base_sha": BASE_SHA,
+        "head_ref": "dev",
+        "head_sha": HEAD_SHA,
+        "head_tree": HEAD_TREE,
+        "pull_request": 691,
+    }
+    source = attestation["source_pull_request"]
+    assert isinstance(source, dict)
+    assert source["number"] == 714
+    assert source["head_sha"] == SOURCE_SHA
+    assert ("merge-base", "--is-ancestor", BASE_SHA, HEAD_SHA) in fixture.git_calls
+    assert ("rev-parse", f"{SOURCE_SHA}^{{tree}}") in fixture.git_calls
+
+    failed_git = _promotion_fixture(tmp_path)
+    failed_git.git_failures.add(("rev-parse", "HEAD"))
+    _assert_rejected(_load_validator(), failed_git)
+    _assert_cli_contract(tmp_path / "cli", monkeypatch)
+    _assert_default_git_runner(tmp_path)
+
+
+def test_lookalike_promotion_is_rejected(tmp_path: Path) -> None:
+    validator = _load_validator()
+    for field_path, value in (
+        (("pull_request", "head", "repo", "id"), 999),
+        (("pull_request", "head", "repo", "full_name"), "fork/specfact-cli"),
+        (("pull_request", "base", "ref"), "release"),
+        (("pull_request", "head", "ref"), "dev-lookalike"),
+    ):
+        fixture = _promotion_fixture(tmp_path)
+        _set_nested(fixture.event, field_path, value)
+        _assert_rejected(validator, fixture)
+
+
+def _assert_field_mutations_rejected(
+    validator: types.ModuleType,
+    tmp_path: Path,
+    target_name: str,
+    mutations: tuple[tuple[tuple[str, ...], object], ...],
+) -> None:
+    for field_path, value in mutations:
+        fixture = _promotion_fixture(tmp_path)
+        target = cast(dict[str, object], getattr(fixture, target_name))
+        _set_nested(target, field_path, value)
+        _assert_rejected(validator, fixture)
+
+
+def _assert_source_pull_mutations_rejected(validator: types.ModuleType, tmp_path: Path) -> None:
+    mutations: tuple[tuple[tuple[str, ...], object], ...] = (
+        (("state",), "open"),
+        (("merged_at",), None),
+        (("merge_commit_sha",), "9" * 40),
+        (("base", "ref"), "main"),
+        (("base", "sha"), "9" * 40),
+        (("base", "repo", "id"), 999),
+        (("base", "repo", "full_name"), "fork/specfact-cli"),
+        (("head", "ref"), "other-source"),
+        (("head", "sha"), "9" * 40),
+        (("head", "repo", "id"), 999),
+        (("head", "repo", "full_name"), "fork/specfact-cli"),
+    )
+    for field_path, value in mutations:
+        fixture = _promotion_fixture(tmp_path)
+        source_pull = cast(dict[str, object], fixture.source_pulls[1])
+        _set_nested(source_pull, field_path, value)
+        _assert_rejected(validator, fixture)
+    duplicate = _promotion_fixture(tmp_path)
+    other_pull = copy.deepcopy(cast(dict[str, object], duplicate.source_pulls[1]))
+    other_pull["number"] = 715
+    duplicate.source_pulls.append(other_pull)
+    _assert_rejected(validator, duplicate)
+
+
+def _assert_check_and_run_mutations_rejected(validator: types.ModuleType, tmp_path: Path) -> None:
+    for check_index in (0, 1):
+        for field_path, value in (
+            (("status",), "in_progress"),
+            (("conclusion",), "failure"),
+            (("head_sha",), "9" * 40),
+            (("app", "id"), 999),
+            (("app", "slug"), "spoof"),
+            (("app", "owner", "login"), "spoof"),
+            (("details_url",), f"https://github.com/{REPOSITORY}/actions/runs/999/job/1"),
+        ):
+            fixture = _promotion_fixture(tmp_path)
+            _set_nested(_object_list(fixture.check_runs, "check_runs")[check_index], field_path, value)
+            _assert_rejected(validator, fixture)
+    for check_index in (0, 1):
+        duplicate = _promotion_fixture(tmp_path)
+        checks = _object_list(duplicate.check_runs, "check_runs")
+        checks.append(copy.deepcopy(checks[check_index]))
+        duplicate.check_runs["total_count"] = len(checks)
+        _assert_rejected(validator, duplicate)
+    incomplete_checks = _promotion_fixture(tmp_path)
+    incomplete_checks.check_runs["total_count"] = 5
+    _assert_rejected(validator, incomplete_checks)
+    for target_name in ("requirements_run", "authority_run"):
+        _assert_field_mutations_rejected(
+            validator,
+            tmp_path,
+            target_name,
+            (
+                (("event",), "push"),
+                (("id",), 999),
+                (("name",), "Spoofed workflow"),
+                (("status",), "in_progress"),
+                (("conclusion",), "failure"),
+                (("head_sha",), "9" * 40),
+                (("head_branch",), "other"),
+                (("repository", "id"), 999),
+                (("repository", "full_name"), "fork/specfact-cli"),
+            ),
+        )
+    _assert_field_mutations_rejected(
+        validator,
+        tmp_path,
+        "requirements_run",
+        (
+            (("path",), ".github/workflows/spoof.yml"),
+            (("workflow_id",), 999),
+            (("workflow_url",), f"https://api.github.com/repos/{REPOSITORY}/actions/workflows/999"),
+        ),
+    )
+    _assert_field_mutations_rejected(
+        validator,
+        tmp_path,
+        "authority_run",
+        (
+            (("path",), ".github/workflows/spoof.yml"),
+            (("workflow_id",), 999),
+            (
+                ("workflow_url",),
+                f"https://api.github.com/repos/{REPOSITORY}/actions/workflows/{AUTHORITY_WORKFLOW_ID}",
+            ),
+        ),
+    )
+
+
+def _assert_artifact_metadata_mutations_rejected(validator: types.ModuleType, tmp_path: Path) -> None:
+    for artifact_index in (0, 1):
+        for field_path, value in (
+            (("id",), 999),
+            (("name",), "spoofed-evidence"),
+            (("expired",), True),
+            (("digest",), f"sha256:{'0' * 64}"),
+            (("workflow_run", "id"), 999),
+            (("workflow_run", "head_sha"), "9" * 40),
+            (("workflow_run", "head_branch"), "other-source"),
+            (("workflow_run", "head_repository_id"), 999),
+            (("workflow_run", "repository_id"), 999),
+        ):
+            fixture = _promotion_fixture(tmp_path)
+            _set_nested(_object_list(fixture.artifacts, "artifacts")[artifact_index], field_path, value)
+            _assert_rejected(validator, fixture)
+    for artifact_index in (0, 1):
+        missing = _promotion_fixture(tmp_path)
+        _object_list(missing.artifacts, "artifacts").pop(artifact_index)
+        _assert_rejected(validator, missing)
+        duplicate = _promotion_fixture(tmp_path)
+        artifacts = _object_list(duplicate.artifacts, "artifacts")
+        artifacts.append(copy.deepcopy(artifacts[artifact_index]))
+        duplicate.artifacts["total_count"] = len(artifacts)
+        _assert_rejected(validator, duplicate)
+    incomplete_artifacts = _promotion_fixture(tmp_path)
+    incomplete_artifacts.artifacts["total_count"] = 3
+    _assert_rejected(validator, incomplete_artifacts)
+
+
+def _assert_archive_semantic_mutations_rejected(validator: types.ModuleType, tmp_path: Path) -> None:
+    report_mutations: tuple[tuple[tuple[str, ...], object], ...] = (
+        (("verdict",), "failed"),
+        (("gate_decision",), "fail"),
+        (("required_maturity",), "planned"),
+        (("observed_maturity",), "red"),
+        (("delivery_status",), "proposal-only"),
+        (("implementation_evidence",), "not-yet-available"),
+        (("mapping_digest",), f"sha256:{'9' * 64}"),
+        (("plan_digest",), f"sha256:{'9' * 64}"),
+        (("execution_proof", "source_ref"), "9" * 40),
+        (("execution_proof", "proof_basis"), "untrusted"),
+        (("execution_proof", "selectors"), ["tests/test_other.py::test_other"]),
+        (("execution_proof", "junit_digest"), f"sha256:{'9' * 64}"),
+    )
+    for field_path, value in report_mutations:
+        fixture = _promotion_fixture(tmp_path)
+        _rewrite_json_member(fixture.producer_archive, "requirements-evidence.json", field_path, value)
+        _refresh_artifact_digest(fixture, 0, fixture.producer_archive)
+        _assert_rejected(validator, fixture)
+    for member in ("requirements-evidence.json", "requirements-evidence-plan.json", "requirements-proof.xml"):
+        fixture = _promotion_fixture(tmp_path)
+        files = _archive_files(fixture.producer_archive)
+        files.pop(member)
+        _write_archive(fixture.producer_archive, files)
+        _refresh_artifact_digest(fixture, 0, fixture.producer_archive)
+        _assert_rejected(validator, fixture)
+    tampered_junit = _promotion_fixture(tmp_path)
+    files = _archive_files(tampered_junit.producer_archive)
+    files["requirements-proof.xml"] += b"tampered"
+    _write_archive(tampered_junit.producer_archive, files)
+    _refresh_artifact_digest(tampered_junit, 0, tampered_junit.producer_archive)
+    _assert_rejected(validator, tampered_junit)
+    producer_plan = _promotion_fixture(tmp_path)
+    _rewrite_json_member(
+        producer_plan.producer_archive,
+        "requirements-evidence-plan.json",
+        ("plan", "plan_digest"),
+        f"sha256:{'9' * 64}",
+    )
+    _refresh_artifact_digest(producer_plan, 0, producer_plan.producer_archive)
+    _assert_rejected(validator, producer_plan)
+    mismatched_case = _promotion_fixture(tmp_path)
+    _rewrite_json_member(
+        mismatched_case.producer_archive,
+        "requirements-evidence-plan.json",
+        ("plan", "cases"),
+        [
+            {
+                "method": "test",
+                "node_id": "tests/test_other.py::test_other",
+                "selector": {"runner": "pytest", "node_id": "tests/test_other.py::test_other"},
+            }
+        ],
+    )
+    _refresh_artifact_digest(mismatched_case, 0, mismatched_case.producer_archive)
+    _assert_rejected(validator, mismatched_case)
+    execution_plan = _promotion_fixture(tmp_path)
+    _rewrite_json_member(
+        execution_plan.execution_archive,
+        "requirements-evidence-plan.json",
+        ("mapping_digest",),
+        f"sha256:{'9' * 64}",
+    )
+    _refresh_artifact_digest(execution_plan, 1, execution_plan.execution_archive)
+    _assert_rejected(validator, execution_plan)
+
+
+def test_incomplete_or_stale_promotion_provenance_is_rejected(tmp_path: Path) -> None:
+    validator = _load_validator()
+    for git_command, value in (
+        (("rev-parse", "HEAD"), "9" * 40),
+        (("rev-parse", "HEAD^{tree}"), "9" * 40),
+        (("rev-parse", "refs/remotes/origin/main^{commit}"), "9" * 40),
+        (("rev-parse", "refs/remotes/origin/dev^{commit}"), "9" * 40),
+        (("rev-list", "--parents", "-n", "1", HEAD_SHA), f"{HEAD_SHA} {PREVIOUS_DEV_SHA} {'9' * 40}"),
+        (("rev-parse", f"{SOURCE_SHA}^{{tree}}"), "9" * 40),
+    ):
+        fixture = _promotion_fixture(tmp_path)
+        fixture.git_outputs[git_command] = value
+        _assert_rejected(validator, fixture)
+    diverged = _promotion_fixture(tmp_path)
+    diverged.git_failures.add(("merge-base", "--is-ancestor", BASE_SHA, HEAD_SHA))
+    _assert_rejected(validator, diverged)
+    for commit in (BASE_SHA, HEAD_SHA, PREVIOUS_DEV_SHA, SOURCE_SHA):
+        missing_commit = _promotion_fixture(tmp_path)
+        missing_commit.git_failures.add(("cat-file", "-t", commit))
+        _assert_rejected(validator, missing_commit)
+    _assert_source_pull_mutations_rejected(validator, tmp_path)
+    _assert_check_and_run_mutations_rejected(validator, tmp_path)
+    _assert_artifact_metadata_mutations_rejected(validator, tmp_path)
+    _assert_archive_semantic_mutations_rejected(validator, tmp_path)

--- a/tests/unit/scripts/test_requirements_promotion_reuse.py
+++ b/tests/unit/scripts/test_requirements_promotion_reuse.py
@@ -136,6 +136,12 @@ def _refresh_artifact_digest(fixture: _PromotionFixture, artifact_index: int, ar
     _object_list(fixture.artifacts, "artifacts")[artifact_index]["digest"] = _artifact_digest(archive)
 
 
+def _rewrite_plan_member(fixture: _PromotionFixture, field_path: tuple[str, ...], value: object) -> None:
+    for artifact_index, archive in enumerate((fixture.producer_archive, fixture.execution_archive)):
+        _rewrite_json_member(archive, "requirements-evidence-plan.json", field_path, value)
+        _refresh_artifact_digest(fixture, artifact_index, archive)
+
+
 def _proof_archives(tmp_path: Path) -> tuple[Path, Path]:
     plan = {
         "schema_version": "2",
@@ -731,6 +737,15 @@ def _assert_archive_semantic_mutations_rejected(validator: types.ModuleType, tmp
         fixture = _promotion_fixture(tmp_path)
         _rewrite_json_member(fixture.producer_archive, "requirements-evidence.json", field_path, value)
         _refresh_artifact_digest(fixture, 0, fixture.producer_archive)
+        _assert_rejected(validator, fixture)
+    valid_source = {"source": "openspec/changes/fix", "mapping_digest": SOURCE_MAPPING_DIGEST}
+    for sources in (
+        [{**valid_source, "source": ""}],
+        [{**valid_source, "mapping_digest": "sha256:invalid"}],
+        [valid_source, copy.deepcopy(valid_source)],
+    ):
+        fixture = _promotion_fixture(tmp_path)
+        _rewrite_plan_member(fixture, ("sources",), sources)
         _assert_rejected(validator, fixture)
     for member in ("requirements-evidence.json", "requirements-evidence-plan.json", "requirements-proof.xml"):
         fixture = _promotion_fixture(tmp_path)

--- a/tests/unit/scripts/test_requirements_promotion_reuse.py
+++ b/tests/unit/scripts/test_requirements_promotion_reuse.py
@@ -648,7 +648,7 @@ def _assert_check_and_run_mutations_rejected(validator: types.ModuleType, tmp_pa
 def _assert_artifact_metadata_mutations_rejected(validator: types.ModuleType, tmp_path: Path) -> None:
     for artifact_index in (0, 1):
         for field_path, value in (
-            (("id",), 999),
+            (("id",), 0),
             (("name",), "spoofed-evidence"),
             (("expired",), True),
             (("digest",), f"sha256:{'0' * 64}"),

--- a/tests/unit/scripts/test_requirements_promotion_reuse.py
+++ b/tests/unit/scripts/test_requirements_promotion_reuse.py
@@ -29,7 +29,12 @@ SOURCE_SHA = "3" * 40
 HEAD_SHA = "4" * 40
 HEAD_TREE = "5" * 40
 MAPPING_DIGEST = f"sha256:{'6' * 64}"
+SOURCE_MAPPING_DIGEST = f"sha256:{'a' * 64}"
 PLAN_DIGEST = f"sha256:{'7' * 64}"
+PLANNED_SELECTORS = (
+    "tests/test_fix.py::test_z_fix",
+    "tests/test_fix.py::test_a_fix",
+)
 REQUIREMENTS_WORKFLOW_ID = 323253915
 AUTHORITY_WORKFLOW_ID = 348163848
 GitArguments = tuple[str, ...]
@@ -132,7 +137,6 @@ def _refresh_artifact_digest(fixture: _PromotionFixture, artifact_index: int, ar
 
 
 def _proof_archives(tmp_path: Path) -> tuple[Path, Path]:
-    selector = "tests/test_fix.py::test_fix"
     plan = {
         "schema_version": "2",
         "verdict": "passed",
@@ -141,7 +145,7 @@ def _proof_archives(tmp_path: Path) -> tuple[Path, Path]:
         "observed_maturity": "test-authored",
         "mapping_digest": MAPPING_DIGEST,
         "plan_identity_digest": f"sha256:{'8' * 64}",
-        "sources": [{"source": "openspec/changes/fix", "mapping_digest": MAPPING_DIGEST}],
+        "sources": [{"source": "openspec/changes/fix", "mapping_digest": SOURCE_MAPPING_DIGEST}],
         "plan": {
             "mapping_digest": MAPPING_DIGEST,
             "plan_digest": PLAN_DIGEST,
@@ -151,15 +155,21 @@ def _proof_archives(tmp_path: Path) -> tuple[Path, Path]:
                     "node_id": selector,
                     "selector": {"runner": "pytest", "node_id": selector},
                 }
+                for selector in PLANNED_SELECTORS
             ],
         },
     }
     junit = (
-        b'<testsuite tests="1" failures="0"><testcase><properties>'
-        b'<property name="specfact.selector" value="tests/test_fix.py::test_fix"/>'
-        b'<property name="specfact.runner" value="pytest"/>'
-        b"</properties></testcase></testsuite>\n"
-    )
+        '<testsuite tests="2" failures="0">'
+        + "".join(
+            "<testcase><properties>"
+            f'<property name="specfact.selector" value="{selector}"/>'
+            '<property name="specfact.runner" value="pytest"/>'
+            "</properties></testcase>"
+            for selector in PLANNED_SELECTORS
+        )
+        + "</testsuite>\n"
+    ).encode()
     report = {
         "schema_version": "2",
         "verdict": "passed",
@@ -174,7 +184,7 @@ def _proof_archives(tmp_path: Path) -> tuple[Path, Path]:
             "source_ref": SOURCE_SHA,
             "run_stage": "final",
             "proof_basis": "red-junit",
-            "selectors": [selector],
+            "selectors": sorted(PLANNED_SELECTORS),
             "junit_digest": f"sha256:{hashlib.sha256(junit).hexdigest()}",
         },
     }
@@ -714,6 +724,7 @@ def _assert_archive_semantic_mutations_rejected(validator: types.ModuleType, tmp
         (("execution_proof", "source_ref"), "9" * 40),
         (("execution_proof", "proof_basis"), "untrusted"),
         (("execution_proof", "selectors"), ["tests/test_other.py::test_other"]),
+        (("execution_proof", "selectors"), [PLANNED_SELECTORS[0], PLANNED_SELECTORS[0]]),
         (("execution_proof", "junit_digest"), f"sha256:{'9' * 64}"),
     )
     for field_path, value in report_mutations:

--- a/tests/unit/scripts/test_requirements_promotion_reuse.py
+++ b/tests/unit/scripts/test_requirements_promotion_reuse.py
@@ -7,6 +7,7 @@ import hashlib
 import importlib.util
 import inspect
 import json
+import os
 import subprocess
 import sys
 import types
@@ -476,17 +477,42 @@ def _assert_default_git_runner(tmp_path: Path) -> None:
     validator = _load_validator()
     repo_root = tmp_path / "git-repository"
     repo_root.mkdir()
-    subprocess.run(["git", "init", "--quiet"], cwd=repo_root, check=True)
-    subprocess.run(["git", "config", "user.email", "proof@example.test"], cwd=repo_root, check=True)
-    subprocess.run(["git", "config", "user.name", "Proof"], cwd=repo_root, check=True)
+    git_environment = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_CONFIG_")
+        and key not in {"GIT_COMMON_DIR", "GIT_DIR", "GIT_INDEX_FILE", "GIT_TEMPLATE_DIR", "GIT_WORK_TREE"}
+    }
+    git_environment.update(
+        {
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "XDG_CONFIG_HOME": str(tmp_path / "xdg"),
+        }
+    )
+    git_command = ["git", "-c", f"core.hooksPath={os.devnull}"]
+    subprocess.run([*git_command, "init", "--quiet", "--template="], cwd=repo_root, check=True, env=git_environment)
+    subprocess.run(
+        [*git_command, "config", "user.email", "proof@example.test"],
+        cwd=repo_root,
+        check=True,
+        env=git_environment,
+    )
+    subprocess.run([*git_command, "config", "user.name", "Proof"], cwd=repo_root, check=True, env=git_environment)
     (repo_root / "proof.txt").write_text("proof\n", encoding="utf-8")
-    subprocess.run(["git", "add", "proof.txt"], cwd=repo_root, check=True)
-    subprocess.run(["git", "commit", "--quiet", "--no-gpg-sign", "-m", "proof"], cwd=repo_root, check=True)
+    subprocess.run([*git_command, "add", "proof.txt"], cwd=repo_root, check=True, env=git_environment)
+    subprocess.run(
+        [*git_command, "commit", "--quiet", "--no-gpg-sign", "-m", "proof"],
+        cwd=repo_root,
+        check=True,
+        env=git_environment,
+    )
     expected = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
+        [*git_command, "rev-parse", "HEAD"],
         cwd=repo_root,
         check=True,
         capture_output=True,
+        env=git_environment,
         text=True,
     ).stdout.strip()
     assert validator._run_git(repo_root, ["rev-parse", "HEAD"]) == expected

--- a/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
+++ b/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
@@ -17,6 +17,17 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 APPROVED_MODULE_COMMIT = "69f075819be5e1ceca1446b026b0417f19e584ca"
+TRUSTED_AUTHORITY_COMMIT = "f7a22379f88010d77c86f9b2bbaf1ac58f15d85d"
+TRUSTED_AUTHORITY_TREE = "47f33b4df92060a36f3afd92948e441555fb280d"
+TRUSTED_AUTHORITY_BLOB = "8c7b30020033c6b6081d6e743d77aa76043724ea"
+TRUSTED_AUTHORITY_SHA256 = "5441e26e7c3c8f18973c781e7d43c72076b3283c915d98ca5188bb174bf17c45"
+PROMOTION_CONDITION = (
+    "github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'dev' && "
+    "github.event.pull_request.base.repo.id == github.event.repository.id && "
+    "github.event.pull_request.head.repo.id == github.event.repository.id && "
+    "github.event.pull_request.base.repo.full_name == github.event.repository.full_name && "
+    "github.event.pull_request.head.repo.full_name == github.event.repository.full_name"
+)
 EVIDENCE_COMMAND_FRAGMENTS = (
     '"${isolated_specfact[@]}" requirements evidence',
     '--base-ref "$evidence_base_commit"',
@@ -1311,6 +1322,245 @@ def test_requirements_evidence_workflow_binds_red_proof_before_publication() -> 
     assert "printf 'Red proof retained; final reconciliation is required.\\n'" in command
     assert "exit_code=1" in command[command.index(binding) : command.index("fallback_required=0")]
     assert command.index(binding) < command.index("fallback_required=0")
+
+
+@dataclass(frozen=True)
+class _PromotionStage:
+    name: str
+    step_id: str
+    policy_path: str
+    evidence_step_name: str
+    expected_attestation: str | None
+    output_attestation: str
+
+
+def _assert_promotion_authority(authority: dict[str, object], policy_path: str) -> None:
+    command = cast(str, authority["run"])
+    trusted_script = f"${{GITHUB_WORKSPACE}}/{policy_path}/.github/scripts/trusted_requirements_authority.py"
+    fragments = (
+        f'trusted_policy_commit="{TRUSTED_AUTHORITY_COMMIT}"',
+        f'trusted_policy_tree="{TRUSTED_AUTHORITY_TREE}"',
+        f'trusted_policy_blob="{TRUSTED_AUTHORITY_BLOB}"',
+        f'trusted_policy_digest="{TRUSTED_AUTHORITY_SHA256}"',
+        'test "$(git -C "$trusted_policy_root" remote get-url origin)" = "https://github.com/nold-ai/.github"',
+        'test "$(git -C "$trusted_policy_root" rev-parse HEAD)" = "$trusted_policy_commit"',
+        'test "$(git -C "$trusted_policy_root" rev-parse \'HEAD^{tree}\')" = "$trusted_policy_tree"',
+        'test "$(git -C "$trusted_policy_root" rev-parse \'HEAD:.github/scripts/trusted_requirements_authority.py\')" = "$trusted_policy_blob"',
+        'test "$(sha256sum < "$trusted_policy_script" | cut -d \' \' -f 1)" = "$trusted_policy_digest"',
+        f'"{trusted_script}"',
+        '--event "$GITHUB_EVENT_PATH"',
+    )
+    positions = [command.index(fragment) for fragment in fragments]
+    assert positions == sorted(positions)
+    assert authority["env"] == {"GITHUB_TOKEN": "${{ github.token }}"}
+
+
+def _assert_promotion_fetch(fetch: dict[str, object]) -> None:
+    command = cast(str, fetch["run"])
+    fragments = (
+        "git fetch --no-tags origin",
+        'git merge-base --is-ancestor "$base_sha" "$head_sha"',
+        'git rev-list --parents -n 1 "$head_sha"',
+        "--paginate --slurp",
+        "commits/${source_head}/pulls",
+        "commits/${source_head}/check-runs?per_page=100",
+        "actions/runs/${requirements_run_id}",
+        "actions/runs/${authority_run_id}",
+        "actions/runs/${requirements_run_id}/artifacts?per_page=100",
+        "actions/artifacts/${producer_artifact_id}/zip",
+        "actions/artifacts/${execution_artifact_id}/zip",
+    )
+    assert all(fragment in command for fragment in fragments)
+    assert fetch["env"] == {"GH_TOKEN": "${{ github.token }}"}
+    assert "scripts/requirements_promotion_reuse.py" not in command
+
+
+def _assert_promotion_validation(validate: dict[str, object], stage: _PromotionStage) -> None:
+    command = cast(str, validate["run"])
+    metadata_root = f"${{RUNNER_TEMP}}/promotion-{stage.step_id}"
+    arguments = (
+        ("--event", "$GITHUB_EVENT_PATH"),
+        ("--repo-root", "$GITHUB_WORKSPACE"),
+        ("--source-pulls", f"{metadata_root}/source-pulls.json"),
+        ("--check-runs", f"{metadata_root}/check-runs.json"),
+        ("--requirements-run", f"{metadata_root}/requirements-run.json"),
+        ("--authority-run", f"{metadata_root}/authority-run.json"),
+        ("--artifacts", f"{metadata_root}/artifacts.json"),
+        ("--producer-archive", f"{metadata_root}/producer.zip"),
+        ("--execution-archive", f"{metadata_root}/execution.zip"),
+        ("--output", stage.output_attestation),
+    )
+    assert validate["id"] == stage.step_id
+    assert "scripts/requirements_promotion_reuse.py" in command
+    assert not {"GITHUB_TOKEN", "GH_TOKEN"}.intersection(cast(dict[str, str], validate.get("env", {})))
+    assert all(f'{argument} "{value}"' in command for argument, value in arguments)
+    if stage.expected_attestation is None:
+        assert "--expected-attestation" not in command
+        return
+    assert f'--expected-attestation "{stage.expected_attestation}"' in command
+    assert f'cmp --silent "{stage.output_attestation}" "{stage.expected_attestation}"' in command
+
+
+def _assert_promotion_stage_boundary(workflow: dict[str, object], stage: _PromotionStage) -> None:
+    checkout_name = f"Checkout trusted promotion authority policy for {stage.name}"
+    authority_name = f"Authenticate protected promotion head for {stage.name}"
+    fetch_name = f"Fetch protected promotion evidence for {stage.name}"
+    validate_name = f"Validate protected promotion evidence for {stage.name}"
+    checkout = _step_by_name(workflow, checkout_name)
+    authority = _step_by_name(workflow, authority_name)
+    fetch = _step_by_name(workflow, fetch_name)
+    validate = _step_by_name(workflow, validate_name)
+    checkout_with = cast(dict[str, str], checkout["with"])
+
+    assert all(step["if"] == PROMOTION_CONDITION for step in (checkout, authority, fetch, validate))
+    assert all("continue-on-error" not in step for step in (checkout, authority, fetch, validate))
+    assert checkout_with["repository"] == "nold-ai/.github"
+    assert checkout_with["ref"] == TRUSTED_AUTHORITY_COMMIT
+    assert checkout_with["path"] == stage.policy_path
+    assert checkout_with["persist-credentials"] == "false"
+    assert checkout["uses"] == "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
+    _assert_promotion_authority(authority, stage.policy_path)
+    _assert_promotion_fetch(fetch)
+    _assert_promotion_validation(validate, stage)
+    _assert_step_order(workflow, checkout_name, authority_name)
+    _assert_step_order(workflow, authority_name, fetch_name)
+    _assert_step_order(workflow, fetch_name, validate_name)
+    _assert_step_order(workflow, validate_name, stage.evidence_step_name)
+
+
+def _promotion_commands(workflow: dict[str, object]) -> tuple[str, str, str]:
+    producer = _step_by_name(workflow, "Run Requirements evidence gate")
+    consumer = _step_by_name(workflow, "Reconcile Requirements evidence on fresh runner")
+    final = _step_by_name(workflow, "Reconcile final Requirements verdict on fresh runner")
+    return cast(str, producer["run"]), cast(str, consumer["run"]), cast(str, final["run"])
+
+
+def _assert_promotion_stage_outputs(workflow: dict[str, object]) -> None:
+    producer = _step_by_name(workflow, "Run Requirements evidence gate")
+    consumer = _step_by_name(workflow, "Reconcile Requirements evidence on fresh runner")
+    final = _step_by_name(workflow, "Reconcile final Requirements verdict on fresh runner")
+    assert (
+        cast(dict[str, str], producer["env"])["EVIDENCE_PROMOTION_REUSE"]
+        == "${{ steps.producer-promotion.outputs.active }}"
+    )
+    assert (
+        cast(dict[str, str], consumer["env"])["EVIDENCE_PROMOTION_REUSE"]
+        == "${{ steps.execution-promotion.outputs.active }}"
+    )
+    assert (
+        cast(dict[str, str], final["env"])["EVIDENCE_PROMOTION_REUSE"] == "${{ steps.final-promotion.outputs.active }}"
+    )
+
+
+def _assert_promotion_scope(workflow: dict[str, object], commands: tuple[str, str, str]) -> None:
+    producer_command, consumer_command, final_command = commands
+    producer_base = 'evidence_base_commit="$(git merge-base "origin/${EVIDENCE_BASE_BRANCH}" HEAD)"'
+    consumer_base = 'evidence_base_commit="$(git merge-base "origin/${GITHUB_BASE_REF}" "$source_ref")"'
+    assert producer_command.count(producer_base) == 1
+    assert consumer_command.count(consumer_base) == 1
+    assert producer_command.count('--base-ref "$evidence_base_commit"') == 1
+    assert consumer_command.count('--base-ref "$evidence_base_commit"') == 1
+    assert final_command.count('--base-ref "$FINAL_BASE_COMMIT"') == 1
+    assert "evidence_scope_commit=" not in producer_command + consumer_command
+    assert "final_scope_commit=" not in final_command
+    final_core = cast(str, _step_by_name(workflow, "Materialize trusted final Requirements core")["run"])
+    assert 'base_commit="$(git merge-base "origin/${GITHUB_BASE_REF}" HEAD)"' in final_core
+    assert "printf 'FINAL_BASE_COMMIT=%s\\n' \"$base_commit\"" in final_core
+
+
+def _assert_promotion_planning(commands: tuple[str, str, str]) -> None:
+    for command in commands:
+        assert 'if [[ "$EVIDENCE_PROMOTION_REUSE" == "true" ]]; then' in command
+        assert "planning_maturity=planned" in command
+        assert '.gate_decision == "pass"' in command
+        assert ".plan.cases | length > 0" in command
+
+
+def _assert_promotion_artifacts(workflow: dict[str, object], commands: tuple[str, str, str]) -> None:
+    producer_command, consumer_command, final_command = commands
+    assert "requirements-promotion-reuse.json" in producer_command
+    assert "requirements-promotion-reuse.json" in consumer_command
+    assert 'test -s "$execution_root/requirements-promotion-reuse.json"' in final_command
+    assert 'review_base_commit="$(git merge-base "origin/${REVIEW_BASE_BRANCH}" HEAD)"' in consumer_command
+
+    producer_upload = _step_by_name(workflow, "Persist Requirements evidence before Code Review")
+    execution_upload = _step_by_name(workflow, "Persist fresh Requirements execution artifact")
+    producer_paths = cast(dict[str, str], producer_upload["with"])["path"]
+    execution_paths = cast(dict[str, str], execution_upload["with"])["path"]
+    assert "artifacts/requirements-evidence/requirements-promotion-reuse.json" in producer_paths
+    assert "artifacts/requirements-evidence/final-verification/requirements-promotion-reuse.json" in execution_paths
+
+
+def _assert_promotion_plan_and_attestation_contract(workflow: dict[str, object]) -> None:
+    commands = _promotion_commands(workflow)
+    _assert_promotion_stage_outputs(workflow)
+    _assert_promotion_scope(workflow, commands)
+    _assert_promotion_planning(commands)
+    _assert_promotion_artifacts(workflow, commands)
+
+
+def test_workflow_revalidates_promotion_reuse_in_all_stages() -> None:
+    """Producer, execution, and final authenticate reuse independently."""
+    workflow = yaml.load(
+        (REPO_ROOT / ".github" / "workflows" / "requirements-evidence.yml").read_text(encoding="utf-8"),
+        Loader=yaml.BaseLoader,
+    )
+    stages = (
+        _PromotionStage(
+            "producer",
+            "producer-promotion",
+            "promotion-authority-policy-producer",
+            "Run Requirements evidence gate",
+            None,
+            "artifacts/requirements-evidence/requirements-promotion-reuse.json",
+        ),
+        _PromotionStage(
+            "fresh execution",
+            "execution-promotion",
+            "promotion-authority-policy-execution",
+            "Reconcile Requirements evidence on fresh runner",
+            "artifacts/requirements-evidence/requirements-promotion-reuse.json",
+            "artifacts/requirements-evidence/final-verification/requirements-promotion-reuse.json",
+        ),
+        _PromotionStage(
+            "final verdict",
+            "final-promotion",
+            "promotion-authority-policy-final",
+            "Reconcile final Requirements verdict on fresh runner",
+            "${RUNNER_TEMP}/requirements-execution/requirements-promotion-reuse.json",
+            "${RUNNER_TEMP}/final-promotion-reuse.json",
+        ),
+    )
+    for stage in stages:
+        _assert_promotion_stage_boundary(workflow, stage)
+    _assert_promotion_plan_and_attestation_contract(workflow)
+
+
+def test_same_named_fork_does_not_enter_promotion_path() -> None:
+    """A fork branch named dev remains on the ordinary Requirements path."""
+    workflow = yaml.load(
+        (REPO_ROOT / ".github" / "workflows" / "requirements-evidence.yml").read_text(encoding="utf-8"),
+        Loader=yaml.BaseLoader,
+    )
+    promotion_steps = (
+        "Checkout trusted promotion authority policy for producer",
+        "Authenticate protected promotion head for producer",
+        "Fetch protected promotion evidence for producer",
+        "Validate protected promotion evidence for producer",
+        "Checkout trusted promotion authority policy for fresh execution",
+        "Authenticate protected promotion head for fresh execution",
+        "Fetch protected promotion evidence for fresh execution",
+        "Validate protected promotion evidence for fresh execution",
+        "Checkout trusted promotion authority policy for final verdict",
+        "Authenticate protected promotion head for final verdict",
+        "Fetch protected promotion evidence for final verdict",
+        "Validate protected promotion evidence for final verdict",
+    )
+    for step_name in promotion_steps:
+        condition = cast(str, _step_by_name(workflow, step_name)["if"])
+        assert condition == PROMOTION_CONDITION
+        assert "pull_request.head.repo.id == github.event.repository.id" in condition
+        assert "pull_request.head.repo.full_name == github.event.repository.full_name" in condition
 
 
 def _review_and_enforcement_steps() -> tuple[

--- a/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
+++ b/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
@@ -466,6 +466,7 @@ def _assert_retention_contract(workflow: dict[str, object]) -> None:
         "artifacts/requirements-evidence/requirements-evidence.md",
         "artifacts/requirements-evidence/requirements-evidence-plan.json",
         "artifacts/requirements-evidence/requirements-proof.xml",
+        "artifacts/requirements-evidence/requirements-promotion-reuse.json",
         "artifacts/requirements-evidence/approved-legacy-tdd-ledger.md",
         "artifacts/requirements-evidence/legacy-tdd-evidence.json",
     ]


### PR DESCRIPTION
# Description

Authenticate reuse of already-verified Requirements evidence for the exact
same-repository `dev`-to-`main` release promotion. The implementation binds the
promotion merge topology, source pull request, GitHub-owned checks and runs,
artifact digests, report/plan/JUnit bytes, and all three workflow stages while
leaving ordinary pull requests unchanged.

**Part of** #692

**Blocks** #691

**Contract References**: OpenSpec change
`fix-release-promotion-requirements-parity`; no packaged CLI contract changes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test enhancement (scenario and security-boundary tests)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Public documentation update
- [ ] 🔒 Packaged contract enforcement
- [x] 🔧 Refactoring (review-gate input grouping only)

## Contract-First Testing Evidence

This is a standard-library-only workflow verifier executed with `python -I -S`;
project `icontract` and `beartype` dependencies are intentionally excluded from
that independent trust boundary. The public CLI and package API are unchanged.

- [x] Strict OpenSpec validation
- [x] Five mapped selectors with immutable append-only RED evidence
- [x] Focused validator/workflow suite: 29 passed on Python 3.12
- [x] Real PR #704 producer/execution artifact validation: 34 selectors accepted
- [x] Full local suite: 3,120 passed, 9 skipped; three host-only failures were
  separately controlled, with the remaining user-home write deferred to CI
- [x] GitHub Python 3.11 compatibility and runtime matrices

## Security and Quality Evidence

- [x] Independent security-boundary and bypass/regression reviews: no actionable
  P0/P1/P2
- [x] SpecFact review: no errors; two documented stdlib-isolation contract
  warnings and one auditability-preserving length advisory
- [x] Frozen runtime and Code Review pip-audit: no unreviewed vulnerabilities
- [x] Socket Security pull-request and project reports
- [x] Bandit high-severity scan and Semgrep SAST gate: zero findings
- [x] Ruff, basedpyright, workflow lint, docs review, reproducible delivery, and
  strict module-signature verification

## Test Environment

- Local: Python 3.12.13, macOS
- CI: Python 3.11/3.12/3.13 package matrices and Python 3.12 full suite

## Checklist

- [x] Code follows repository style and safe-write rules
- [x] Self-review and independent code/security reviews completed
- [x] Behavior was specified and tested before implementation
- [x] Error and bypass controls cover lookalikes, stale/spoofed metadata,
  ambiguous collections, malformed archives/XML, and digest mismatches
- [x] No dependency, version, module manifest, or public documentation change
- [x] Existing unreleased version remains `0.55.4`
- [ ] Exact-head Trusted Requirements Authority check (awaiting final comment)
- [ ] Merge to `dev` after every required check passes

## Scope and Rollback

This is the smallest release-promotion parity repair for the unreleased 0.55.4
patch transaction. It does not change dependencies, package version, core CLI
behavior, module payloads, or published history. Rollback is a normal revert of
this PR's merge commit; published-release rollback remains normal yank/release
guidance.

Screenshots and recordings are not applicable to this internal CI boundary.
