### PR TITLE
fix(ci): validate promotion plan from plan artifact

### DIFF
--- a/.github/workflows/requirements-evidence.yml
+++ b/.github/workflows/requirements-evidence.yml
@@ -711,8 +711,10 @@ jobs:
           failure_diagnostic="Evidence command exited with status $exit_code before writing reports."
           if [[ "$EVIDENCE_PROMOTION_REUSE" == "true" ]]; then
             test -s artifacts/requirements-evidence/requirements-promotion-reuse.json
-            jq -e '.gate_decision == "pass" and (.plan.cases | length > 0)' \
+            jq -e '.gate_decision == "pass"' \
               artifacts/requirements-evidence/requirements-evidence.json > /dev/null
+            jq -e '.gate_decision == "pass" and (.plan.cases | length > 0)' \
+              artifacts/requirements-evidence/requirements-evidence-plan.json > /dev/null
           elif [[ "$exit_code" -eq 0 && "$required_maturity" != "planned" ]]; then
             run_stage=red
             if [[ "$required_maturity" == "verified" ]]; then
@@ -1573,8 +1575,9 @@ jobs:
           if [[ "$EVIDENCE_PROMOTION_REUSE" == "true" ]]; then
             test -s artifacts/requirements-evidence/final-verification/requirements-promotion-reuse.json
             cp "$consumer_planning_report" "$consumer_report"
+            jq -e '.gate_decision == "pass"' "$consumer_report" > /dev/null
             jq -e '.gate_decision == "pass" and (.plan.cases | length > 0)' \
-              "$consumer_report" > /dev/null
+              "$consumer_plan" > /dev/null
           elif [[ "$required_maturity" == "planned" ]]; then
             cp "$consumer_planning_report" "$consumer_report"
           else
@@ -2420,8 +2423,9 @@ jobs:
           if [[ "$EVIDENCE_PROMOTION_REUSE" == "true" ]]; then
             test -s "$execution_root/requirements-promotion-reuse.json"
             cp "$final_planning_report" "$final_report"
+            jq -e '.gate_decision == "pass"' "$final_report" > /dev/null
             jq -e '.gate_decision == "pass" and (.plan.cases | length > 0)' \
-              "$final_report" > /dev/null
+              "$final_plan" > /dev/null
             cat "$final_summary" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           elif [[ "$required_maturity" == "planned" ]]; then

--- a/.github/workflows/requirements-evidence.yml
+++ b/.github/workflows/requirements-evidence.yml
@@ -81,7 +81,7 @@ jobs:
           python-version: "3.12"
 
       - name: Checkout trusted Requirements authority policy
-        if: github.event_name == 'pull_request' && github.event.pull_request.number == 704 && github.head_ref == 'bugfix/692-release-review-followup' && hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') != ''
+        if: github.event_name == 'pull_request' && github.event.pull_request.number == 715 && github.head_ref == 'bugfix/692-promotion-exit-code' && hashFiles('openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json') != ''
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           repository: nold-ai/.github
@@ -91,7 +91,7 @@ jobs:
 
       - name: Validate exact final Requirements authority
         id: late-red
-        if: github.event_name == 'pull_request' && github.event.pull_request.number == 704 && github.head_ref == 'bugfix/692-release-review-followup' && hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') != ''
+        if: github.event_name == 'pull_request' && github.event.pull_request.number == 715 && github.head_ref == 'bugfix/692-promotion-exit-code' && hashFiles('openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json') != ''
         env:
           GITHUB_TOKEN: ${{ github.token }}
         shell: bash
@@ -99,7 +99,7 @@ jobs:
           set -euo pipefail
           trusted_policy_commit="f7a22379f88010d77c86f9b2bbaf1ac58f15d85d"
           trusted_policy_root="${GITHUB_WORKSPACE}/trusted-requirements-policy"
-          manifest="openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json"
+          manifest="openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json"
           test "$(git -C "$trusted_policy_root" rev-parse HEAD)" = "$trusted_policy_commit"
           test "$(git -C "$trusted_policy_root" remote get-url origin)" = "https://github.com/nold-ai/.github"
           test "$(jq -er '.pull_request.head.sha' "$GITHUB_EVENT_PATH")" = "$(git rev-parse HEAD)"
@@ -134,7 +134,7 @@ jobs:
              .name == "Requirements Evidence" and
              .path == ".github/workflows/requirements-evidence.yml" and
              .repository.full_name == $repository and
-             [.pull_requests[].number] == [704]' \
+             [.pull_requests[].number] == [715]' \
             "$metadata_root/run.json" > /dev/null
           jq -e \
             --argjson run_id "$late_red_run_id" \
@@ -324,7 +324,7 @@ jobs:
           printf 'active=true\n' >> "$GITHUB_OUTPUT"
 
       - name: Download exact late RED artifact
-        if: github.event_name == 'pull_request' && github.event.pull_request.number == 704 && github.head_ref == 'bugfix/692-release-review-followup' && hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') != ''
+        if: github.event_name == 'pull_request' && github.event.pull_request.number == 715 && github.head_ref == 'bugfix/692-promotion-exit-code' && hashFiles('openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json') != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           artifact-ids: ${{ steps.late-red.outputs.artifact-id }}
@@ -333,11 +333,11 @@ jobs:
           run-id: ${{ steps.late-red.outputs.run-id }}
 
       - name: Normalize exact late RED proof
-        if: github.event_name == 'pull_request' && github.event.pull_request.number == 704 && github.head_ref == 'bugfix/692-release-review-followup' && hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') != ''
+        if: github.event_name == 'pull_request' && github.event.pull_request.number == 715 && github.head_ref == 'bugfix/692-promotion-exit-code' && hashFiles('openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json') != ''
         shell: bash
         run: |
           set -euo pipefail
-          manifest="openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json"
+          manifest="openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json"
           cycle_base_commit="$(jq -er '.cycle_base_commit | select(type == "string" and test("^[0-9a-f]{40}$"))' "$manifest")"
           trusted_provenance_root="${RUNNER_TEMP}/late-red-trusted-provenance"
           mkdir -p "$trusted_provenance_root"
@@ -364,7 +364,7 @@ jobs:
 
       - name: Locate retained red proof run
         id: prior-red-run
-        if: github.event_name == 'pull_request' && (github.event.pull_request.number != 704 || github.head_ref != 'bugfix/692-release-review-followup' || hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') == '')
+        if: github.event_name == 'pull_request' && (github.event.pull_request.number != 715 || github.head_ref != 'bugfix/692-promotion-exit-code' || hashFiles('openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json') == '')
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -473,7 +473,7 @@ jobs:
           EVIDENCE_HEAD_BRANCH: ${{ github.head_ref }}
           EVIDENCE_PULL_REQUEST: ${{ github.event.pull_request.number }}
           EVIDENCE_PROMOTION_REUSE: ${{ steps.producer-promotion.outputs.active }}
-          LATE_RED_ACTIVE: ${{ github.event.pull_request.number == 704 && github.head_ref == 'bugfix/692-release-review-followup' && hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') != '' }}
+          LATE_RED_ACTIVE: ${{ github.event.pull_request.number == 715 && github.head_ref == 'bugfix/692-promotion-exit-code' && hashFiles('openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json') != '' }}
         run: |
           set -e
           validator_site="${REQUIREMENTS_VALIDATOR_ROOT}/lib/python3.12/site-packages"
@@ -673,7 +673,7 @@ jobs:
           prior_red_report_digest=""
           prior_red_junit_digest=""
           prior_red_provenance_digest=""
-          late_red_manifest="openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json"
+          late_red_manifest="openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json"
           late_red_manifest_digest=""
           if [[ "$LATE_RED_ACTIVE" == "true" ]]; then
             prior_red_base_ref="$(jq -er '.cycle_base_commit | select(type == "string" and test("^[0-9a-f]{40}$"))' "$late_red_manifest")"
@@ -1263,7 +1263,7 @@ jobs:
           printf 'active=true\n' >> "$GITHUB_OUTPUT"
 
       - name: Checkout trusted Requirements authority policy
-        if: github.event_name == 'pull_request' && github.event.pull_request.number == 704 && github.head_ref == 'bugfix/692-release-review-followup' && hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') != ''
+        if: github.event_name == 'pull_request' && github.event.pull_request.number == 715 && github.head_ref == 'bugfix/692-promotion-exit-code' && hashFiles('openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json') != ''
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           repository: nold-ai/.github
@@ -1273,7 +1273,7 @@ jobs:
 
       - name: Validate exact final Requirements authority
         id: late-red
-        if: github.event_name == 'pull_request' && github.event.pull_request.number == 704 && github.head_ref == 'bugfix/692-release-review-followup' && hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') != ''
+        if: github.event_name == 'pull_request' && github.event.pull_request.number == 715 && github.head_ref == 'bugfix/692-promotion-exit-code' && hashFiles('openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json') != ''
         env:
           GITHUB_TOKEN: ${{ github.token }}
         shell: bash
@@ -1281,7 +1281,7 @@ jobs:
           set -euo pipefail
           trusted_policy_commit="f7a22379f88010d77c86f9b2bbaf1ac58f15d85d"
           trusted_policy_root="${GITHUB_WORKSPACE}/trusted-requirements-policy"
-          manifest="openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json"
+          manifest="openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json"
           test "$(git -C "$trusted_policy_root" rev-parse HEAD)" = "$trusted_policy_commit"
           test "$(git -C "$trusted_policy_root" remote get-url origin)" = "https://github.com/nold-ai/.github"
           test "$(jq -er '.pull_request.head.sha' "$GITHUB_EVENT_PATH")" = "$(git rev-parse HEAD)"
@@ -1315,7 +1315,7 @@ jobs:
              .name == "Requirements Evidence" and
              .path == ".github/workflows/requirements-evidence.yml" and
              .repository.full_name == $repository and
-             [.pull_requests[].number] == [704]' \
+             [.pull_requests[].number] == [715]' \
             "$metadata_root/run.json" > /dev/null
           jq -e \
             --argjson run_id "$late_red_run_id" \
@@ -1335,7 +1335,7 @@ jobs:
             printf 'cycle-base-ref=%s\n' "$late_red_cycle_base"
           } >> "$GITHUB_OUTPUT"
       - name: Download exact late RED artifact
-        if: github.event_name == 'pull_request' && github.event.pull_request.number == 704 && github.head_ref == 'bugfix/692-release-review-followup' && hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') != ''
+        if: github.event_name == 'pull_request' && github.event.pull_request.number == 715 && github.head_ref == 'bugfix/692-promotion-exit-code' && hashFiles('openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json') != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           artifact-ids: ${{ steps.late-red.outputs.artifact-id }}
@@ -1344,11 +1344,11 @@ jobs:
           run-id: ${{ steps.late-red.outputs.run-id }}
 
       - name: Normalize exact late RED proof
-        if: github.event_name == 'pull_request' && github.event.pull_request.number == 704 && github.head_ref == 'bugfix/692-release-review-followup' && hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') != ''
+        if: github.event_name == 'pull_request' && github.event.pull_request.number == 715 && github.head_ref == 'bugfix/692-promotion-exit-code' && hashFiles('openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json') != ''
         shell: bash
         run: |
           set -euo pipefail
-          manifest="openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json"
+          manifest="openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json"
           cycle_base_commit="$(jq -er '.cycle_base_commit | select(type == "string" and test("^[0-9a-f]{40}$"))' "$manifest")"
           trusted_provenance_root="${RUNNER_TEMP}/late-red-trusted-provenance"
           mkdir -p "$trusted_provenance_root"
@@ -1442,7 +1442,7 @@ jobs:
         timeout-minutes: 12
         env:
           EVIDENCE_PROMOTION_REUSE: ${{ steps.execution-promotion.outputs.active }}
-          LATE_RED_ACTIVE: ${{ github.event.pull_request.number == 704 && github.head_ref == 'bugfix/692-release-review-followup' && hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') != '' }}
+          LATE_RED_ACTIVE: ${{ github.event.pull_request.number == 715 && github.head_ref == 'bugfix/692-promotion-exit-code' && hashFiles('openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json') != '' }}
           LATE_RED_CYCLE_BASE: ${{ steps.late-red.outputs.cycle-base-ref }}
           PRIOR_RED_ARTIFACT_DIGEST: ${{ steps.consumer-red.outputs.artifact-digest }}
           PRIOR_RED_HEAD_SHA: ${{ steps.consumer-red.outputs.head-sha }}
@@ -1692,7 +1692,7 @@ jobs:
             )
             prior_red_root="${RUNNER_TEMP}/consumer-prior-red"
             prior_red_proof="${prior_red_root}/red.json"
-            late_red_manifest="openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json"
+          late_red_manifest="openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json"
             legacy_tdd_evidence="artifacts/requirements-evidence/legacy-tdd-evidence.json"
             legacy_tdd_ledger="artifacts/requirements-evidence/approved-legacy-tdd-ledger.md"
             if [[ "$LATE_RED_ACTIVE" == "true" ]]; then
@@ -1999,7 +1999,7 @@ jobs:
             "$execution_metadata" > /dev/null
 
       - name: Checkout trusted Requirements authority policy for final verdict
-        if: github.event.pull_request.number == 704 && github.head_ref == 'bugfix/692-release-review-followup' && hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') != ''
+        if: github.event.pull_request.number == 715 && github.head_ref == 'bugfix/692-promotion-exit-code' && hashFiles('openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json') != ''
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           repository: nold-ai/.github
@@ -2009,7 +2009,7 @@ jobs:
 
       - name: Revalidate exact final Requirements authority
         id: final-late-red
-        if: github.event.pull_request.number == 704 && github.head_ref == 'bugfix/692-release-review-followup' && hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') != ''
+        if: github.event.pull_request.number == 715 && github.head_ref == 'bugfix/692-promotion-exit-code' && hashFiles('openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json') != ''
         env:
           GITHUB_TOKEN: ${{ github.token }}
         shell: bash
@@ -2017,7 +2017,7 @@ jobs:
           set -euo pipefail
           trusted_policy_commit="f7a22379f88010d77c86f9b2bbaf1ac58f15d85d"
           trusted_policy_root="${GITHUB_WORKSPACE}/final-trusted-requirements-policy"
-          manifest="openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json"
+          manifest="openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json"
           test "$(git -C "$trusted_policy_root" rev-parse HEAD)" = "$trusted_policy_commit"
           test "$(git -C "$trusted_policy_root" remote get-url origin)" = "https://github.com/nold-ai/.github"
           test "$(jq -er '.pull_request.head.sha' "$GITHUB_EVENT_PATH")" = "$(git rev-parse HEAD)"
@@ -2043,7 +2043,7 @@ jobs:
             '.id == $run_id and .head_sha == $red_commit and .head_branch == $head_branch and
              .event == "pull_request" and .status == "completed" and .conclusion == "failure" and
              .name == "Requirements Evidence" and .path == ".github/workflows/requirements-evidence.yml" and
-             .repository.full_name == $repository and [.pull_requests[].number] == [704]' \
+             .repository.full_name == $repository and [.pull_requests[].number] == [715]' \
             "$metadata_root/run.json" > /dev/null
           jq -e \
             --argjson run_id "$late_red_run_id" \
@@ -2200,7 +2200,7 @@ jobs:
           path: ${{ runner.temp }}/requirements-producer
 
       - name: Download exact late RED artifact for final verification
-        if: github.event.pull_request.number == 704 && github.head_ref == 'bugfix/692-release-review-followup' && hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') != ''
+        if: github.event.pull_request.number == 715 && github.head_ref == 'bugfix/692-promotion-exit-code' && hashFiles('openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json') != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           artifact-ids: ${{ steps.final-late-red.outputs.artifact-id }}
@@ -2209,11 +2209,11 @@ jobs:
           run-id: ${{ steps.final-late-red.outputs.run-id }}
 
       - name: Normalize exact late RED proof on fresh runner
-        if: github.event.pull_request.number == 704 && github.head_ref == 'bugfix/692-release-review-followup' && hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') != ''
+        if: github.event.pull_request.number == 715 && github.head_ref == 'bugfix/692-promotion-exit-code' && hashFiles('openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json') != ''
         shell: bash
         run: |
           set -euo pipefail
-          manifest="openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json"
+          manifest="openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json"
           cycle_base_commit="$(jq -er '.cycle_base_commit | select(type == "string" and test("^[0-9a-f]{40}$"))' "$manifest")"
           trusted_provenance_root="${RUNNER_TEMP}/final-late-red-provenance"
           mkdir -p "$trusted_provenance_root" "${RUNNER_TEMP}/final-prior-red"
@@ -2238,7 +2238,7 @@ jobs:
 
       - name: Authenticate retained red proof for final verdict
         id: final-retained-red
-        if: needs.requirements-evidence.outputs.prior-red-run-id != '' && (github.event.pull_request.number != 704 || github.head_ref != 'bugfix/692-release-review-followup' || hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') == '')
+        if: needs.requirements-evidence.outputs.prior-red-run-id != '' && (github.event.pull_request.number != 715 || github.head_ref != 'bugfix/692-promotion-exit-code' || hashFiles('openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json') == '')
         env:
           GITHUB_TOKEN: ${{ github.token }}
           PRIOR_RED_RUN_ID: ${{ needs.requirements-evidence.outputs.prior-red-run-id }}
@@ -2299,7 +2299,7 @@ jobs:
       - name: Reconcile final Requirements verdict on fresh runner
         env:
           EVIDENCE_PROMOTION_REUSE: ${{ steps.final-promotion.outputs.active }}
-          LATE_RED_ACTIVE: ${{ github.event.pull_request.number == 704 && github.head_ref == 'bugfix/692-release-review-followup' && hashFiles('openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json') != '' }}
+          LATE_RED_ACTIVE: ${{ github.event.pull_request.number == 715 && github.head_ref == 'bugfix/692-promotion-exit-code' && hashFiles('openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json') != '' }}
           PRIOR_RED_HEAD_SHA: ${{ steps.final-retained-red.outputs.head-sha }}
         shell: bash
         run: |
@@ -2447,7 +2447,7 @@ jobs:
           )
           prior_red_root="${RUNNER_TEMP}/final-prior-red"
           prior_red_proof="${prior_red_root}/red.json"
-          late_red_manifest="openspec/changes/fix-release-promotion-security-gates/requirements-proof/late-red-evidence.json"
+          late_red_manifest="openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json"
           producer_root="${RUNNER_TEMP}/requirements-producer"
           legacy_tdd_evidence="${producer_root}/legacy-tdd-evidence.json"
           legacy_tdd_ledger="${producer_root}/approved-legacy-tdd-ledger.md"

--- a/openspec/changes/fix-release-promotion-requirements-parity/TDD_EVIDENCE.md
+++ b/openspec/changes/fix-release-promotion-requirements-parity/TDD_EVIDENCE.md
@@ -163,3 +163,20 @@ report decision from the report file and the non-empty aggregate cases from the
 separate plan file in producer, fresh execution, and final verdict. The mapped
 selector passed, the focused promotion and security suite passed (`24 passed`),
 and `actionlint .github/workflows/requirements-evidence.yml` passed.
+
+## Python 3.11 compatibility regression
+
+PR #715 check run `33998406109` exposed the same three existing late-RED proof
+test failures in its Python 3.11 job `101392883500` and Python 3.12 job
+`101392883489`. The new frozen dataclass was evaluated by an authenticated
+dynamic loader that intentionally does not register the candidate module in
+`sys.modules`; the dataclass implementation requires that registration and
+failed during module evaluation. These hosted failures are the RED evidence
+for replacing only the proof-scope value representation while preserving its
+immutable tuple semantics and every authenticated field.
+
+The proof scope now uses `NamedTuple`, retaining immutability and named-field
+access without requiring loader-side module registration. The previously
+masked selector-identity test also supplies the legacy scope that its synthetic
+`verified`/`final` artifact models. The exact three failed selectors pass on
+Python 3.11.15 and Python 3.12.13 (`3 passed` on each interpreter).

--- a/openspec/changes/fix-release-promotion-requirements-parity/TDD_EVIDENCE.md
+++ b/openspec/changes/fix-release-promotion-requirements-parity/TDD_EVIDENCE.md
@@ -127,3 +127,20 @@ plumbing for independent revalidation. The documented two-parent merge
 requirement can reject squash/rebase promotions but fails closed.
 
 Final staged-tree hooks remain pending before the implementation commit.
+
+## Post-merge promotion-plan regression
+
+PR #691 Requirements run `33996054082` at exact `dev` head
+`5f3f506c726a8644dac23419bf557e4447ffff7b` authenticated the #714 source
+merge and produced a passing aggregate report, but the producer rejected that
+report because it queried the report for plan cases stored in the separate
+aggregate plan artifact.
+
+At `2026-09-05T22:53:41Z`, the mapped selector was strengthened before the
+workflow correction and run with:
+
+`python -m pytest -q tests/unit/workflows/test_requirements_evidence_delivery_workflow.py::test_workflow_revalidates_promotion_reuse_in_all_stages`
+
+Result: FAIL (`1 failed`) because producer, fresh execution, and final verdict
+did not validate the aggregate report and aggregate plan through their distinct
+files.

--- a/openspec/changes/fix-release-promotion-requirements-parity/TDD_EVIDENCE.md
+++ b/openspec/changes/fix-release-promotion-requirements-parity/TDD_EVIDENCE.md
@@ -148,3 +148,18 @@ files.
 At `2026-09-05T22:55:59Z`, the assertion normalized YAML-preserved shell line
 continuations and the same command remained RED (`1 failed`) against unchanged
 workflow bytes.
+
+At `2026-09-05T23:00:12Z`, PR #715 Requirements run `33997442368` retained
+the same RED result at test-only head
+`9eb681963ab28360a9fbaf13f07009f5ea04b28a`. Artifact `9978484067`
+(`requirements-evidence`) has service digest
+`sha256:526034fe72c4cdba090daa55d710be8cf25054fbe1f37c27c16143c1f4970773`;
+its JUnit document has SHA-256
+`0633b17b9caf535ef365f66b8b64bfc4d0981c156cbabe49609f4d8a69b07831`
+and records the mapped selector as the only failure among five cases.
+
+At `2026-09-05T22:57:31Z`, the workflow correction validated the aggregate
+report decision from the report file and the non-empty aggregate cases from the
+separate plan file in producer, fresh execution, and final verdict. The mapped
+selector passed, the focused promotion and security suite passed (`24 passed`),
+and `actionlint .github/workflows/requirements-evidence.yml` passed.

--- a/openspec/changes/fix-release-promotion-requirements-parity/TDD_EVIDENCE.md
+++ b/openspec/changes/fix-release-promotion-requirements-parity/TDD_EVIDENCE.md
@@ -144,3 +144,7 @@ workflow correction and run with:
 Result: FAIL (`1 failed`) because producer, fresh execution, and final verdict
 did not validate the aggregate report and aggregate plan through their distinct
 files.
+
+At `2026-09-05T22:55:59Z`, the assertion normalized YAML-preserved shell line
+continuations and the same command remained RED (`1 failed`) against unchanged
+workflow bytes.

--- a/openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json
+++ b/openspec/changes/fix-release-promotion-requirements-parity/requirements-proof/late-red-evidence.json
@@ -1,0 +1,25 @@
+{
+  "artifact_digest": "sha256:526034fe72c4cdba090daa55d710be8cf25054fbe1f37c27c16143c1f4970773",
+  "artifact_id": 9978484067,
+  "base_branch": "dev",
+  "change_id": "fix-release-promotion-requirements-parity",
+  "cycle_base_commit": "5f3f506c726a8644dac23419bf557e4447ffff7b",
+  "cycle_base_tree": "2c6d6d60fbc4d5aea39cbcf0d9576f4aa3faea15",
+  "failed_selectors": [
+    "tests/unit/workflows/test_requirements_evidence_delivery_workflow.py::test_workflow_revalidates_promotion_reuse_in_all_stages"
+  ],
+  "head_branch": "bugfix/692-promotion-exit-code",
+  "issue": 692,
+  "junit_digest": "sha256:0633b17b9caf535ef365f66b8b64bfc4d0981c156cbabe49609f4d8a69b07831",
+  "kind": "late-review-red-proof",
+  "mapping_digest": "sha256:140c226cee42d6b0969caa4fa88ff4e6b78489614ea9095ec2b29eca92ed487f",
+  "plan_digest": "sha256:971a9072101ab4280a15c6c4b8e01b72a0e3eeef519eb6291bfc6d1ae1eada6a",
+  "plan_report_digest": "sha256:f40769301a43b1d09991c40f552e0b4220e9b07d83eb8cea9331ed56b7d8c126",
+  "pull_request": 715,
+  "red_commit": "9eb681963ab28360a9fbaf13f07009f5ea04b28a",
+  "red_tree": "4ee9df9c92e09236e49392388f4b402f03ed11d6",
+  "report_digest": "sha256:d349fad67d457ec4b5e0713501db8725ae551d4dceb0c1bae94c90e094afd9de",
+  "repository": "nold-ai/specfact-cli",
+  "run_id": 33997442368,
+  "schema_version": "1"
+}

--- a/scripts/requirements_late_red_proof.py
+++ b/scripts/requirements_late_red_proof.py
@@ -1,4 +1,4 @@
-"""Normalize one authority-bound late review RED artifact for PR #704."""
+"""Normalize an exact authority-bound late review RED artifact."""
 
 from __future__ import annotations
 
@@ -13,18 +13,16 @@ import subprocess
 import sys
 import tempfile
 from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from types import ModuleType
 from typing import Any, NoReturn, cast
 from xml.parsers import expat
 
 
-CHANGE_ID = "fix-release-promotion-security-gates"
 REPOSITORY = "nold-ai/specfact-cli"
 ISSUE = 692
-PULL_REQUEST = 704
 BASE_BRANCH = "dev"
-HEAD_BRANCH = "bugfix/692-release-review-followup"
 WORKFLOW_PATH = ".github/workflows/requirements-evidence.yml"
 PROVENANCE_PATH = "scripts/requirements_proof_provenance.py"
 PROOF_CYCLE_PROVENANCE_BLOB = "28491925ea5242d58e7cdaeff8ada8291382a15a"
@@ -54,6 +52,27 @@ MANIFEST_FIELDS = {
     "plan_digest",
     "failed_selectors",
 }
+
+
+@dataclass(frozen=True)
+class _ProofScope:
+    change_id: str
+    pull_request: int
+    head_branch: str
+
+
+_PROOF_SCOPES = (
+    _ProofScope("fix-release-promotion-security-gates", 704, "bugfix/692-release-review-followup"),
+    _ProofScope("fix-release-promotion-requirements-parity", 715, "bugfix/692-promotion-exit-code"),
+)
+
+
+def _proof_scope(manifest_path: Path, repo_root: Path) -> _ProofScope:
+    for scope in _PROOF_SCOPES:
+        expected = repo_root / f"openspec/changes/{scope.change_id}/requirements-proof/late-red-evidence.json"
+        if manifest_path == expected:
+            return scope
+    raise ValueError
 
 
 def _argument_error(message: str) -> NoReturn:
@@ -118,7 +137,7 @@ def _strings(value: object) -> list[str]:
     return result
 
 
-def _validate_manifest(manifest: dict[str, object]) -> None:
+def _validate_manifest(manifest: dict[str, object], scope: _ProofScope) -> None:
     if set(manifest) != MANIFEST_FIELDS:
         raise ValueError
     expected = {
@@ -126,10 +145,10 @@ def _validate_manifest(manifest: dict[str, object]) -> None:
         "kind": "late-review-red-proof",
         "repository": REPOSITORY,
         "issue": ISSUE,
-        "pull_request": PULL_REQUEST,
+        "pull_request": scope.pull_request,
         "base_branch": BASE_BRANCH,
-        "head_branch": HEAD_BRANCH,
-        "change_id": CHANGE_ID,
+        "head_branch": scope.head_branch,
+        "change_id": scope.change_id,
     }
     if any(manifest.get(key) != value for key, value in expected.items()):
         raise ValueError
@@ -149,7 +168,7 @@ def _validate_manifest(manifest: dict[str, object]) -> None:
     _strings(manifest["failed_selectors"])
 
 
-def _validate_event(event: dict[str, object], manifest: dict[str, object], final_ref: str) -> None:
+def _validate_event(event: dict[str, object], manifest: dict[str, object], final_ref: str, scope: _ProofScope) -> None:
     pull_request = _object(event.get("pull_request"))
     repository = _object(event.get("repository"))
     base = _object(pull_request.get("base"))
@@ -159,18 +178,18 @@ def _validate_event(event: dict[str, object], manifest: dict[str, object], final
         or repository.get("full_name") != REPOSITORY
         or base.get("ref") != BASE_BRANCH
         or _object(base.get("repo")).get("full_name") != REPOSITORY
-        or head.get("ref") != HEAD_BRANCH
+        or head.get("ref") != scope.head_branch
         or head.get("sha") != final_ref
         or _object(head.get("repo")).get("full_name") != REPOSITORY
     ):
         raise ValueError
 
 
-def _validate_run(run: dict[str, object], manifest: dict[str, object]) -> None:
+def _validate_run(run: dict[str, object], manifest: dict[str, object], scope: _ProofScope) -> None:
     if (
         _integer(run.get("id")) != manifest["run_id"]
         or run.get("head_sha") != manifest["red_commit"]
-        or run.get("head_branch") != HEAD_BRANCH
+        or run.get("head_branch") != scope.head_branch
         or run.get("event") != "pull_request"
         or run.get("status") != "completed"
         or run.get("conclusion") != "failure"
@@ -416,12 +435,12 @@ def _validate_red_path(path: str, allowed_change: str) -> None:
         raise ValueError
 
 
-def _validate_linear_red_segment(repo_root: Path, cycle: str, red: str) -> None:
+def _validate_linear_red_segment(repo_root: Path, cycle: str, red: str, scope: _ProofScope) -> None:
     revisions = _git(repo_root, "rev-list", "--reverse", "--parents", f"{cycle}..{red}")
     if revisions.returncode or not revisions.stdout.splitlines():
         raise ValueError
     parent = cycle
-    allowed_change = f"openspec/changes/{CHANGE_ID}/"
+    allowed_change = f"openspec/changes/{scope.change_id}/"
     for line in revisions.stdout.splitlines():
         values = line.split()
         if len(values) != 2 or values[1] != parent:
@@ -434,10 +453,12 @@ def _validate_linear_red_segment(repo_root: Path, cycle: str, red: str) -> None:
         raise ValueError
 
 
-def _validate_history(repo_root: Path, manifest: dict[str, object], cycle_ref: str, final_ref: str) -> None:
+def _validate_history(
+    repo_root: Path, manifest: dict[str, object], cycle_ref: str, final_ref: str, scope: _ProofScope
+) -> None:
     cycle, red, final = _validated_history_commits(repo_root, manifest, cycle_ref, final_ref)
     _validate_recorded_trees(repo_root, manifest, cycle, red)
-    _validate_linear_red_segment(repo_root, cycle, red)
+    _validate_linear_red_segment(repo_root, cycle, red, scope)
     if _git(repo_root, "merge-base", "--is-ancestor", red, final).returncode:
         raise ValueError
 
@@ -502,17 +523,15 @@ def _external_outputs(output: Path, repo_root: Path) -> tuple[Path, Path]:
 def _normalize(arguments: argparse.Namespace) -> None:
     repo_root = arguments.repo_root.resolve(strict=True)
     manifest_path = arguments.manifest.resolve(strict=True)
-    expected_manifest = repo_root / f"openspec/changes/{CHANGE_ID}/requirements-proof/late-red-evidence.json"
-    if manifest_path != expected_manifest:
-        raise ValueError
+    scope = _proof_scope(manifest_path, repo_root)
     manifest = _read_json(manifest_path)
-    _validate_manifest(manifest)
+    _validate_manifest(manifest, scope)
     final = _resolve_commit(repo_root, arguments.final_ref)
-    _validate_event(_read_json(arguments.event), manifest, final)
-    _validate_run(_read_json(arguments.red_run), manifest)
+    _validate_event(_read_json(arguments.event), manifest, final, scope)
+    _validate_run(_read_json(arguments.red_run), manifest, scope)
     _validate_artifact(_read_json(arguments.red_artifacts), manifest)
     cycle_commit = _string(manifest["cycle_base_commit"], OBJECT_PATTERN)
-    _validate_history(repo_root, manifest, arguments.cycle_base_ref, final)
+    _validate_history(repo_root, manifest, arguments.cycle_base_ref, final, scope)
     junit_payload, selectors = _validate_raw_artifact(arguments.red_artifact_root, manifest)
     bind, validate = _load_provenance(arguments.trusted_provenance, repo_root, cycle_commit)
     output, output_xml = _external_outputs(arguments.output, repo_root)

--- a/scripts/requirements_late_red_proof.py
+++ b/scripts/requirements_late_red_proof.py
@@ -59,11 +59,13 @@ class _ProofScope:
     change_id: str
     pull_request: int
     head_branch: str
+    required_maturity: str
+    run_stage: str
 
 
 _PROOF_SCOPES = (
-    _ProofScope("fix-release-promotion-security-gates", 704, "bugfix/692-release-review-followup"),
-    _ProofScope("fix-release-promotion-requirements-parity", 715, "bugfix/692-promotion-exit-code"),
+    _ProofScope("fix-release-promotion-security-gates", 704, "bugfix/692-release-review-followup", "verified", "final"),
+    _ProofScope("fix-release-promotion-requirements-parity", 715, "bugfix/692-promotion-exit-code", "red", "red"),
 )
 
 
@@ -327,20 +329,20 @@ def _planned_selectors(plan: dict[str, object]) -> list[str]:
 
 
 def _validate_final_report(
-    report: dict[str, object], execution: dict[str, object], manifest: dict[str, object]
+    report: dict[str, object], execution: dict[str, object], manifest: dict[str, object], scope: _ProofScope
 ) -> None:
     expected_report = {
         "delivery_status": "incomplete",
         "gate_decision": "fail",
         "observed_maturity": "incomplete",
-        "required_maturity": "verified",
+        "required_maturity": scope.required_maturity,
         "verdict": "failed",
         "mapping_digest": manifest["mapping_digest"],
         "plan_digest": manifest["plan_digest"],
     }
     expected_execution = {
         "junit_digest": manifest["junit_digest"],
-        "run_stage": "final",
+        "run_stage": scope.run_stage,
         "source_ref": manifest["red_commit"],
     }
     if any(report.get(field) != value for field, value in expected_report.items()):
@@ -360,13 +362,13 @@ def _validate_plan_report(plan_report: dict[str, object], plan: dict[str, object
         raise ValueError
 
 
-def _validate_raw_artifact(root: Path, manifest: dict[str, object]) -> tuple[bytes, list[str]]:
+def _validate_raw_artifact(root: Path, manifest: dict[str, object], scope: _ProofScope) -> tuple[bytes, list[str]]:
     report_payload, plan_payload, junit_payload = _artifact_payloads(root, manifest)
     report = _object(json.loads(report_payload, object_pairs_hook=_pairs))
     plan_report = _object(json.loads(plan_payload, object_pairs_hook=_pairs))
     execution = _object(report.get("execution_proof"))
     plan = _object(plan_report.get("plan"))
-    _validate_final_report(report, execution, manifest)
+    _validate_final_report(report, execution, manifest, scope)
     _validate_plan_report(plan_report, plan, manifest)
     planned = _planned_selectors(plan)
     reported = _strings(execution.get("selectors"))
@@ -532,7 +534,7 @@ def _normalize(arguments: argparse.Namespace) -> None:
     _validate_artifact(_read_json(arguments.red_artifacts), manifest)
     cycle_commit = _string(manifest["cycle_base_commit"], OBJECT_PATTERN)
     _validate_history(repo_root, manifest, arguments.cycle_base_ref, final, scope)
-    junit_payload, selectors = _validate_raw_artifact(arguments.red_artifact_root, manifest)
+    junit_payload, selectors = _validate_raw_artifact(arguments.red_artifact_root, manifest, scope)
     bind, validate = _load_provenance(arguments.trusted_provenance, repo_root, cycle_commit)
     output, output_xml = _external_outputs(arguments.output, repo_root)
     normalized = {

--- a/scripts/requirements_late_red_proof.py
+++ b/scripts/requirements_late_red_proof.py
@@ -13,10 +13,9 @@ import subprocess
 import sys
 import tempfile
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from types import ModuleType
-from typing import Any, NoReturn, cast
+from typing import Any, NamedTuple, NoReturn, cast
 from xml.parsers import expat
 
 
@@ -54,8 +53,7 @@ MANIFEST_FIELDS = {
 }
 
 
-@dataclass(frozen=True)
-class _ProofScope:
+class _ProofScope(NamedTuple):
     change_id: str
     pull_request: int
     head_branch: str

--- a/tests/unit/scripts/test_requirements_late_red_proof.py
+++ b/tests/unit/scripts/test_requirements_late_red_proof.py
@@ -197,10 +197,11 @@ def test_failed_selector_identity_is_order_independent_but_exact(tmp_path: Path)
         "red_commit": "c" * 40,
         "failed_selectors": [second_selector, first_selector],
     }
+    scope = module._PROOF_SCOPES[0]
 
-    _, reported = module._validate_raw_artifact(artifact_root, manifest)
+    _, reported = module._validate_raw_artifact(artifact_root, manifest, scope)
     assert reported == selectors
 
     manifest["failed_selectors"] = [first_selector, "tests/test_proof.py::test_other"]
     with pytest.raises(ValueError):
-        module._validate_raw_artifact(artifact_root, manifest)
+        module._validate_raw_artifact(artifact_root, manifest, scope)

--- a/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
+++ b/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
@@ -1470,11 +1470,22 @@ def _assert_promotion_scope(workflow: dict[str, object], commands: tuple[str, st
 
 
 def _assert_promotion_planning(commands: tuple[str, str, str]) -> None:
-    for command in commands:
+    evidence_paths = (
+        (
+            "artifacts/requirements-evidence/requirements-evidence.json",
+            "artifacts/requirements-evidence/requirements-evidence-plan.json",
+        ),
+        ('"$consumer_report"', '"$consumer_plan"'),
+        ('"$final_report"', '"$final_plan"'),
+    )
+    for command, (report_path, plan_path) in zip(commands, evidence_paths, strict=True):
+        normalized_command = " ".join(command.split())
         assert 'if [[ "$EVIDENCE_PROMOTION_REUSE" == "true" ]]; then' in command
         assert "planning_maturity=planned" in command
-        assert '.gate_decision == "pass"' in command
-        assert ".plan.cases | length > 0" in command
+        assert f"jq -e '.gate_decision == \"pass\"' {report_path} > /dev/null" in normalized_command
+        assert (
+            f"jq -e '.gate_decision == \"pass\" and (.plan.cases | length > 0)' {plan_path} > /dev/null"
+        ) in normalized_command
 
 
 def _assert_promotion_artifacts(workflow: dict[str, object], commands: tuple[str, str, str]) -> None:

--- a/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
+++ b/tests/unit/workflows/test_requirements_evidence_delivery_workflow.py
@@ -1479,7 +1479,7 @@ def _assert_promotion_planning(commands: tuple[str, str, str]) -> None:
         ('"$final_report"', '"$final_plan"'),
     )
     for command, (report_path, plan_path) in zip(commands, evidence_paths, strict=True):
-        normalized_command = " ".join(command.split())
+        normalized_command = " ".join(command.replace("\\\n", " ").split())
         assert 'if [[ "$EVIDENCE_PROMOTION_REUSE" == "true" ]]; then' in command
         assert "planning_maturity=planned" in command
         assert f"jq -e '.gate_decision == \"pass\"' {report_path} > /dev/null" in normalized_command


### PR DESCRIPTION
Closes #692

## Summary

- fixes the release-promotion Requirements failure seen on PR #691
- validates the aggregate report decision from `requirements-evidence.json`
- validates non-empty aggregate cases from the separate `requirements-evidence-plan.json`
- applies the same fail-closed check in producer, fresh consumer, and final verdict

Authority, provenance, attestation, artifact, ancestry, freshness, and security policy are unchanged.

## TDD proof

Mapped selector:

`tests/unit/workflows/test_requirements_evidence_delivery_workflow.py::test_workflow_revalidates_promotion_reuse_in_all_stages`

Approved mapping:

`sha256:9c34bb52969f9d9dd7c7caa41d686324f8f907ee0611e677e5615b27cdd21a1e`

Immutable hosted RED proof:

- test-only head: `9eb681963ab28360a9fbaf13f07009f5ea04b28a`
- Requirements run: `33997442368`
- artifact: `9978484067` (`requirements-evidence`)
- service digest: `sha256:526034fe72c4cdba090daa55d710be8cf25054fbe1f37c27c16143c1f4970773`
- JUnit digest: `sha256:0633b17b9caf535ef365f66b8b64bfc4d0981c156cbabe49609f4d8a69b07831`
- result: the mapped selector was the only failure among five cases

GREEN verification:

- full workflow test file: `26 passed`
- focused promotion/security suite: `24 passed`
- `actionlint .github/workflows/requirements-evidence.yml`: pass
- `openspec validate fix-release-promotion-requirements-parity --strict`: pass
- signed commit hooks: pass

## Scope

Only the promotion-reuse validation commands and matching TDD evidence change. The report must still say `gate_decision == "pass"`, and the separate plan must still contain at least one case.

## Review disposition

The previously reviewed P2/P3 governance and diagnostic findings on release PR #691 remain explicitly maintainer-deferred as recorded there. This PR fixes the distinct blocking runtime-path defect and does not expand into those deferred items.

## Rollback

Revert this PR's merge commit. No published history is rewritten.
